### PR TITLE
Admin: Drop Optional and Union constructs in favor of |-notation

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -4,7 +4,7 @@ import datetime
 import ipaddress
 import re
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 import cryptography.hazmat.primitives.asymmetric.rsa
 import cryptography.x509
@@ -64,12 +64,12 @@ def datetime_to_epoch(date: datetime.datetime) -> float:
     return float(calendar.timegm(aware_dt.timetuple()))
 
 
-class TagHolder(dict[str, Optional[str]]):
+class TagHolder(dict[str, str | None]):
     MAX_TAG_COUNT = 50
     MAX_KEY_LENGTH = 128
     MAX_VALUE_LENGTH = 256
 
-    def _validate_kv(self, key: str, value: Optional[str], index: int) -> None:
+    def _validate_kv(self, key: str, value: str | None, index: int) -> None:
         if len(key) > self.MAX_KEY_LENGTH:
             raise AWSValidationException(
                 f"Value '{key}' at 'tags.{index}.member.key' failed to satisfy constraint: Member must have length less than or equal to {self.MAX_KEY_LENGTH}"
@@ -127,13 +127,13 @@ class CertBundle(BaseModel):
         account_id: str,
         certificate: bytes,
         private_key: bytes,
-        chain: Optional[bytes] = None,
+        chain: bytes | None = None,
         region: str = "us-east-1",
-        arn: Optional[str] = None,
+        arn: str | None = None,
         cert_type: str = "IMPORTED",
         cert_status: str = "ISSUED",
-        cert_authority_arn: Optional[str] = None,
-        cert_options: Optional[dict[str, Any]] = None,
+        cert_authority_arn: str | None = None,
+        cert_options: dict[str, Any] | None = None,
     ):
         self.created_at = utcnow()
         self.cert = certificate
@@ -175,8 +175,8 @@ class CertBundle(BaseModel):
         domain_name: str,
         account_id: str,
         region: str,
-        sans: Optional[list[str]] = None,
-        cert_authority_arn: Optional[str] = None,
+        sans: list[str] | None = None,
+        cert_authority_arn: str | None = None,
     ) -> "CertBundle":
         unique_sans: set[str] = set(sans) if sans else set()
 
@@ -477,7 +477,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         cert_bundle = self._certificates[arn]
         cert_bundle.in_use_by.append(load_balancer_name)
 
-    def _get_arn_from_idempotency_token(self, token: str) -> Optional[str]:
+    def _get_arn_from_idempotency_token(self, token: str) -> str | None:
         """
         If token doesnt exist, return None, later it will be
         set with an expiry and arn.
@@ -510,8 +510,8 @@ class AWSCertificateManagerBackend(BaseBackend):
         self,
         certificate: bytes,
         private_key: bytes,
-        chain: Optional[bytes],
-        arn: Optional[str],
+        chain: bytes | None,
+        arn: str | None,
         tags: list[dict[str, str]],
     ) -> str:
         if arn is not None:
@@ -594,8 +594,8 @@ class AWSCertificateManagerBackend(BaseBackend):
         idempotency_token: str,
         subject_alt_names: list[str],
         tags: list[dict[str, str]],
-        cert_authority_arn: Optional[str] = None,
-        cert_options: Optional[dict[str, Any]] = None,
+        cert_authority_arn: str | None = None,
+        cert_options: dict[str, Any] | None = None,
     ) -> str:
         """
         The parameter DomainValidationOptions has not yet been implemented

--- a/moto/acm/responses.py
+++ b/moto/acm/responses.py
@@ -1,13 +1,12 @@
 import base64
 import json
-from typing import Union
 
 from moto.core.responses import BaseResponse
 
 from .exceptions import AWSValidationException
 from .models import AWSCertificateManagerBackend, acm_backends
 
-GENERIC_RESPONSE_TYPE = Union[str, tuple[str, dict[str, int]]]
+GENERIC_RESPONSE_TYPE = str | tuple[str, dict[str, int]]
 
 
 class AWSCertificateManagerResponse(BaseResponse):

--- a/moto/acmpca/models.py
+++ b/moto/acmpca/models.py
@@ -3,7 +3,7 @@
 import base64
 import contextlib
 import datetime
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -35,7 +35,7 @@ class CertificateAuthority(BaseModel):
         certificate_authority_configuration: dict[str, Any],
         certificate_authority_type: str,
         revocation_configuration: dict[str, Any],
-        security_standard: Optional[str],
+        security_standard: str | None,
     ):
         self.id = mock_random.uuid4()
         self.arn = f"arn:{get_partition(region)}:acm-pca:{region}:{account_id}:certificate-authority/{self.id}"
@@ -48,11 +48,11 @@ class CertificateAuthority(BaseModel):
         }
         self.set_revocation_configuration(revocation_configuration)
         self.created_at = unix_time()
-        self.updated_at: Optional[float] = None
+        self.updated_at: float | None = None
         self.status = "PENDING_CERTIFICATE"
         self.usage_mode = "SHORT_LIVED_CERTIFICATE"
         self.security_standard = security_standard or "FIPS_140_2_LEVEL_3_OR_HIGHER"
-        self.policy: Optional[str] = None
+        self.policy: str | None = None
         self.revoked_certificates: dict[str, dict[str, Any]] = {}
 
         self.password = str(mock_random.uuid4()).encode("utf-8")
@@ -65,7 +65,7 @@ class CertificateAuthority(BaseModel):
         )
 
         self.certificate_bytes: bytes = b""
-        self.certificate_chain: Optional[bytes] = None
+        self.certificate_chain: bytes | None = None
         self.issued_certificates: dict[str, bytes] = {}
         self.issued_certificates_certificate_chains: dict[str, bytes] = {}
 
@@ -103,7 +103,7 @@ class CertificateAuthority(BaseModel):
         return cast(rsa.RSAPrivateKey, private_key)
 
     @property
-    def certificate(self) -> Optional[x509.Certificate]:
+    def certificate(self) -> x509.Certificate | None:
         if self.certificate_bytes:
             return x509.load_pem_x509_certificate(self.certificate_bytes)
         return None
@@ -153,7 +153,7 @@ class CertificateAuthority(BaseModel):
         )
         return csr.public_bytes(serialization.Encoding.PEM)
 
-    def issue_certificate(self, csr_bytes: bytes, template_arn: Optional[str]) -> str:
+    def issue_certificate(self, csr_bytes: bytes, template_arn: str | None) -> str:
         csr = x509.load_pem_x509_csr(base64.b64decode(csr_bytes))
         extensions = self._x509_extensions(csr, template_arn)
         new_cert = self.generate_cert(
@@ -177,7 +177,7 @@ class CertificateAuthority(BaseModel):
         return cert_arn
 
     def _x509_extensions(
-        self, csr: x509.CertificateSigningRequest, template_arn: Optional[str]
+        self, csr: x509.CertificateSigningRequest, template_arn: str | None
     ) -> list[tuple[x509.ExtensionType, bool]]:
         """
         Uses a PCA certificate template ARN to return a list of X.509 extensions.
@@ -283,7 +283,7 @@ class CertificateAuthority(BaseModel):
         return certificate, certificate_chain
 
     def set_revocation_configuration(
-        self, revocation_configuration: Optional[dict[str, Any]]
+        self, revocation_configuration: dict[str, Any] | None
     ) -> None:
         if revocation_configuration is not None:
             self.revocation_configuration = revocation_configuration
@@ -300,7 +300,7 @@ class CertificateAuthority(BaseModel):
                         raise InvalidS3ObjectAclInCrlConfiguration(acl)
 
     @property
-    def not_valid_after(self) -> Optional[float]:
+    def not_valid_after(self) -> float | None:
         if self.certificate is None:
             return None
         try:
@@ -309,7 +309,7 @@ class CertificateAuthority(BaseModel):
             return unix_time(self.certificate.not_valid_after)
 
     @property
-    def not_valid_before(self) -> Optional[float]:
+    def not_valid_before(self) -> float | None:
         if self.certificate is None:
             return None
         try:
@@ -318,7 +318,7 @@ class CertificateAuthority(BaseModel):
             return unix_time(self.certificate.not_valid_before)
 
     def import_certificate_authority_certificate(
-        self, certificate: bytes, certificate_chain: Optional[bytes]
+        self, certificate: bytes, certificate_chain: bytes | None
     ) -> None:
         try:
             x509.load_pem_x509_certificate(certificate)
@@ -376,7 +376,7 @@ class ACMPCABackend(BaseBackend):
         certificate_authority_configuration: dict[str, Any],
         revocation_configuration: dict[str, Any],
         certificate_authority_type: str,
-        security_standard: Optional[str],
+        security_standard: str | None,
         tags: list[dict[str, str]],
     ) -> str:
         """
@@ -404,7 +404,7 @@ class ACMPCABackend(BaseBackend):
 
     def get_certificate_authority_certificate(
         self, certificate_authority_arn: str
-    ) -> tuple[bytes, Optional[bytes]]:
+    ) -> tuple[bytes, bytes | None]:
         ca = self.describe_certificate_authority(certificate_authority_arn)
         if ca.status != "ACTIVE":
             raise InvalidStateException(certificate_authority_arn)
@@ -439,7 +439,7 @@ class ACMPCABackend(BaseBackend):
         ca.status = "DELETED"
 
     def issue_certificate(
-        self, certificate_authority_arn: str, csr: bytes, template_arn: Optional[str]
+        self, certificate_authority_arn: str, csr: bytes, template_arn: str | None
     ) -> str:
         """
         The following parameters are not yet implemented: ApiPassthrough, SigningAlgorithm, Validity, ValidityNotBefore, IdempotencyToken
@@ -471,7 +471,7 @@ class ACMPCABackend(BaseBackend):
         self,
         certificate_authority_arn: str,
         certificate: bytes,
-        certificate_chain: Optional[bytes],
+        certificate_chain: bytes | None,
     ) -> None:
         ca = self.describe_certificate_authority(certificate_authority_arn)
         ca.import_certificate_authority_certificate(certificate, certificate_chain)
@@ -532,7 +532,7 @@ class ACMPCABackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_certificate_authorities(
         self,
-        resource_owner: Optional[str] = None,
+        resource_owner: str | None = None,
     ) -> list[CertificateAuthority]:
         """
         Lists the private certificate authorities that you created by using the CreateCertificateAuthority action.

--- a/moto/amp/models.py
+++ b/moto/amp/models.py
@@ -1,7 +1,7 @@
 """PrometheusServiceBackend class with methods for supported APIs."""
 
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -64,7 +64,7 @@ class Workspace(BaseModel):
         self.created_at = unix_time()
         self.tag_fn = tag_fn
         self.rule_group_namespaces: dict[str, RuleGroupNamespace] = {}
-        self.logging_config: Optional[dict[str, Any]] = None
+        self.logging_config: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/moto/apigateway/integration_parsers/__init__.py
+++ b/moto/apigateway/integration_parsers/__init__.py
@@ -1,5 +1,4 @@
 import abc
-from typing import Union
 
 from requests.models import PreparedRequest
 
@@ -10,5 +9,5 @@ class IntegrationParser:
     @abc.abstractmethod
     def invoke(
         self, request: PreparedRequest, integration: Integration
-    ) -> tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, str | bytes]:
         pass

--- a/moto/apigateway/integration_parsers/aws_parser.py
+++ b/moto/apigateway/integration_parsers/aws_parser.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import requests
 
 from ..models import Integration
@@ -9,7 +7,7 @@ from . import IntegrationParser
 class TypeAwsParser(IntegrationParser):
     def invoke(
         self, request: requests.PreparedRequest, integration: Integration
-    ) -> tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, str | bytes]:
         # integration.uri = arn:aws:apigateway:{region}:{subdomain.service|service}:path|action/{service_api}
         # example value = 'arn:aws:apigateway:us-west-2:dynamodb:action/PutItem'
         try:

--- a/moto/apigateway/integration_parsers/http_parser.py
+++ b/moto/apigateway/integration_parsers/http_parser.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import requests
 
 from ..models import Integration
@@ -13,7 +11,7 @@ class TypeHttpParser(IntegrationParser):
 
     def invoke(
         self, request: requests.PreparedRequest, integration: Integration
-    ) -> tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, str | bytes]:
         uri = integration.uri
         requests_func = getattr(requests, integration.http_method.lower())  # type: ignore[union-attr]
         response = requests_func(uri)

--- a/moto/apigateway/integration_parsers/unknown_parser.py
+++ b/moto/apigateway/integration_parsers/unknown_parser.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 import requests
 
 from ..models import Integration
@@ -13,6 +11,6 @@ class TypeUnknownParser(IntegrationParser):
 
     def invoke(
         self, request: requests.PreparedRequest, integration: Integration
-    ) -> tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, str | bytes]:
         _type = integration.integration_type
         raise NotImplementedError(f"The {_type} type has not been implemented")

--- a/moto/apigateway/models.py
+++ b/moto/apigateway/models.py
@@ -3,7 +3,7 @@ import string
 import time
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 from urllib.parse import urlparse
 
 import requests
@@ -132,11 +132,11 @@ class Deployment(CloudFormationModel):
 class IntegrationResponse(BaseModel):
     def __init__(
         self,
-        status_code: Union[str, int],
-        selection_pattern: Optional[str] = None,
-        response_templates: Optional[dict[str, Any]] = None,
-        response_parameters: Optional[dict[str, str]] = None,
-        content_handling: Optional[Any] = None,
+        status_code: str | int,
+        selection_pattern: str | None = None,
+        response_templates: dict[str, Any] | None = None,
+        response_parameters: dict[str, str] | None = None,
+        content_handling: Any | None = None,
     ):
         if response_templates is None:
             # response_templates = {"application/json": None}  # Note: removed for compatibility with TF
@@ -171,16 +171,16 @@ class Integration(BaseModel):
         integration_type: str,
         uri: str,
         http_method: str,
-        request_templates: Optional[dict[str, Any]] = None,
-        passthrough_behavior: Optional[str] = "WHEN_NO_MATCH",
-        cache_key_parameters: Optional[list[str]] = None,
-        tls_config: Optional[dict[str, Any]] = None,
-        cache_namespace: Optional[str] = None,
-        timeout_in_millis: Optional[str] = None,
-        request_parameters: Optional[dict[str, Any]] = None,
-        content_handling: Optional[str] = None,
-        credentials: Optional[str] = None,
-        connection_type: Optional[str] = None,
+        request_templates: dict[str, Any] | None = None,
+        passthrough_behavior: str | None = "WHEN_NO_MATCH",
+        cache_key_parameters: list[str] | None = None,
+        tls_config: dict[str, Any] | None = None,
+        cache_namespace: str | None = None,
+        timeout_in_millis: str | None = None,
+        request_parameters: dict[str, Any] | None = None,
+        content_handling: str | None = None,
+        credentials: str | None = None,
+        connection_type: str | None = None,
     ):
         self.integration_type = integration_type
         self.uri = uri
@@ -195,10 +195,10 @@ class Integration(BaseModel):
         self.content_handling = content_handling
         self.credentials = credentials
         self.connection_type = connection_type
-        self.integration_responses: Optional[dict[str, IntegrationResponse]] = None
+        self.integration_responses: dict[str, IntegrationResponse] | None = None
 
     def to_json(self) -> dict[str, Any]:
-        int_responses: Optional[dict[str, Any]] = None
+        int_responses: dict[str, Any] | None = None
         if self.integration_responses is not None:
             int_responses = {
                 k: v.to_json() for k, v in self.integration_responses.items()
@@ -226,7 +226,7 @@ class Integration(BaseModel):
         selection_pattern: str,
         response_templates: dict[str, str],
         response_parameters: dict[str, str],
-        content_handling: Optional[str] = None,
+        content_handling: str | None = None,
     ) -> IntegrationResponse:
         integration_response = IntegrationResponse(
             status_code,
@@ -270,9 +270,7 @@ class MethodResponse(BaseModel):
 
 
 class Method(CloudFormationModel):
-    def __init__(
-        self, method_type: str, authorization_type: Optional[str], **kwargs: Any
-    ):
+    def __init__(self, method_type: str, authorization_type: str | None, **kwargs: Any):
         self.http_method = method_type
         self.authorization_type = authorization_type
         self.authorizer_id = kwargs.get("authorizer_id")
@@ -280,7 +278,7 @@ class Method(CloudFormationModel):
         self.api_key_required = kwargs.get("api_key_required") or False
         self.request_parameters = kwargs.get("request_parameters")
         self.request_models = kwargs.get("request_models")
-        self.method_integration: Optional[Integration] = None
+        self.method_integration: Integration | None = None
         self.operation_name = kwargs.get("operation_name")
         self.request_validator_id = kwargs.get("request_validator_id")
         self.method_responses: dict[str, MethodResponse] = {}
@@ -360,10 +358,10 @@ class Method(CloudFormationModel):
         self.method_responses[response_code] = method_response
         return method_response
 
-    def get_response(self, response_code: str) -> Optional[MethodResponse]:
+    def get_response(self, response_code: str) -> MethodResponse | None:
         return self.method_responses.get(response_code)
 
-    def delete_response(self, response_code: str) -> Optional[MethodResponse]:
+    def delete_response(self, response_code: str) -> MethodResponse | None:
         return self.method_responses.pop(response_code, None)
 
 
@@ -375,7 +373,7 @@ class Resource(CloudFormationModel):
         region_name: str,
         api_id: str,
         path_part: str,
-        parent_id: Optional[str],
+        parent_id: str | None,
     ):
         self.id = resource_id
         self.account_id = account_id
@@ -463,7 +461,7 @@ class Resource(CloudFormationModel):
 
     def get_response(
         self, request: requests.PreparedRequest
-    ) -> tuple[int, Union[str, bytes]]:
+    ) -> tuple[int, str | bytes]:
         integration = self.get_integration(str(request.method))
         integration_type = integration.integration_type  # type: ignore[union-attr]
 
@@ -477,12 +475,12 @@ class Resource(CloudFormationModel):
     def add_method(
         self,
         method_type: str,
-        authorization_type: Optional[str],
-        api_key_required: Optional[bool],
+        authorization_type: str | None,
+        api_key_required: bool | None,
         request_parameters: Any = None,
         request_models: Any = None,
-        operation_name: Optional[str] = None,
-        authorizer_id: Optional[str] = None,
+        operation_name: str | None = None,
+        authorizer_id: str | None = None,
         authorization_scopes: Any = None,
         request_validator_id: Any = None,
     ) -> Method:
@@ -516,16 +514,16 @@ class Resource(CloudFormationModel):
         method_type: str,
         integration_type: str,
         uri: str,
-        request_templates: Optional[dict[str, Any]] = None,
-        passthrough_behavior: Optional[str] = None,
-        integration_method: Optional[str] = None,
-        tls_config: Optional[dict[str, Any]] = None,
-        cache_namespace: Optional[str] = None,
-        timeout_in_millis: Optional[str] = None,
-        request_parameters: Optional[dict[str, Any]] = None,
-        content_handling: Optional[str] = None,
-        credentials: Optional[str] = None,
-        connection_type: Optional[str] = None,
+        request_templates: dict[str, Any] | None = None,
+        passthrough_behavior: str | None = None,
+        integration_method: str | None = None,
+        tls_config: dict[str, Any] | None = None,
+        cache_namespace: str | None = None,
+        timeout_in_millis: str | None = None,
+        request_parameters: dict[str, Any] | None = None,
+        content_handling: str | None = None,
+        credentials: str | None = None,
+        connection_type: str | None = None,
     ) -> Integration:
         integration_method = integration_method or method_type
         integration = Integration(
@@ -545,7 +543,7 @@ class Resource(CloudFormationModel):
         self.resource_methods[method_type].method_integration = integration
         return integration
 
-    def get_integration(self, method_type: str) -> Optional[Integration]:
+    def get_integration(self, method_type: str) -> Integration | None:
         method = self.resource_methods.get(method_type)
         return method.method_integration if method else None
 
@@ -558,9 +556,9 @@ class Resource(CloudFormationModel):
 class Authorizer(BaseModel):
     def __init__(
         self,
-        authorizer_id: Optional[str],
-        name: Optional[str],
-        authorizer_type: Optional[str],
+        authorizer_id: str | None,
+        name: str | None,
+        authorizer_type: str | None,
         **kwargs: Any,
     ):
         self.id = authorizer_id
@@ -628,14 +626,14 @@ class Authorizer(BaseModel):
 class Stage(BaseModel):
     def __init__(
         self,
-        name: Optional[str] = None,
-        deployment_id: Optional[str] = None,
-        variables: Optional[dict[str, Any]] = None,
+        name: str | None = None,
+        deployment_id: str | None = None,
+        variables: dict[str, Any] | None = None,
         description: str = "",
-        cacheClusterEnabled: Optional[bool] = False,
-        cacheClusterSize: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        tracing_enabled: Optional[bool] = None,
+        cacheClusterEnabled: bool | None = False,
+        cacheClusterSize: str | None = None,
+        tags: dict[str, str] | None = None,
+        tracing_enabled: bool | None = None,
     ):
         self.name = name
         self.deployment_id = deployment_id
@@ -649,8 +647,8 @@ class Stage(BaseModel):
         )
         self.tags = tags
         self.tracing_enabled = tracing_enabled
-        self.access_log_settings: Optional[dict[str, Any]] = None
-        self.web_acl_arn: Optional[str] = None
+        self.access_log_settings: dict[str, Any] | None = None
+        self.web_acl_arn: str | None = None
 
     def to_json(self) -> dict[str, Any]:
         dct: dict[str, Any] = {
@@ -742,7 +740,7 @@ class Stage(BaseModel):
             "requireAuthorizationForCacheControl": True,
         }
 
-    def _method_settings_translations(self, key: str) -> Optional[str]:
+    def _method_settings_translations(self, key: str) -> str | None:
         mappings = {
             "metrics/enabled": "metricsEnabled",
             "logging/loglevel": "loggingLevel",
@@ -761,7 +759,7 @@ class Stage(BaseModel):
     def _str2bool(self, v: str) -> bool:
         return v.lower() == "true"
 
-    def _convert_to_type(self, key: str, val: str) -> Union[str, int, float]:
+    def _convert_to_type(self, key: str, val: str) -> str | int | float:
         type_mappings = {
             "metricsEnabled": "bool",
             "loggingLevel": "str",
@@ -803,14 +801,14 @@ class ApiKey(BaseModel):
     def __init__(
         self,
         api_key_id: str,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
         enabled: bool = False,
         generateDistinctId: bool = False,
-        value: Optional[str] = None,
-        stageKeys: Optional[Any] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        customerId: Optional[str] = None,
+        value: str | None = None,
+        stageKeys: Any | None = None,
+        tags: list[dict[str, str]] | None = None,
+        customerId: str | None = None,
     ):
         self.id = api_key_id
         self.value = value or "".join(
@@ -861,13 +859,13 @@ class UsagePlan(BaseModel):
     def __init__(
         self,
         usage_plan_id: str,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
         apiStages: Any = None,
-        throttle: Optional[dict[str, Any]] = None,
-        quota: Optional[dict[str, Any]] = None,
-        productCode: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        throttle: dict[str, Any] | None = None,
+        quota: dict[str, Any] | None = None,
+        productCode: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.id = usage_plan_id
         self.name = name
@@ -952,7 +950,7 @@ class RequestValidator(BaseModel):
         self,
         _id: str,
         name: str,
-        validateRequestBody: Optional[bool],
+        validateRequestBody: bool | None,
         validateRequestParameters: Any,
     ):
         self.id = _id
@@ -982,7 +980,7 @@ class RequestValidator(BaseModel):
 
 
 class UsagePlanKey(BaseModel):
-    def __init__(self, plan_id: str, plan_type: str, name: Optional[str], value: str):
+    def __init__(self, plan_id: str, plan_type: str, name: str | None, value: str):
         self.id = plan_id
         self.name = name
         self.type = plan_type
@@ -1181,7 +1179,7 @@ class RestAPI(CloudFormationModel):
             name=name, description=desc, endpoint_configuration=config
         )
 
-    def add_child(self, path: str, parent_id: Optional[str] = None) -> Resource:
+    def add_child(self, path: str, parent_id: str | None = None) -> Resource:
         child_id = ApigwResourceIdentifier(
             self.account_id, self.region_name, parent_id or "", path
         ).generate()
@@ -1225,7 +1223,7 @@ class RestAPI(CloudFormationModel):
 
     def resource_callback(
         self, request: Any
-    ) -> tuple[int, dict[str, str], Union[str, bytes]]:
+    ) -> tuple[int, dict[str, str], str | bytes]:
         path = path_url(request.url)
         path_after_stage_name = "/" + "/".join(path.split("/")[2:])
 
@@ -1260,13 +1258,13 @@ class RestAPI(CloudFormationModel):
         authorizer_id: str,
         name: str,
         authorizer_type: str,
-        provider_arns: Optional[list[str]],
-        auth_type: Optional[str],
-        authorizer_uri: Optional[str],
-        authorizer_credentials: Optional[str],
-        identity_source: Optional[str],
-        identiy_validation_expression: Optional[str],
-        authorizer_result_ttl: Optional[int],
+        provider_arns: list[str] | None,
+        auth_type: str | None,
+        authorizer_uri: str | None,
+        authorizer_credentials: str | None,
+        identity_source: str | None,
+        identiy_validation_expression: str | None,
+        authorizer_result_ttl: int | None,
     ) -> Authorizer:
         authorizer = Authorizer(
             authorizer_id=authorizer_id,
@@ -1289,10 +1287,10 @@ class RestAPI(CloudFormationModel):
         deployment_id: str,
         variables: Any,
         description: str,
-        cacheClusterEnabled: Optional[bool],
-        cacheClusterSize: Optional[str],
-        tags: Optional[dict[str, str]],
-        tracing_enabled: Optional[bool],
+        cacheClusterEnabled: bool | None,
+        cacheClusterSize: str | None,
+        tags: dict[str, str] | None,
+        tracing_enabled: bool | None,
     ) -> Stage:
         if name in self.stages:
             raise ConflictException("Stage already exists")
@@ -1357,7 +1355,7 @@ class RestAPI(CloudFormationModel):
     def create_request_validator(
         self,
         name: str,
-        validateRequestBody: Optional[bool],
+        validateRequestBody: bool | None,
         validateRequestParameters: Any,
     ) -> RequestValidator:
         validator_id = ApigwRequestValidatorIdentifier(
@@ -1565,12 +1563,12 @@ class GatewayResponse(BaseModel):
 
 class Account(BaseModel):
     def __init__(self) -> None:
-        self.cloudwatch_role_arn: Optional[str] = None
+        self.cloudwatch_role_arn: str | None = None
         self.throttle_settings: dict[str, Any] = {
             "burstLimit": 5000,
             "rateLimit": 10000.0,
         }
-        self.features: Optional[list[str]] = None
+        self.features: list[str] | None = None
         self.api_key_version: str = "1"
 
     def apply_patch_operations(
@@ -1654,12 +1652,12 @@ class APIGatewayBackend(BaseBackend):
         self,
         name: str,
         description: str,
-        api_key_source: Optional[str] = None,
-        endpoint_configuration: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        policy: Optional[str] = None,
-        minimum_compression_size: Optional[int] = None,
-        disable_execute_api_endpoint: Optional[bool] = None,
+        api_key_source: str | None = None,
+        endpoint_configuration: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        policy: str | None = None,
+        minimum_compression_size: int | None = None,
+        disable_execute_api_endpoint: bool | None = None,
     ) -> RestAPI:
         api_id = ApigwRestApiIdentifier(
             self.account_id, self.region_name, name
@@ -1892,14 +1890,14 @@ class APIGatewayBackend(BaseBackend):
         function_id: str,
         resource_id: str,
         method_type: str,
-        authorization_type: Optional[str],
-        api_key_required: Optional[bool] = None,
-        request_parameters: Optional[dict[str, Any]] = None,
-        request_models: Optional[dict[str, Any]] = None,
-        operation_name: Optional[str] = None,
-        authorizer_id: Optional[str] = None,
-        authorization_scopes: Optional[str] = None,
-        request_validator_id: Optional[str] = None,
+        authorization_type: str | None,
+        api_key_required: bool | None = None,
+        request_parameters: dict[str, Any] | None = None,
+        request_models: dict[str, Any] | None = None,
+        operation_name: str | None = None,
+        authorizer_id: str | None = None,
+        authorization_scopes: str | None = None,
+        request_validator_id: str | None = None,
     ) -> Method:
         resource = self.get_resource(function_id, resource_id)
         method = resource.add_method(
@@ -1979,12 +1977,12 @@ class APIGatewayBackend(BaseBackend):
         function_id: str,
         stage_name: str,
         deploymentId: str,
-        variables: Optional[Any] = None,
+        variables: Any | None = None,
         description: str = "",
-        cacheClusterEnabled: Optional[bool] = None,
-        cacheClusterSize: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        tracing_enabled: Optional[bool] = None,
+        cacheClusterEnabled: bool | None = None,
+        cacheClusterSize: str | None = None,
+        tags: dict[str, str] | None = None,
+        tracing_enabled: bool | None = None,
     ) -> Stage:
         if variables is None:
             variables = {}
@@ -2017,7 +2015,7 @@ class APIGatewayBackend(BaseBackend):
 
     def get_method_response(
         self, function_id: str, resource_id: str, method_type: str, response_code: str
-    ) -> Optional[MethodResponse]:
+    ) -> MethodResponse | None:
         method = self.get_method(function_id, resource_id, method_type)
         return method.get_response(response_code)
 
@@ -2037,7 +2035,7 @@ class APIGatewayBackend(BaseBackend):
 
     def delete_method_response(
         self, function_id: str, resource_id: str, method_type: str, response_code: str
-    ) -> Optional[MethodResponse]:
+    ) -> MethodResponse | None:
         method = self.get_method(function_id, resource_id, method_type)
         return method.delete_response(response_code)
 
@@ -2049,15 +2047,15 @@ class APIGatewayBackend(BaseBackend):
         integration_type: str,
         uri: str,
         integration_method: str,
-        credentials: Optional[str] = None,
-        request_templates: Optional[dict[str, Any]] = None,
-        passthrough_behavior: Optional[str] = None,
-        tls_config: Optional[dict[str, Any]] = None,
-        cache_namespace: Optional[str] = None,
-        timeout_in_millis: Optional[str] = None,
-        request_parameters: Optional[dict[str, Any]] = None,
-        content_handling: Optional[str] = None,
-        connection_type: Optional[str] = None,
+        credentials: str | None = None,
+        request_templates: dict[str, Any] | None = None,
+        passthrough_behavior: str | None = None,
+        tls_config: dict[str, Any] | None = None,
+        cache_namespace: str | None = None,
+        timeout_in_millis: str | None = None,
+        request_parameters: dict[str, Any] | None = None,
+        content_handling: str | None = None,
+        connection_type: str | None = None,
     ) -> Integration:
         resource = self.get_resource(function_id, resource_id)
         if credentials and not re.match(
@@ -2132,7 +2130,7 @@ class APIGatewayBackend(BaseBackend):
         selection_pattern: str,
         response_templates: dict[str, str],
         response_parameters: dict[str, str],
-        content_handling: Optional[str] = None,
+        content_handling: str | None = None,
     ) -> IntegrationResponse:
         integration = self.get_integration(function_id, resource_id, method_type)
         if integration:
@@ -2213,7 +2211,7 @@ class APIGatewayBackend(BaseBackend):
         self.keys[key.id] = key
         return key
 
-    def get_api_keys(self, name: Optional[str] = None) -> list[ApiKey]:
+    def get_api_keys(self, name: str | None = None) -> list[ApiKey]:
         return [
             key
             for key in self.keys.values()
@@ -2244,7 +2242,7 @@ class APIGatewayBackend(BaseBackend):
         self.usage_plans[plan.id] = plan
         return plan
 
-    def get_usage_plans(self, api_key_id: Optional[str] = None) -> list[UsagePlan]:
+    def get_usage_plans(self, api_key_id: str | None = None) -> list[UsagePlan]:
         plans = list(self.usage_plans.values())
         if api_key_id is not None:
             plans = [
@@ -2297,7 +2295,7 @@ class APIGatewayBackend(BaseBackend):
         return usage_plan_key
 
     def get_usage_plan_keys(
-        self, usage_plan_id: str, name: Optional[str] = None
+        self, usage_plan_id: str, name: str | None = None
     ) -> list[UsagePlanKey]:
         if usage_plan_id not in self.usage_plan_keys:
             return []
@@ -2436,7 +2434,7 @@ class APIGatewayBackend(BaseBackend):
         return restApi.get_request_validators()
 
     def create_request_validator(
-        self, restapi_id: str, name: str, body: Optional[bool], params: Any
+        self, restapi_id: str, name: str, body: bool | None, params: Any
     ) -> RequestValidator:
         restApi = self.get_rest_api(restapi_id)
         return restApi.create_request_validator(

--- a/moto/apigateway/responses.py
+++ b/moto/apigateway/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.responses import TYPE_RESPONSE, BaseResponse
@@ -28,7 +28,7 @@ class APIGatewayResponse(BaseResponse):
     def backend(self) -> APIGatewayBackend:
         return apigateway_backends[self.current_account][self.region]
 
-    def __validate_api_key_source(self, api_key_source: str) -> Optional[TYPE_RESPONSE]:
+    def __validate_api_key_source(self, api_key_source: str) -> TYPE_RESPONSE | None:
         if api_key_source and api_key_source not in API_KEY_SOURCES:
             return self.error(
                 "ValidationException",
@@ -43,7 +43,7 @@ class APIGatewayResponse(BaseResponse):
 
     def __validate_endpoint_configuration(
         self, endpoint_configuration: dict[str, str]
-    ) -> Optional[TYPE_RESPONSE]:
+    ) -> TYPE_RESPONSE | None:
         if endpoint_configuration and "types" in endpoint_configuration:
             invalid_types = list(
                 set(endpoint_configuration["types"]) - set(ENDPOINT_CONFIGURATION_TYPES)
@@ -106,7 +106,7 @@ class APIGatewayResponse(BaseResponse):
 
     def __validte_rest_patch_operations(
         self, patch_operations: list[dict[str, str]]
-    ) -> Optional[TYPE_RESPONSE]:
+    ) -> TYPE_RESPONSE | None:
         for op in patch_operations:
             path = op["path"]
             if "apiKeySource" in path:

--- a/moto/apigateway/utils.py
+++ b/moto/apigateway/utils.py
@@ -1,6 +1,6 @@
 import json
 import string
-from typing import Any, Union
+from typing import Any
 
 import yaml
 
@@ -14,9 +14,7 @@ class ApigwIdentifier(ResourceIdentifier):
     def __init__(self, account_id: str, region: str, name: str):
         super().__init__(account_id, region, name)
 
-    def generate(
-        self, existing_ids: Union[list[str], None] = None, tags: Tags = None
-    ) -> str:
+    def generate(self, existing_ids: list[str] | None = None, tags: Tags = None) -> str:
         return generate_str_id(
             resource_identifier=self,
             existing_ids=existing_ids,

--- a/moto/apigatewayv2/models.py
+++ b/moto/apigatewayv2/models.py
@@ -3,7 +3,7 @@
 import hashlib
 import string
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 import yaml
 
@@ -157,23 +157,23 @@ class Authorizer(BaseModel):
 class Integration(BaseModel):
     def __init__(
         self,
-        connection_id: Optional[str],
+        connection_id: str | None,
         connection_type: str,
-        content_handling_strategy: Optional[str],
-        credentials_arn: Optional[str],
+        content_handling_strategy: str | None,
+        credentials_arn: str | None,
         description: str,
         integration_method: str,
         integration_type: str,
         integration_uri: str,
-        passthrough_behavior: Optional[str],
-        payload_format_version: Optional[str],
-        integration_subtype: Optional[str],
-        request_parameters: Optional[dict[str, str]],
-        request_templates: Optional[dict[str, str]],
-        response_parameters: Optional[dict[str, dict[str, str]]],
-        template_selection_expression: Optional[str],
-        timeout_in_millis: Optional[str],
-        tls_config: Optional[dict[str, str]],
+        passthrough_behavior: str | None,
+        payload_format_version: str | None,
+        integration_subtype: str | None,
+        request_parameters: dict[str, str] | None,
+        request_templates: dict[str, str] | None,
+        response_parameters: dict[str, dict[str, str]] | None,
+        template_selection_expression: str | None,
+        timeout_in_millis: str | None,
+        tls_config: dict[str, str] | None,
     ):
         self.id = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
         self.connection_id = connection_id
@@ -282,7 +282,7 @@ class Integration(BaseModel):
         request_templates: dict[str, str],
         response_parameters: dict[str, dict[str, str]],
         template_selection_expression: str,
-        timeout_in_millis: Optional[int],
+        timeout_in_millis: int | None,
         tls_config: dict[str, str],
     ) -> None:
         if connection_id is not None:
@@ -450,14 +450,14 @@ class Route(BaseModel):
         self,
         api_key_required: bool,
         authorization_scopes: list[str],
-        authorization_type: Optional[str],
-        authorizer_id: Optional[str],
-        model_selection_expression: Optional[str],
-        operation_name: Optional[str],
-        request_models: Optional[dict[str, str]],
-        request_parameters: Optional[dict[str, dict[str, bool]]],
+        authorization_type: str | None,
+        authorizer_id: str | None,
+        model_selection_expression: str | None,
+        operation_name: str | None,
+        request_models: dict[str, str] | None,
+        request_parameters: dict[str, dict[str, bool]] | None,
         route_key: str,
-        route_response_selection_expression: Optional[str],
+        route_response_selection_expression: str | None,
         target: str,
     ):
         self.route_id = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
@@ -502,8 +502,8 @@ class Route(BaseModel):
 
     def update(
         self,
-        api_key_required: Optional[bool],
-        authorization_scopes: Optional[list[str]],
+        api_key_required: bool | None,
+        authorization_scopes: list[str] | None,
         authorization_type: str,
         authorizer_id: str,
         model_selection_expression: str,
@@ -562,7 +562,7 @@ class Api(BaseModel):
         region: str,
         name: str,
         api_key_selection_expression: str,
-        cors_configuration: Optional[str],
+        cors_configuration: str | None,
         description: str,
         disable_execute_api_endpoint: str,
         disable_schema_validation: str,
@@ -774,18 +774,18 @@ class Api(BaseModel):
         integration_method: str,
         integration_type: str,
         integration_uri: str,
-        connection_id: Optional[str] = None,
-        content_handling_strategy: Optional[str] = None,
-        credentials_arn: Optional[str] = None,
-        passthrough_behavior: Optional[str] = None,
-        payload_format_version: Optional[str] = None,
-        integration_subtype: Optional[str] = None,
-        request_parameters: Optional[dict[str, str]] = None,
-        request_templates: Optional[dict[str, str]] = None,
-        response_parameters: Optional[dict[str, dict[str, str]]] = None,
-        template_selection_expression: Optional[str] = None,
-        timeout_in_millis: Optional[str] = None,
-        tls_config: Optional[dict[str, str]] = None,
+        connection_id: str | None = None,
+        content_handling_strategy: str | None = None,
+        credentials_arn: str | None = None,
+        passthrough_behavior: str | None = None,
+        payload_format_version: str | None = None,
+        integration_subtype: str | None = None,
+        request_parameters: dict[str, str] | None = None,
+        request_templates: dict[str, str] | None = None,
+        response_parameters: dict[str, dict[str, str]] | None = None,
+        template_selection_expression: str | None = None,
+        timeout_in_millis: str | None = None,
+        tls_config: dict[str, str] | None = None,
     ) -> Integration:
         integration = Integration(
             connection_id=connection_id,
@@ -838,7 +838,7 @@ class Api(BaseModel):
         request_templates: dict[str, str],
         response_parameters: dict[str, dict[str, str]],
         template_selection_expression: str,
-        timeout_in_millis: Optional[int],
+        timeout_in_millis: int | None,
         tls_config: dict[str, str],
     ) -> Integration:
         integration = self.integrations[integration_id]
@@ -925,13 +925,13 @@ class Api(BaseModel):
         authorization_scopes: list[str],
         route_key: str,
         target: str,
-        authorization_type: Optional[str] = None,
-        authorizer_id: Optional[str] = None,
-        model_selection_expression: Optional[str] = None,
-        operation_name: Optional[str] = None,
-        request_models: Optional[dict[str, str]] = None,
-        request_parameters: Optional[dict[str, dict[str, bool]]] = None,
-        route_response_selection_expression: Optional[str] = None,
+        authorization_type: str | None = None,
+        authorizer_id: str | None = None,
+        model_selection_expression: str | None = None,
+        operation_name: str | None = None,
+        request_models: dict[str, str] | None = None,
+        request_parameters: dict[str, dict[str, bool]] | None = None,
+        route_response_selection_expression: str | None = None,
     ) -> Route:
         route = Route(
             api_key_required=api_key_required,
@@ -967,7 +967,7 @@ class Api(BaseModel):
     def update_route(
         self,
         route_id: str,
-        api_key_required: Optional[bool],
+        api_key_required: bool | None,
         authorization_scopes: list[str],
         authorization_type: str,
         authorizer_id: str,
@@ -1363,8 +1363,8 @@ class ApiGatewayV2Backend(BaseBackend):
         authorizer_id: str,
         model_selection_expression: str,
         operation_name: str,
-        request_models: Optional[dict[str, str]],
-        request_parameters: Optional[dict[str, dict[str, bool]]],
+        request_models: dict[str, str] | None,
+        request_parameters: dict[str, dict[str, bool]] | None,
         route_key: str,
         route_response_selection_expression: str,
         target: str,
@@ -1484,9 +1484,9 @@ class ApiGatewayV2Backend(BaseBackend):
         integration_uri: str,
         passthrough_behavior: str,
         payload_format_version: str,
-        request_parameters: Optional[dict[str, str]],
-        request_templates: Optional[dict[str, str]],
-        response_parameters: Optional[dict[str, dict[str, str]]],
+        request_parameters: dict[str, str] | None,
+        request_templates: dict[str, str] | None,
+        response_parameters: dict[str, dict[str, str]] | None,
         template_selection_expression: str,
         timeout_in_millis: str,
         tls_config: dict[str, str],
@@ -1548,7 +1548,7 @@ class ApiGatewayV2Backend(BaseBackend):
         request_templates: dict[str, str],
         response_parameters: dict[str, dict[str, str]],
         template_selection_expression: str,
-        timeout_in_millis: Optional[int],
+        timeout_in_millis: int | None,
         tls_config: dict[str, str],
     ) -> Integration:
         api = self.get_api(api_id)
@@ -1685,7 +1685,7 @@ class ApiGatewayV2Backend(BaseBackend):
         self.domain_names[domain.domain_name] = domain
         return domain
 
-    def get_domain_name(self, domain_name: Union[str, None]) -> DomainName:
+    def get_domain_name(self, domain_name: str | None) -> DomainName:
         if domain_name is None or domain_name not in self.domain_names:
             raise DomainNameNotFound
         return self.domain_names[domain_name]

--- a/moto/appconfig/models.py
+++ b/moto/appconfig/models.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -115,7 +115,7 @@ class ConfigurationProfile(BaseModel):
 
 class Application(BaseModel):
     def __init__(
-        self, name: str, description: Optional[str], region: str, account_id: str
+        self, name: str, description: str | None, region: str, account_id: str
     ):
         self.id = mock_random.get_random_hex(7)
         self.arn = f"arn:{get_partition(region)}:appconfig:{region}:{account_id}:application/{self.id}"
@@ -141,7 +141,7 @@ class AppConfigBackend(BaseBackend):
         self.tagger = TaggingService()
 
     def create_application(
-        self, name: str, description: Optional[str], tags: dict[str, str]
+        self, name: str, description: str | None, tags: dict[str, str]
     ) -> Application:
         app = Application(
             name, description, region=self.region_name, account_id=self.account_id

--- a/moto/applicationautoscaling/models.py
+++ b/moto/applicationautoscaling/models.py
@@ -2,7 +2,7 @@ import re
 import time
 from collections import OrderedDict
 from enum import Enum, unique
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -79,7 +79,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
         self.scheduled_actions: list[FakeScheduledAction] = []
 
     def describe_scalable_targets(
-        self, namespace: str, r_ids: Union[None, list[str]], dimension: Union[None, str]
+        self, namespace: str, r_ids: None | list[str], dimension: None | str
     ) -> list["FakeScalableTarget"]:
         if r_ids is None:
             r_ids = []
@@ -104,8 +104,8 @@ class ApplicationAutoscalingBackend(BaseBackend):
         namespace: str,
         r_id: str,
         dimension: str,
-        min_capacity: Optional[int],
-        max_capacity: Optional[int],
+        min_capacity: int | None,
+        max_capacity: int | None,
         role_arn: str,
         suspended_state: str,
     ) -> "FakeScalableTarget":
@@ -168,7 +168,7 @@ class ApplicationAutoscalingBackend(BaseBackend):
         resource_id: str,
         scalable_dimension: str,
         policy_body: dict[str, Any],
-        policy_type: Optional[None],
+        policy_type: str | None,
     ) -> "FakeApplicationAutoscalingPolicy":
         policy_key = FakeApplicationAutoscalingPolicy.formulate_key(
             service_namespace, resource_id, scalable_dimension, policy_name
@@ -204,9 +204,9 @@ class ApplicationAutoscalingBackend(BaseBackend):
         service_namespace: str,
         resource_id: str,
         scalable_dimension: str,
-        max_results: Optional[int],
+        max_results: int | None,
         next_token: str,
-    ) -> tuple[Optional[str], list["FakeApplicationAutoscalingPolicy"]]:
+    ) -> tuple[str | None, list["FakeApplicationAutoscalingPolicy"]]:
         max_results = max_results or 100
         policies = [
             policy
@@ -404,8 +404,8 @@ class FakeScalableTarget(BaseModel):
         service_namespace: str,
         resource_id: str,
         scalable_dimension: str,
-        min_capacity: Optional[int],
-        max_capacity: Optional[int],
+        min_capacity: int | None,
+        max_capacity: int | None,
         role_arn: str,
         suspended_state: str,
     ) -> None:
@@ -422,8 +422,8 @@ class FakeScalableTarget(BaseModel):
 
     def update(
         self,
-        min_capacity: Optional[int],
-        max_capacity: Optional[int],
+        min_capacity: int | None,
+        max_capacity: int | None,
         suspended_state: str,
     ) -> None:
         if min_capacity is not None:
@@ -443,7 +443,7 @@ class FakeApplicationAutoscalingPolicy(BaseModel):
         service_namespace: str,
         resource_id: str,
         scalable_dimension: str,
-        policy_type: Optional[str],
+        policy_type: str | None,
         policy_body: dict[str, Any],
     ) -> None:
         self.step_scaling_policy_configuration = None

--- a/moto/appmesh/dataclasses/mesh.py
+++ b/moto/appmesh/dataclasses/mesh.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from moto.appmesh.dataclasses.shared import Metadata, Status
 from moto.appmesh.dataclasses.virtual_node import VirtualNode
@@ -8,8 +8,8 @@ from moto.appmesh.dataclasses.virtual_router import VirtualRouter
 
 @dataclass
 class MeshSpec:
-    egress_filter: dict[Literal["type"], Optional[str]]
-    service_discovery: dict[Literal["ip_preference"], Optional[str]]
+    egress_filter: dict[Literal["type"], str | None]
+    service_discovery: dict[Literal["ip_preference"], str | None]
 
 
 @dataclass

--- a/moto/appmesh/dataclasses/route.py
+++ b/moto/appmesh/dataclasses/route.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from moto.appmesh.dataclasses.shared import (
     Duration,
@@ -15,7 +15,7 @@ from moto.appmesh.utils.common import clean_dict
 class RouteActionWeightedTarget:
     virtual_node: str
     weight: int
-    port: Optional[int] = field(default=None)
+    port: int | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -42,11 +42,11 @@ class Range:
 
 @dataclass
 class Match:
-    exact: Optional[str]
-    prefix: Optional[str]
-    range: Optional[Range]
-    regex: Optional[str]
-    suffix: Optional[str]
+    exact: str | None
+    prefix: str | None
+    range: Range | None
+    regex: str | None
+    suffix: str | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -62,8 +62,8 @@ class Match:
 
 @dataclass
 class GrpcMetadatum:
-    invert: Optional[bool]
-    match: Optional[Match]
+    invert: bool | None
+    match: Match | None
     name: str
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
@@ -96,7 +96,7 @@ class QueryParameterMatch:
 @dataclass
 class RouteMatchQueryParameter:
     name: str
-    match: Optional[QueryParameterMatch] = field(default=None)
+    match: QueryParameterMatch | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -106,13 +106,13 @@ class RouteMatchQueryParameter:
 
 @dataclass
 class HttpRouteMatch:
-    headers: Optional[list[HttpRouteMatchHeader]] = field(default=None)
-    method: Optional[str] = field(default=None)
-    path: Optional[RouteMatchPath] = field(default=None)
-    port: Optional[int] = field(default=None)
-    prefix: Optional[str] = field(default=None)
-    query_parameters: Optional[list[RouteMatchQueryParameter]] = field(default=None)
-    scheme: Optional[str] = field(default=None)
+    headers: list[HttpRouteMatchHeader] | None = field(default=None)
+    method: str | None = field(default=None)
+    path: RouteMatchPath | None = field(default=None)
+    port: int | None = field(default=None)
+    prefix: str | None = field(default=None)
+    query_parameters: list[RouteMatchQueryParameter] | None = field(default=None)
+    scheme: str | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -133,9 +133,9 @@ class HttpRouteMatch:
 @dataclass
 class HttpRouteRetryPolicy:
     max_retries: int
-    http_retry_events: Optional[list[str]]
+    http_retry_events: list[str] | None
     per_retry_timeout: Duration
-    tcp_retry_events: Optional[list[str]]
+    tcp_retry_events: list[str] | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -150,10 +150,10 @@ class HttpRouteRetryPolicy:
 
 @dataclass
 class GrpcRouteMatch:
-    metadata: Optional[list[GrpcMetadatum]]
-    method_name: Optional[str]
-    port: Optional[int]
-    service_name: Optional[str]
+    metadata: list[GrpcMetadatum] | None
+    method_name: str | None
+    port: int | None
+    service_name: str | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -170,9 +170,9 @@ class GrpcRouteMatch:
 class GrcpRouteRetryPolicy:
     max_retries: int
     per_retry_timeout: Duration
-    grpc_retry_events: Optional[list[str]]
-    http_retry_events: Optional[list[str]]
-    tcp_retry_events: Optional[list[str]]
+    grpc_retry_events: list[str] | None
+    http_retry_events: list[str] | None
+    tcp_retry_events: list[str] | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -190,8 +190,8 @@ class GrcpRouteRetryPolicy:
 class GrpcRoute:
     action: RouteAction
     match: GrpcRouteMatch
-    retry_policy: Optional[GrcpRouteRetryPolicy]
-    timeout: Optional[Timeout]
+    retry_policy: GrcpRouteRetryPolicy | None
+    timeout: Timeout | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -208,8 +208,8 @@ class GrpcRoute:
 class HttpRoute:
     action: RouteAction
     match: HttpRouteMatch
-    retry_policy: Optional[HttpRouteRetryPolicy] = field(default=None)
-    timeout: Optional[Timeout] = field(default=None)
+    retry_policy: HttpRouteRetryPolicy | None = field(default=None)
+    timeout: Timeout | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -231,8 +231,8 @@ class TCPRouteMatch:
 @dataclass
 class TCPRoute:
     action: RouteAction
-    match: Optional[TCPRouteMatch]
-    timeout: Optional[Timeout]
+    match: TCPRouteMatch | None
+    timeout: Timeout | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -246,11 +246,11 @@ class TCPRoute:
 
 @dataclass
 class RouteSpec:
-    priority: Optional[int]
-    grpc_route: Optional[GrpcRoute] = field(default=None)
-    http_route: Optional[HttpRoute] = field(default=None)
-    http2_route: Optional[HttpRoute] = field(default=None)
-    tcp_route: Optional[TCPRoute] = field(default=None)
+    priority: int | None
+    grpc_route: GrpcRoute | None = field(default=None)
+    http_route: HttpRoute | None = field(default=None)
+    http2_route: HttpRoute | None = field(default=None)
+    tcp_route: TCPRoute | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         spec = {

--- a/moto/appmesh/dataclasses/shared.py
+++ b/moto/appmesh/dataclasses/shared.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 from uuid import uuid4
 
 from moto.appmesh.utils.common import clean_dict
@@ -36,8 +36,8 @@ class MissingField:
 
 @dataclass
 class Timeout:
-    idle: Optional[Duration] = field(default=None)
-    per_request: Optional[Duration] = field(default=None)
+    idle: Duration | None = field(default=None)
+    per_request: Duration | None = field(default=None)
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(

--- a/moto/appmesh/dataclasses/virtual_node.py
+++ b/moto/appmesh/dataclasses/virtual_node.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from moto.appmesh.dataclasses.shared import (
     Duration,
@@ -40,8 +40,8 @@ class SDS:
 
 @dataclass
 class Certificate:
-    file: Optional[CertificateFileWithPrivateKey]
-    sds: Optional[SDS]
+    file: CertificateFileWithPrivateKey | None
+    sds: SDS | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -62,7 +62,7 @@ class ListenerCertificateACM:
 
 @dataclass
 class TLSListenerCertificate(Certificate):
-    acm: Optional[ListenerCertificateACM]
+    acm: ListenerCertificateACM | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -99,8 +99,8 @@ class ACM:
 
 @dataclass
 class Trust:
-    file: Optional[CertificateFile]
-    sds: Optional[SDS]
+    file: CertificateFile | None
+    sds: SDS | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -113,7 +113,7 @@ class Trust:
 
 @dataclass
 class BackendTrust(Trust):
-    acm: Optional[ACM]
+    acm: ACM | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -127,7 +127,7 @@ class BackendTrust(Trust):
 
 @dataclass
 class Validation:
-    subject_alternative_names: Optional[SubjectAlternativeNames]
+    subject_alternative_names: SubjectAlternativeNames | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -171,9 +171,9 @@ class TLSListenerValidation(Validation):
 
 @dataclass
 class TLSClientPolicy:
-    certificate: Optional[Certificate]
-    enforce: Optional[bool]
-    ports: Optional[list[int]]
+    certificate: Certificate | None
+    enforce: bool | None
+    ports: list[int] | None
     validation: TLSBackendValidation
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
@@ -189,7 +189,7 @@ class TLSClientPolicy:
 
 @dataclass
 class ClientPolicy:
-    tls: Optional[TLSClientPolicy]
+    tls: TLSClientPolicy | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict({"tls": (self.tls or MissingField()).to_dict()})
@@ -197,7 +197,7 @@ class ClientPolicy:
 
 @dataclass
 class BackendDefaults:
-    client_policy: Optional[ClientPolicy]
+    client_policy: ClientPolicy | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -207,7 +207,7 @@ class BackendDefaults:
 
 @dataclass
 class VirtualService:
-    client_policy: Optional[ClientPolicy]
+    client_policy: ClientPolicy | None
     virtual_service_name: str
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
@@ -221,7 +221,7 @@ class VirtualService:
 
 @dataclass
 class Backend:
-    virtual_service: Optional[VirtualService]
+    virtual_service: VirtualService | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -232,7 +232,7 @@ class Backend:
 @dataclass
 class HTTPConnection:
     max_connections: int
-    max_pending_requests: Optional[int]
+    max_pending_requests: int | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -261,10 +261,10 @@ class TCPConnection:
 
 @dataclass
 class ConnectionPool:
-    grpc: Optional[GRPCOrHTTP2Connection]
-    http: Optional[HTTPConnection]
-    http2: Optional[GRPCOrHTTP2Connection]
-    tcp: Optional[TCPConnection]
+    grpc: GRPCOrHTTP2Connection | None
+    http: HTTPConnection | None
+    http2: GRPCOrHTTP2Connection | None
+    tcp: TCPConnection | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -281,8 +281,8 @@ class ConnectionPool:
 class HealthCheck:
     healthy_threshold: int
     interval_millis: int
-    path: Optional[str]
-    port: Optional[int]
+    path: str | None
+    port: int | None
     protocol: str
     timeout_millis: int
     unhealthy_threshold: int
@@ -334,10 +334,10 @@ class TCPTimeout:
 
 @dataclass
 class ProtocolTimeouts:
-    grpc: Optional[Timeout]
-    http: Optional[Timeout]
-    http2: Optional[Timeout]
-    tcp: Optional[TCPTimeout]
+    grpc: Timeout | None
+    http: Timeout | None
+    http2: Timeout | None
+    tcp: TCPTimeout | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -354,7 +354,7 @@ class ProtocolTimeouts:
 class ListenerTLS:
     certificate: TLSListenerCertificate
     mode: str
-    validation: Optional[TLSListenerValidation]
+    validation: TLSListenerValidation | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -368,12 +368,12 @@ class ListenerTLS:
 
 @dataclass
 class Listener:
-    connection_pool: Optional[ConnectionPool]
-    health_check: Optional[HealthCheck]
-    outlier_detection: Optional[OutlierDetection]
+    connection_pool: ConnectionPool | None
+    health_check: HealthCheck | None
+    outlier_detection: OutlierDetection | None
     port_mapping: PortMapping
-    timeout: Optional[ProtocolTimeouts]
-    tls: Optional[ListenerTLS]
+    timeout: ProtocolTimeouts | None
+    tls: ListenerTLS | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -399,8 +399,8 @@ class KeyValue:
 
 @dataclass
 class LoggingFormat:
-    json: Optional[list[KeyValue]]
-    text: Optional[str]
+    json: list[KeyValue] | None
+    text: str | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -410,7 +410,7 @@ class LoggingFormat:
 
 @dataclass
 class AccessLogFile:
-    format: Optional[LoggingFormat]
+    format: LoggingFormat | None
     path: str
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
@@ -421,7 +421,7 @@ class AccessLogFile:
 
 @dataclass
 class AccessLog:
-    file: Optional[AccessLogFile]
+    file: AccessLogFile | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict({"file": (self.file or MissingField()).to_dict()})
@@ -429,7 +429,7 @@ class AccessLog:
 
 @dataclass
 class Logging:
-    access_log: Optional[AccessLog]
+    access_log: AccessLog | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict({"accessLog": (self.access_log or MissingField()).to_dict()})
@@ -437,8 +437,8 @@ class Logging:
 
 @dataclass
 class AWSCloudMap:
-    attributes: Optional[list[KeyValue]]
-    ip_preference: Optional[str]
+    attributes: list[KeyValue] | None
+    ip_preference: str | None
     namespace_name: str
     service_name: str
 
@@ -458,8 +458,8 @@ class AWSCloudMap:
 @dataclass
 class DNS:
     hostname: str
-    ip_preference: Optional[str]
-    response_type: Optional[str]
+    ip_preference: str | None
+    response_type: str | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -473,8 +473,8 @@ class DNS:
 
 @dataclass
 class ServiceDiscovery:
-    aws_cloud_map: Optional[AWSCloudMap]
-    dns: Optional[DNS]
+    aws_cloud_map: AWSCloudMap | None
+    dns: DNS | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(
@@ -487,11 +487,11 @@ class ServiceDiscovery:
 
 @dataclass
 class VirtualNodeSpec:
-    backend_defaults: Optional[BackendDefaults]
-    backends: Optional[list[Backend]]
-    listeners: Optional[list[Listener]]
-    logging: Optional[Logging]
-    service_discovery: Optional[ServiceDiscovery]
+    backend_defaults: BackendDefaults | None
+    backends: list[Backend] | None
+    listeners: list[Listener] | None
+    logging: Logging | None
+    service_discovery: ServiceDiscovery | None
 
     def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
         return clean_dict(

--- a/moto/appmesh/dataclasses/virtual_router.py
+++ b/moto/appmesh/dataclasses/virtual_router.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from moto.appmesh.dataclasses.route import Route
 from moto.appmesh.dataclasses.shared import Metadata, Status
@@ -7,8 +7,8 @@ from moto.appmesh.dataclasses.shared import Metadata, Status
 
 @dataclass
 class PortMapping:
-    port: Optional[int]
-    protocol: Optional[str]
+    port: int | None
+    protocol: str | None
 
 
 @dataclass

--- a/moto/appmesh/models.py
+++ b/moto/appmesh/models.py
@@ -1,6 +1,6 @@
 """AppMeshBackend class with methods for supported APIs."""
 
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from moto.appmesh.dataclasses.mesh import (
     Mesh,
@@ -73,7 +73,7 @@ class AppMeshBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.meshes: dict[str, Mesh] = {}
 
-    def _validate_mesh(self, mesh_name: str, mesh_owner: Optional[str]) -> None:
+    def _validate_mesh(self, mesh_name: str, mesh_owner: str | None) -> None:
         if mesh_name not in self.meshes:
             raise MeshNotFoundError(mesh_name=mesh_name)
         if (
@@ -85,7 +85,7 @@ class AppMeshBackend(BaseBackend):
     def _check_virtual_node_validity(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         virtual_node_name: str,
     ) -> None:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
@@ -96,7 +96,7 @@ class AppMeshBackend(BaseBackend):
     def _check_virtual_node_availability(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         virtual_node_name: str,
     ) -> None:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
@@ -109,7 +109,7 @@ class AppMeshBackend(BaseBackend):
     def _check_router_availability(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         virtual_router_name: str,
     ) -> None:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
@@ -122,7 +122,7 @@ class AppMeshBackend(BaseBackend):
     def _check_router_validity(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         virtual_router_name: str,
     ) -> None:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
@@ -135,7 +135,7 @@ class AppMeshBackend(BaseBackend):
     def _check_route_validity(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         virtual_router_name: str,
         route_name: str,
     ) -> None:
@@ -158,7 +158,7 @@ class AppMeshBackend(BaseBackend):
     def _check_route_availability(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         virtual_router_name: str,
         route_name: str,
     ) -> None:
@@ -180,11 +180,11 @@ class AppMeshBackend(BaseBackend):
 
     def create_mesh(
         self,
-        client_token: Optional[str],
+        client_token: str | None,
         mesh_name: str,
-        egress_filter_type: Optional[str],
-        ip_preference: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        egress_filter_type: str | None,
+        ip_preference: str | None,
+        tags: list[dict[str, str]] | None,
     ) -> Mesh:
         from moto.sts import sts_backends
 
@@ -214,10 +214,10 @@ class AppMeshBackend(BaseBackend):
 
     def update_mesh(
         self,
-        client_token: Optional[str],
+        client_token: str | None,
         mesh_name: str,
-        egress_filter_type: Optional[str],
-        ip_preference: Optional[str],
+        egress_filter_type: str | None,
+        ip_preference: str | None,
     ) -> Mesh:
         if mesh_name not in self.meshes:
             raise MeshNotFoundError(mesh_name=mesh_name)
@@ -237,7 +237,7 @@ class AppMeshBackend(BaseBackend):
             self.meshes[mesh_name].metadata.version += 1
         return self.meshes[mesh_name]
 
-    def describe_mesh(self, mesh_name: str, mesh_owner: Optional[str]) -> Mesh:
+    def describe_mesh(self, mesh_name: str, mesh_owner: str | None) -> Mesh:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
         return self.meshes[mesh_name]
 
@@ -250,7 +250,7 @@ class AppMeshBackend(BaseBackend):
         return mesh
 
     @paginate(pagination_model=PAGINATION_MODEL)
-    def list_meshes(self) -> list[dict[str, Union[str, int]]]:
+    def list_meshes(self) -> list[dict[str, str | int]]:
         return [
             {
                 "arn": mesh.metadata.arn,
@@ -268,7 +268,7 @@ class AppMeshBackend(BaseBackend):
 
     def _get_resource_with_arn(
         self, resource_arn: str
-    ) -> Union[Mesh, VirtualRouter, Route, VirtualNode]:
+    ) -> Mesh | VirtualRouter | Route | VirtualNode:
         for mesh in self.meshes.values():
             if mesh.metadata.arn == resource_arn:
                 return mesh
@@ -294,7 +294,7 @@ class AppMeshBackend(BaseBackend):
         return
 
     def describe_virtual_router(
-        self, mesh_name: str, mesh_owner: Optional[str], virtual_router_name: str
+        self, mesh_name: str, mesh_owner: str | None, virtual_router_name: str
     ) -> VirtualRouter:
         self._check_router_validity(
             mesh_name=mesh_name,
@@ -307,9 +307,9 @@ class AppMeshBackend(BaseBackend):
         self,
         client_token: str,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         port_mappings: list[PortMapping],
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
         virtual_router_name: str,
     ) -> VirtualRouter:
         self._check_router_availability(
@@ -342,7 +342,7 @@ class AppMeshBackend(BaseBackend):
         self,
         client_token: str,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         port_mappings: list[PortMapping],
         virtual_router_name: str,
     ) -> VirtualRouter:
@@ -362,7 +362,7 @@ class AppMeshBackend(BaseBackend):
         return virtual_router
 
     def delete_virtual_router(
-        self, mesh_name: str, mesh_owner: Optional[str], virtual_router_name: str
+        self, mesh_name: str, mesh_owner: str | None, virtual_router_name: str
     ) -> VirtualRouter:
         self._check_router_validity(
             mesh_name=mesh_name,
@@ -377,8 +377,8 @@ class AppMeshBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_virtual_routers(
-        self, mesh_name: str, mesh_owner: Optional[str]
-    ) -> list[dict[str, Union[str, int]]]:
+        self, mesh_name: str, mesh_owner: str | None
+    ) -> list[dict[str, str | int]]:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
         return [
             {
@@ -400,12 +400,12 @@ class AppMeshBackend(BaseBackend):
 
     def create_route(
         self,
-        client_token: Optional[str],
+        client_token: str | None,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         route_name: str,
         spec: RouteSpec,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
         virtual_router_name: str,
     ) -> Route:
         self._check_route_availability(
@@ -440,7 +440,7 @@ class AppMeshBackend(BaseBackend):
     def describe_route(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         route_name: str,
         virtual_router_name: str,
     ) -> Route:
@@ -458,9 +458,9 @@ class AppMeshBackend(BaseBackend):
 
     def update_route(
         self,
-        client_token: Optional[str],
+        client_token: str | None,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         route_name: str,
         spec: RouteSpec,
         virtual_router_name: str,
@@ -484,7 +484,7 @@ class AppMeshBackend(BaseBackend):
     def delete_route(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         route_name: str,
         virtual_router_name: str,
     ) -> Route:
@@ -511,7 +511,7 @@ class AppMeshBackend(BaseBackend):
     def list_routes(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         virtual_router_name: str,
     ) -> list[RouteMetadata]:
         self._check_router_validity(
@@ -523,7 +523,7 @@ class AppMeshBackend(BaseBackend):
         return [route.metadata for route in virtual_router.routes.values()]
 
     def describe_virtual_node(
-        self, mesh_name: str, mesh_owner: Optional[str], virtual_node_name: str
+        self, mesh_name: str, mesh_owner: str | None, virtual_node_name: str
     ) -> VirtualNode:
         self._check_virtual_node_validity(
             mesh_name=mesh_name,
@@ -534,11 +534,11 @@ class AppMeshBackend(BaseBackend):
 
     def create_virtual_node(
         self,
-        client_token: Optional[str],
+        client_token: str | None,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         spec: VirtualNodeSpec,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
         virtual_node_name: str,
     ) -> VirtualNode:
         self._check_virtual_node_availability(
@@ -567,9 +567,9 @@ class AppMeshBackend(BaseBackend):
 
     def update_virtual_node(
         self,
-        client_token: Optional[str],
+        client_token: str | None,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
         spec: VirtualNodeSpec,
         virtual_node_name: str,
     ) -> VirtualNode:
@@ -585,7 +585,7 @@ class AppMeshBackend(BaseBackend):
         return virtual_node
 
     def delete_virtual_node(
-        self, mesh_name: str, mesh_owner: Optional[str], virtual_node_name: str
+        self, mesh_name: str, mesh_owner: str | None, virtual_node_name: str
     ) -> VirtualNode:
         self._check_virtual_node_validity(
             mesh_name=mesh_name,
@@ -601,7 +601,7 @@ class AppMeshBackend(BaseBackend):
     def list_virtual_nodes(
         self,
         mesh_name: str,
-        mesh_owner: Optional[str],
+        mesh_owner: str | None,
     ) -> list[VirtualNodeMetadata]:
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
         virtual_nodes = self.meshes[mesh_name].virtual_nodes

--- a/moto/appmesh/utils/spec_parsing.py
+++ b/moto/appmesh/utils/spec_parsing.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.appmesh.dataclasses.route import (
     GrcpRouteRetryPolicy,
@@ -160,7 +160,7 @@ def get_http_match_from_route(route: Any) -> HttpRouteMatch:  # type: ignore[mis
     )
 
 
-def get_http_retry_policy_from_route(route: Any) -> Optional[HttpRouteRetryPolicy]:  # type: ignore[misc]
+def get_http_retry_policy_from_route(route: Any) -> HttpRouteRetryPolicy | None:  # type: ignore[misc]
     _retry_policy = route.get("retryPolicy")
     retry_policy = None
     if _retry_policy is not None:
@@ -177,7 +177,7 @@ def get_http_retry_policy_from_route(route: Any) -> Optional[HttpRouteRetryPolic
     return retry_policy
 
 
-def get_timeout_from_route(route: Any) -> Optional[Timeout]:  # type: ignore[misc]
+def get_timeout_from_route(route: Any) -> Timeout | None:  # type: ignore[misc]
     _timeout = route.get("timeout") or {}
     idle, per_request = None, None
     _idle = _timeout.get("idle")

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import base64
 import json
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -54,9 +56,9 @@ class APICache(BaseModel):
         ttl: int,
         api_caching_behavior: str,
         type_: str,
-        transit_encryption_enabled: Optional[bool] = None,
-        at_rest_encryption_enabled: Optional[bool] = None,
-        health_metrics_config: Optional[str] = None,
+        transit_encryption_enabled: bool | None = None,
+        at_rest_encryption_enabled: bool | None = None,
+        health_metrics_config: str | None = None,
     ):
         self.ttl = ttl
         self.api_caching_behavior = api_caching_behavior
@@ -71,7 +73,7 @@ class APICache(BaseModel):
         ttl: int,
         api_caching_behavior: str,
         type: str,
-        health_metrics_config: Optional[str] = None,
+        health_metrics_config: str | None = None,
     ) -> None:
         self.ttl = ttl
         self.api_caching_behavior = api_caching_behavior
@@ -103,10 +105,10 @@ class GraphqlSchema(BaseModel):
         self.types: list[Any] = []
 
         self.status = "PROCESSING"
-        self.parse_error: Optional[str] = None
+        self.parse_error: str | None = None
         self._parse_graphql_definition()
 
-    def get_type(self, name: str) -> Optional[dict[str, Any]]:  # type: ignore[return]
+    def get_type(self, name: str) -> dict[str, Any] | None:  # type: ignore[return]
         for graphql_type in self.types:
             if graphql_type.name.value == name:
                 return {
@@ -118,7 +120,7 @@ class GraphqlSchema(BaseModel):
                     "definition": "NotYetImplemented",
                 }
 
-    def get_status(self) -> tuple[str, Optional[str]]:
+    def get_status(self) -> tuple[str, str | None]:
         return self.status, self.parse_error
 
     def _parse_graphql_definition(self) -> None:
@@ -159,7 +161,7 @@ class GraphqlSchema(BaseModel):
 
 
 class GraphqlAPIKey(BaseModel):
-    def __init__(self, description: str, expires: Optional[int]):
+    def __init__(self, description: str, expires: int | None):
         self.key_id = str(mock_random.uuid4())[0:6]
         self.description = description
         if not expires:
@@ -172,7 +174,7 @@ class GraphqlAPIKey(BaseModel):
         else:
             self.expires = expires
 
-    def update(self, description: Optional[str], expires: Optional[int]) -> None:
+    def update(self, description: str | None, expires: int | None) -> None:
         if description:
             self.description = description
         if expires:
@@ -194,14 +196,14 @@ class GraphqlAPI(BaseModel):
         region: str,
         name: str,
         authentication_type: str,
-        additional_authentication_providers: Optional[list[str]],
+        additional_authentication_providers: list[str] | None,
         log_config: str,
         xray_enabled: str,
         user_pool_config: str,
         open_id_connect_config: str,
         lambda_authorizer_config: str,
         visibility: str,
-        backend: "AppSyncBackend",
+        backend: AppSyncBackend,
     ) -> None:
         self.region = region
         self.name = name
@@ -216,17 +218,17 @@ class GraphqlAPI(BaseModel):
         self.visibility = visibility or "GLOBAL"  # Default to Global if not provided
 
         self.arn = f"arn:{get_partition(self.region)}:appsync:{self.region}:{account_id}:apis/{self.api_id}"
-        self.graphql_schema: Optional[GraphqlSchema] = None
+        self.graphql_schema: GraphqlSchema | None = None
 
         self.api_keys: dict[str, GraphqlAPIKey] = {}
 
-        self.api_cache: Optional[APICache] = None
+        self.api_cache: APICache | None = None
         self.backend = backend
 
     def update(
         self,
         name: str,
-        additional_authentication_providers: Optional[list[str]],
+        additional_authentication_providers: list[str] | None,
         authentication_type: str,
         lambda_authorizer_config: str,
         log_config: str,
@@ -253,7 +255,7 @@ class GraphqlAPI(BaseModel):
         if xray_enabled is not None:
             self.xray_enabled = xray_enabled
 
-    def create_api_key(self, description: str, expires: Optional[int]) -> GraphqlAPIKey:
+    def create_api_key(self, description: str, expires: int | None) -> GraphqlAPIKey:
         api_key = GraphqlAPIKey(description, expires)
         self.api_keys[api_key.key_id] = api_key
         return api_key
@@ -265,7 +267,7 @@ class GraphqlAPI(BaseModel):
         self.api_keys.pop(api_key_id)
 
     def update_api_key(
-        self, api_key_id: str, description: str, expires: Optional[int]
+        self, api_key_id: str, description: str, expires: int | None
     ) -> GraphqlAPIKey:
         api_key = self.api_keys[api_key_id]
         api_key.update(description, expires)
@@ -289,9 +291,9 @@ class GraphqlAPI(BaseModel):
         ttl: int,
         api_caching_behavior: str,
         type: str,
-        transit_encryption_enabled: Optional[bool] = None,
-        at_rest_encryption_enabled: Optional[bool] = None,
-        health_metrics_config: Optional[str] = None,
+        transit_encryption_enabled: bool | None = None,
+        at_rest_encryption_enabled: bool | None = None,
+        health_metrics_config: str | None = None,
     ) -> APICache:
         self.api_cache = APICache(
             ttl,
@@ -308,7 +310,7 @@ class GraphqlAPI(BaseModel):
         ttl: int,
         api_caching_behavior: str,
         type: str,
-        health_metrics_config: Optional[str] = None,
+        health_metrics_config: str | None = None,
     ) -> APICache:
         self.api_cache.update(ttl, api_caching_behavior, type, health_metrics_config)  # type: ignore[union-attr]
         return self.api_cache  # type: ignore[return-value]
@@ -339,7 +341,7 @@ class GraphqlAPI(BaseModel):
 
 # region: EventsAPI
 class EventsAPIKey(BaseModel):
-    def __init__(self, description: str, expires: Optional[int]):
+    def __init__(self, description: str, expires: int | None):
         self.key_id = str(mock_random.uuid4())[0:6]
         self.description = description
         if not expires:
@@ -352,7 +354,7 @@ class EventsAPIKey(BaseModel):
         else:
             self.expires = expires
 
-    def update(self, description: Optional[str], expires: Optional[int]) -> None:
+    def update(self, description: str | None, expires: int | None) -> None:
         if description:
             self.description = description
         if expires:
@@ -374,11 +376,11 @@ class ChannelNamespace(BaseModel):
         name: str,
         subscribe_auth_modes: list[dict[str, str]],
         publish_auth_modes: list[dict[str, str]],
-        code_handlers: Optional[list[dict[str, Any]]] = None,
-        handler_configs: Optional[dict[str, Any]] = None,
+        code_handlers: list[dict[str, Any]] | None = None,
+        handler_configs: dict[str, Any] | None = None,
         account_id: str = "",
         region: str = "",
-        backend: Optional["AppSyncBackend"] = None,
+        backend: AppSyncBackend | None = None,
     ) -> None:
         self.api_id = api_id
         self.name = name
@@ -424,9 +426,9 @@ class EventsAPI(BaseModel):
         account_id: str,
         region: str,
         name: str,
-        owner_contact: Optional[str],
-        event_config: Optional[dict[str, Any]],
-        backend: "AppSyncBackend",
+        owner_contact: str | None,
+        event_config: dict[str, Any] | None,
+        backend: AppSyncBackend,
     ) -> None:
         self.region = region
         self.name = name
@@ -465,7 +467,7 @@ class EventsAPI(BaseModel):
 
         return response
 
-    def create_api_key(self, description: str, expires: Optional[int]) -> EventsAPIKey:
+    def create_api_key(self, description: str, expires: int | None) -> EventsAPIKey:
         api_key = EventsAPIKey(description, expires)
         self.api_keys[api_key.key_id] = api_key
         return api_key
@@ -477,7 +479,7 @@ class EventsAPI(BaseModel):
         self.api_keys.pop(api_key_id)
 
     def update_api_key(
-        self, api_key_id: str, description: str, expires: Optional[int]
+        self, api_key_id: str, description: str, expires: int | None
     ) -> EventsAPIKey:
         api_key = self.api_keys[api_key_id]
         api_key.update(description, expires)
@@ -504,7 +506,7 @@ class AppSyncBackend(BaseBackend):
         authentication_type: str,
         user_pool_config: str,
         open_id_connect_config: str,
-        additional_authentication_providers: Optional[list[str]],
+        additional_authentication_providers: list[str] | None,
         xray_enabled: str,
         lambda_authorizer_config: str,
         tags: dict[str, str],
@@ -538,7 +540,7 @@ class AppSyncBackend(BaseBackend):
         authentication_type: str,
         user_pool_config: str,
         open_id_connect_config: str,
-        additional_authentication_providers: Optional[list[str]],
+        additional_authentication_providers: list[str] | None,
         xray_enabled: str,
         lambda_authorizer_config: str,
     ) -> GraphqlAPI:
@@ -579,8 +581,8 @@ class AppSyncBackend(BaseBackend):
         return self.graphql_apis.values()
 
     def create_api_key(
-        self, api_id: str, description: str, expires: Optional[int]
-    ) -> Union[GraphqlAPIKey, EventsAPIKey]:
+        self, api_id: str, description: str, expires: int | None
+    ) -> GraphqlAPIKey | EventsAPIKey:
         if api_id in self.graphql_apis:
             return self.graphql_apis[api_id].create_api_key(description, expires)
         else:
@@ -592,9 +594,7 @@ class AppSyncBackend(BaseBackend):
         else:
             self.events_apis[api_id].delete_api_key(api_key_id)
 
-    def list_api_keys(
-        self, api_id: str
-    ) -> Iterable[Union[GraphqlAPIKey, EventsAPIKey]]:
+    def list_api_keys(self, api_id: str) -> Iterable[GraphqlAPIKey | EventsAPIKey]:
         """
         Pagination or the maxResults-parameter have not yet been implemented.
         """
@@ -610,8 +610,8 @@ class AppSyncBackend(BaseBackend):
         api_id: str,
         api_key_id: str,
         description: str,
-        expires: Optional[int],
-    ) -> Union[GraphqlAPIKey, EventsAPIKey]:
+        expires: int | None,
+    ) -> GraphqlAPIKey | EventsAPIKey:
         if api_id in self.graphql_apis:
             return self.graphql_apis[api_id].update_api_key(
                 api_key_id, description, expires
@@ -664,9 +664,9 @@ class AppSyncBackend(BaseBackend):
         ttl: int,
         api_caching_behavior: str,
         type: str,
-        transit_encryption_enabled: Optional[bool] = None,
-        at_rest_encryption_enabled: Optional[bool] = None,
-        health_metrics_config: Optional[str] = None,
+        transit_encryption_enabled: bool | None = None,
+        at_rest_encryption_enabled: bool | None = None,
+        health_metrics_config: str | None = None,
     ) -> APICache:
         if api_id not in self.graphql_apis:
             raise GraphqlAPINotFound(api_id)
@@ -689,7 +689,7 @@ class AppSyncBackend(BaseBackend):
         ttl: int,
         api_caching_behavior: str,
         type: str,
-        health_metrics_config: Optional[str] = None,
+        health_metrics_config: str | None = None,
     ) -> APICache:
         if api_id not in self.graphql_apis:
             raise GraphqlAPINotFound(api_id)
@@ -711,9 +711,9 @@ class AppSyncBackend(BaseBackend):
     def create_api(
         self,
         name: str,
-        owner_contact: Optional[str],
-        tags: Optional[dict[str, str]],
-        event_config: Optional[dict[str, Any]],
+        owner_contact: str | None,
+        tags: dict[str, str] | None,
+        event_config: dict[str, Any] | None,
     ) -> EventsAPI:
         events_api = EventsAPI(
             account_id=self.account_id,
@@ -747,9 +747,9 @@ class AppSyncBackend(BaseBackend):
         name: str,
         subscribe_auth_modes: list[dict[str, str]],
         publish_auth_modes: list[dict[str, str]],
-        code_handlers: Optional[list[dict[str, Any]]] = None,
-        tags: Optional[dict[str, str]] = None,
-        handler_configs: Optional[dict[str, Any]] = None,
+        code_handlers: list[dict[str, Any]] | None = None,
+        tags: dict[str, str] | None = None,
+        handler_configs: dict[str, Any] | None = None,
     ) -> ChannelNamespace:
         # Check if API exists
         if api_id not in self.events_apis:

--- a/moto/athena/exceptions.py
+++ b/moto/athena/exceptions.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 
 from moto.core.exceptions import JsonRESTError
 
@@ -36,6 +35,6 @@ class MetadataException(JsonRESTError):
 
 
 class QueryStillRunning(JsonRESTError):
-    def __init__(self, current_status: Optional[str]):
+    def __init__(self, current_status: str | None):
         msg = f"Query has not yet finished. Current state: {current_status}"
         super().__init__("InvalidRequestException", msg)

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -1,7 +1,7 @@
 import re
 import time
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.athena.exceptions import (
     InvalidArgumentException,
@@ -115,8 +115,8 @@ class Execution(ManagedState):
         query: str,
         context: str,
         config: dict[str, Any],
-        workgroup: Optional[WorkGroup],
-        execution_parameters: Optional[list[str]],
+        workgroup: WorkGroup | None,
+        execution_parameters: list[str] | None,
     ):
         ManagedState.__init__(
             self,
@@ -180,7 +180,7 @@ class Database(BaseModel):
         catalog_name: str,
         database_name: str,
         description: str = "",
-        parameters: Optional[dict[str, str]] = None,
+        parameters: dict[str, str] | None = None,
     ):
         self.catalog_name = catalog_name
         self.name = database_name
@@ -273,7 +273,7 @@ class AthenaBackend(BaseBackend):
         configuration: dict[str, Any],
         description: str,
         tags: list[dict[str, str]],
-    ) -> Optional[WorkGroup]:
+    ) -> WorkGroup | None:
         if name in self.work_groups:
             return None
         work_group = WorkGroup(self, name, configuration, description, tags)
@@ -292,7 +292,7 @@ class AthenaBackend(BaseBackend):
             for wg in self.work_groups.values()
         ]
 
-    def get_work_group(self, name: str) -> Optional[dict[str, Any]]:
+    def get_work_group(self, name: str) -> dict[str, Any] | None:
         if name not in self.work_groups:
             return None
         wg = self.work_groups[name]
@@ -313,7 +313,7 @@ class AthenaBackend(BaseBackend):
         context: str,
         config: dict[str, Any],
         workgroup: str,
-        execution_parameters: Optional[list[str]],
+        execution_parameters: list[str] | None,
     ) -> str:
         execution = Execution(
             query=query,
@@ -338,7 +338,7 @@ class AthenaBackend(BaseBackend):
         re.IGNORECASE,
     )
 
-    def _process_ddl(self, query: str, context: Optional[str]) -> None:
+    def _process_ddl(self, query: str, context: str | None) -> None:
         catalog_name = "AwsDataCatalog"
         if context and isinstance(context, dict):
             catalog_name = context.get("Catalog", "AwsDataCatalog")
@@ -396,7 +396,7 @@ class AthenaBackend(BaseBackend):
         execution.advance()
         return execution
 
-    def list_query_executions(self, workgroup: Optional[str]) -> dict[str, Execution]:
+    def list_query_executions(self, workgroup: str | None) -> dict[str, Execution]:
         # Note: We do not advance the execution status here, only in `get_query_execution`
         # This method simply returns the QueryExecutionIds to the user
         # They will always have to call `get_query_execution` to get the status
@@ -508,7 +508,7 @@ class AthenaBackend(BaseBackend):
         self.tagger.tag_resource(cr.arn, tags)
         return None
 
-    def get_capacity_reservation(self, name: str) -> Optional[CapacityReservation]:
+    def get_capacity_reservation(self, name: str) -> CapacityReservation | None:
         return self.capacity_reservations.get(name)
 
     def list_capacity_reservations(self) -> list[dict[str, Any]]:
@@ -541,7 +541,7 @@ class AthenaBackend(BaseBackend):
         self.named_queries[nq.id] = nq
         return nq.id
 
-    def get_named_query(self, query_id: str) -> Optional[NamedQuery]:
+    def get_named_query(self, query_id: str) -> NamedQuery | None:
         return self.named_queries[query_id] if query_id in self.named_queries else None
 
     def list_data_catalogs(self) -> list[dict[str, str]]:
@@ -550,7 +550,7 @@ class AthenaBackend(BaseBackend):
             for dc in self.data_catalogs.values()
         ]
 
-    def get_data_catalog(self, name: str) -> Optional[dict[str, str]]:
+    def get_data_catalog(self, name: str) -> dict[str, str] | None:
         if name not in self.data_catalogs:
             return None
         dc = self.data_catalogs[name]
@@ -568,7 +568,7 @@ class AthenaBackend(BaseBackend):
         description: str,
         parameters: str,
         tags: list[dict[str, str]],
-    ) -> Optional[DataCatalog]:
+    ) -> DataCatalog | None:
         if name in self.data_catalogs:
             return None
         data_catalog = DataCatalog(
@@ -603,21 +603,19 @@ class AthenaBackend(BaseBackend):
 
     def get_prepared_statement(
         self, statement_name: str, work_group: WorkGroup
-    ) -> Optional[PreparedStatement]:
+    ) -> PreparedStatement | None:
         if statement_name in self.prepared_statements:
             ps = self.prepared_statements[statement_name]
             if ps.workgroup == work_group:
                 return ps
         return None
 
-    def get_query_runtime_statistics(
-        self, query_execution_id: str
-    ) -> Optional[Execution]:
+    def get_query_runtime_statistics(self, query_execution_id: str) -> Execution | None:
         if query_execution_id in self.executions:
             return self.executions[query_execution_id]
         return None
 
-    def list_tags_for_resource(self, resource_arn: str) -> Optional[dict[str, Any]]:
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, Any] | None:
         if self.tagger.has_tags(resource_arn):
             return self.tagger.list_tags_for_resource(resource_arn)
         return None

--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Union
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -14,7 +14,7 @@ class AthenaResponse(BaseResponse):
     def athena_backend(self) -> AthenaBackend:
         return athena_backends[self.current_account][self.region]
 
-    def create_work_group(self) -> Union[tuple[str, dict[str, int]], str]:
+    def create_work_group(self) -> tuple[str, dict[str, int]] | str:
         name = self._get_param("Name")
         description = self._get_param("Description")
         configuration = self._get_param("Configuration", {})
@@ -46,7 +46,7 @@ class AthenaResponse(BaseResponse):
         self.athena_backend.delete_work_group(name)
         return "{}"
 
-    def start_query_execution(self) -> Union[tuple[str, dict[str, int]], str]:
+    def start_query_execution(self) -> tuple[str, dict[str, int]] | str:
         query = self._get_param("QueryString")
         context = self._get_param("QueryExecutionContext")
         config = self._get_param("ResultConfiguration")
@@ -104,14 +104,14 @@ class AthenaResponse(BaseResponse):
             )
         return json.dumps(result)
 
-    def create_capacity_reservation(self) -> Union[tuple[str, dict[str, int]], str]:
+    def create_capacity_reservation(self) -> tuple[str, dict[str, int]] | str:
         name = self._get_param("Name")
         target_dpus = self._get_param("TargetDpus")
         tags = self._get_param("Tags")
         self.athena_backend.create_capacity_reservation(name, target_dpus, tags)
         return json.dumps({})
 
-    def get_capacity_reservation(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def get_capacity_reservation(self) -> str | tuple[str, dict[str, int]]:
         name = self._get_param("Name")
         capacity_reservation = self.athena_backend.get_capacity_reservation(name)
         if not capacity_reservation:
@@ -157,7 +157,7 @@ class AthenaResponse(BaseResponse):
             {"status": status},
         )
 
-    def create_named_query(self) -> Union[tuple[str, dict[str, int]], str]:
+    def create_named_query(self) -> tuple[str, dict[str, int]] | str:
         name = self._get_param("Name")
         description = self._get_param("Description")
         database = self._get_param("Database")
@@ -191,7 +191,7 @@ class AthenaResponse(BaseResponse):
             {"DataCatalogsSummary": self.athena_backend.list_data_catalogs()}
         )
 
-    def list_tags_for_resource(self) -> Union[tuple[str, dict[str, int]], str]:
+    def list_tags_for_resource(self) -> tuple[str, dict[str, int]] | str:
         resource_arn = self._get_param("ResourceARN")
         tags = self.athena_backend.list_tags_for_resource(resource_arn)
         if not tags:
@@ -243,7 +243,7 @@ class AthenaResponse(BaseResponse):
             result["NextToken"] = new_next_token
         return json.dumps(result)
 
-    def create_data_catalog(self) -> Union[tuple[str, dict[str, int]], str]:
+    def create_data_catalog(self) -> tuple[str, dict[str, int]] | str:
         name = self._get_param("Name")
         catalog_type = self._get_param("Type")
         description = self._get_param("Description")
@@ -273,7 +273,7 @@ class AthenaResponse(BaseResponse):
         )
         return json.dumps({"NamedQueryIds": named_query_ids, "NextToken": next_token})
 
-    def create_prepared_statement(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def create_prepared_statement(self) -> str | tuple[str, dict[str, int]]:
         statement_name = self._get_param("StatementName")
         work_group = self._get_param("WorkGroup")
         query_statement = self._get_param("QueryStatement")
@@ -307,7 +307,7 @@ class AthenaResponse(BaseResponse):
             }
         )
 
-    def get_query_runtime_statistics(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def get_query_runtime_statistics(self) -> str | tuple[str, dict[str, int]]:
         query_execution_id = self._get_param("QueryExecutionId")
 
         ps = self.athena_backend.get_query_runtime_statistics(

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -4,7 +4,7 @@ import itertools
 import math
 from collections import OrderedDict
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -38,7 +38,7 @@ DEFAULT_COOLDOWN = 300
 ASG_NAME_TAG = "aws:autoscaling:groupName"
 
 
-def make_int(value: Union[None, str, int]) -> Optional[int]:
+def make_int(value: None | str | int) -> int | None:
     return int(value) if value is not None else value
 
 
@@ -48,9 +48,9 @@ class Activity:
         description: str,
         cause: str,
         auto_scaling_group: FakeAutoScalingGroup,
-        activity_id: Optional[str] = None,
-        start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None,
+        activity_id: str | None = None,
+        start_time: datetime | None = None,
+        end_time: datetime | None = None,
         status_code: str = "InProgress",
     ):
         self.activity_id = activity_id or str(random.uuid4())
@@ -83,7 +83,7 @@ class TerminateInstanceActivity(Activity):
 
 
 class EnterStandbyActivity(Activity):
-    def __init__(self, instance: Instance, original_capacity: Optional[int] = None):
+    def __init__(self, instance: Instance, original_capacity: int | None = None):
         auto_scaling_group = instance.autoscaling_group  # type: ignore[attr-defined]
         desired_capacity = auto_scaling_group.desired_capacity
         should_decrement = desired_capacity < original_capacity
@@ -99,7 +99,7 @@ class EnterStandbyActivity(Activity):
 
 
 class ExitStandbyActivity(Activity):
-    def __init__(self, instance: Instance, original_capacity: Optional[int] = None):
+    def __init__(self, instance: Instance, original_capacity: int | None = None):
         auto_scaling_group = instance.autoscaling_group  # type: ignore[attr-defined]
         desired_capacity = auto_scaling_group.desired_capacity
         description = f"Moving EC2 instance out of StandBy: {instance.id}"
@@ -126,8 +126,8 @@ class InstanceState:
         instance: Instance,
         lifecycle_state: str = "InService",
         health_status: str = "Healthy",
-        protected_from_scale_in: Optional[bool] = False,
-        autoscaling_group: Optional[FakeAutoScalingGroup] = None,
+        protected_from_scale_in: bool | None = False,
+        autoscaling_group: FakeAutoScalingGroup | None = None,
     ):
         self.instance = instance
         self.lifecycle_state = lifecycle_state
@@ -142,7 +142,7 @@ class InstanceState:
         self.instance_type = self.instance.instance_type
 
     @property
-    def launch_template(self) -> Optional[dict[str, Any]]:
+    def launch_template(self) -> dict[str, Any] | None:
         if (
             self.auto_scaling_group is not None
             and self.auto_scaling_group.ec2_launch_template is None
@@ -156,7 +156,7 @@ class InstanceState:
         return lt
 
     @property
-    def launch_configuration_name(self) -> Optional[str]:
+    def launch_configuration_name(self) -> str | None:
         return (
             self.auto_scaling_group.launch_configuration_name
             if self.auto_scaling_group is not None
@@ -169,9 +169,9 @@ class LifecycleHook(BaseModel):
         self,
         name: str,
         as_name: str,
-        transition: Optional[str],
-        timeout: Optional[int],
-        result: Optional[str],
+        transition: str | None,
+        timeout: int | None,
+        result: str | None,
     ):
         self.name = name
         self.auto_scaling_group_name = as_name
@@ -185,7 +185,7 @@ class LifecycleHook(BaseModel):
 
 
 class TargetTrackingConfiguration:
-    def __init__(self, data: Optional[dict[str, Any]]) -> None:
+    def __init__(self, data: dict[str, Any] | None) -> None:
         data = data or {}
         customized_metric_spec = data.get("CustomizedMetricSpecification", {})
         if customized_metric_spec:
@@ -206,8 +206,8 @@ class FakeScalingPolicy(BaseModel):
         adjustment_type: str,
         as_name: str,
         min_adjustment_magnitude: str,
-        scaling_adjustment: Optional[int],
-        cooldown: Optional[int],
+        scaling_adjustment: int | None,
+        cooldown: int | None,
         target_tracking_config: dict[str, Any],
         step_adjustments: str,
         estimated_instance_warmup: str,
@@ -225,7 +225,7 @@ class FakeScalingPolicy(BaseModel):
         self.cooldown = None
         if self.policy_type == "SimpleScaling":
             self.cooldown = cooldown if cooldown is not None else DEFAULT_COOLDOWN
-        self.target_tracking_configuration: Optional[TargetTrackingConfiguration] = None
+        self.target_tracking_configuration: TargetTrackingConfiguration | None = None
         if self.policy_type == "TargetTrackingScaling":
             self.target_tracking_configuration = TargetTrackingConfiguration(
                 target_tracking_config
@@ -261,23 +261,23 @@ class FakeLaunchConfiguration(CloudFormationModel):
         self,
         name: str,
         image_id: str,
-        key_name: Optional[str],
+        key_name: str | None,
         ramdisk_id: str,
         kernel_id: str,
         security_groups: list[str],
-        user_data: Optional[Base64EncodedString],
+        user_data: Base64EncodedString | None,
         instance_type: str,
         instance_monitoring: bool,
-        instance_profile_name: Optional[str],
-        spot_price: Optional[str],
+        instance_profile_name: str | None,
+        spot_price: str | None,
         ebs_optimized: bool,
         associate_public_ip_address: bool,
         block_device_mapping_dict: list[dict[str, Any]],
         account_id: str,
         region_name: str,
-        metadata_options: Optional[str],
-        classic_link_vpc_id: Optional[str],
-        classic_link_vpc_security_groups: Optional[str],
+        metadata_options: str | None,
+        classic_link_vpc_id: str | None,
+        classic_link_vpc_security_groups: str | None,
     ):
         self.name = name
         self.image_id = image_id
@@ -456,14 +456,14 @@ class FakeScheduledAction(CloudFormationModel):
     def __init__(
         self,
         autos_caling_group_name: str,
-        desired_capacity: Optional[int],
-        max_size: Optional[int],
-        min_size: Optional[int],
+        desired_capacity: int | None,
+        max_size: int | None,
+        min_size: int | None,
         scheduled_action_name: str,
-        start_time: Optional[str],
-        end_time: Optional[str],
-        recurrence: Optional[str],
-        time_zone: Optional[str],
+        start_time: str | None,
+        end_time: str | None,
+        recurrence: str | None,
+        time_zone: str | None,
     ):
         self.auto_scaling_group_name = autos_caling_group_name
         self.desired_capacity = desired_capacity
@@ -522,8 +522,8 @@ class FailedScheduledUpdateGroupActionRequest:
         self,
         *,
         scheduled_action_name: str,
-        error_code: Optional[str] = None,
-        error_message: Optional[str] = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
     ) -> None:
         self.scheduled_action_name = scheduled_action_name
         self.error_code = error_code
@@ -533,10 +533,10 @@ class FailedScheduledUpdateGroupActionRequest:
 class FakeWarmPool(CloudFormationModel):
     def __init__(
         self,
-        max_group_prepared_capacity: Optional[int],
-        min_size: Optional[int],
-        pool_state: Optional[str],
-        instance_reuse_policy: Optional[dict[str, bool]],
+        max_group_prepared_capacity: int | None,
+        min_size: int | None,
+        pool_state: str | None,
+        instance_reuse_policy: dict[str, bool] | None,
     ):
         self.max_group_prepared_capacity = max_group_prepared_capacity
         self.min_size = min_size or 0
@@ -549,23 +549,23 @@ class FakeAutoScalingGroup(CloudFormationModel):
         self,
         name: str,
         availability_zones: list[str],
-        desired_capacity: Optional[int],
-        max_size: Optional[int],
-        min_size: Optional[int],
+        desired_capacity: int | None,
+        max_size: int | None,
+        min_size: int | None,
         launch_config_name: str,
         launch_template: dict[str, Any],
-        vpc_zone_identifier: Optional[str],
-        default_cooldown: Optional[int],
-        health_check_period: Optional[int],
-        health_check_type: Optional[str],
+        vpc_zone_identifier: str | None,
+        default_cooldown: int | None,
+        health_check_period: int | None,
+        health_check_type: str | None,
         load_balancers: list[str],
         target_group_arns: list[str],
-        placement_group: Optional[str],
+        placement_group: str | None,
         termination_policies: list[str],
         autoscaling_backend: AutoScalingBackend,
         ec2_backend: EC2Backend,
         tags: list[dict[str, str]],
-        mixed_instances_policy: Optional[dict[str, Any]],
+        mixed_instances_policy: dict[str, Any] | None,
         capacity_rebalance: bool,
         new_instances_protected_from_scale_in: bool = False,
     ):
@@ -578,14 +578,14 @@ class FakeAutoScalingGroup(CloudFormationModel):
         partition = get_partition(self.region)
         self.service_linked_role_arn = f"arn:{partition}:iam::{self.account_id}:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling"
 
-        self.vpc_zone_identifier: Optional[str] = None
+        self.vpc_zone_identifier: str | None = None
         self._set_azs_and_vpcs(availability_zones, vpc_zone_identifier)
 
         self.max_size = max_size
         self.min_size = min_size
 
         self.mixed_instances_policy = mixed_instances_policy
-        self.ec2_launch_template: Optional[LaunchTemplate] = None
+        self.ec2_launch_template: LaunchTemplate | None = None
         # Will be None if self.launch_template is used instead
         self.launch_config: FakeLaunchConfiguration = None  # type: ignore[assignment]
 
@@ -626,11 +626,11 @@ class FakeAutoScalingGroup(CloudFormationModel):
         self.set_desired_capacity(desired_capacity)
 
         self.metrics: list[str] = []
-        self.warm_pool: Optional[FakeWarmPool] = None
+        self.warm_pool: FakeWarmPool | None = None
         self.created_time = datetime.now().isoformat()
 
     @property
-    def launch_template(self) -> Optional[dict[str, Any]]:
+    def launch_template(self) -> dict[str, Any] | None:
         if self.ec2_launch_template is None:
             return None
         lt = {
@@ -680,7 +680,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
     def _set_azs_and_vpcs(
         self,
         availability_zones: list[str],
-        vpc_zone_identifier: Optional[str],
+        vpc_zone_identifier: str | None,
         update: bool = False,
     ) -> None:
         # for updates, if only AZs are provided, they must not clash with
@@ -717,7 +717,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         self,
         launch_config_name: str,
         launch_template: dict[str, Any],
-        mixed_instances_policy: Optional[dict[str, Any]],
+        mixed_instances_policy: dict[str, Any] | None,
     ) -> None:
         if launch_config_name:
             self.launch_config = self.autoscaling_backend.launch_configurations[
@@ -893,7 +893,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         return self.launch_config.instance_type  # type: ignore[union-attr]
 
     @property
-    def user_data(self) -> Optional[Base64EncodedString]:
+    def user_data(self) -> Base64EncodedString | None:
         if self.ec2_launch_template:
             version = self.ec2_launch_template.get_version(self.launch_template_version)
             return version.user_data
@@ -920,22 +920,22 @@ class FakeAutoScalingGroup(CloudFormationModel):
         return self.instance_states
 
     @property
-    def warm_pool_configuration(self) -> Optional[FakeWarmPool]:
+    def warm_pool_configuration(self) -> FakeWarmPool | None:
         return self.warm_pool
 
     def update(
         self,
         availability_zones: list[str],
-        desired_capacity: Optional[int],
-        max_size: Optional[int],
-        min_size: Optional[int],
+        desired_capacity: int | None,
+        max_size: int | None,
+        min_size: int | None,
         launch_config_name: str,
         launch_template: dict[str, Any],
         vpc_zone_identifier: str,
         health_check_period: int,
         health_check_type: str,
-        new_instances_protected_from_scale_in: Optional[bool] = None,
-        mixed_instances_policy: Optional[dict[str, Any]] = None,
+        new_instances_protected_from_scale_in: bool | None = None,
+        mixed_instances_policy: dict[str, Any] | None = None,
     ) -> None:
         self._set_azs_and_vpcs(availability_zones, vpc_zone_identifier, update=True)
 
@@ -969,7 +969,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
         if desired_capacity is not None:
             self.set_desired_capacity(desired_capacity)
 
-    def set_desired_capacity(self, new_capacity: Optional[int]) -> None:
+    def set_desired_capacity(self, new_capacity: int | None) -> None:
         if new_capacity is None:
             self.desired_capacity = self.min_size
         else:
@@ -1126,10 +1126,10 @@ class FakeAutoScalingGroup(CloudFormationModel):
 
     def put_warm_pool(
         self,
-        max_group_prepared_capacity: Optional[int],
-        min_size: Optional[int],
-        pool_state: Optional[str],
-        instance_reuse_policy: Optional[dict[str, bool]],
+        max_group_prepared_capacity: int | None,
+        min_size: int | None,
+        pool_state: str | None,
+        instance_reuse_policy: dict[str, bool] | None,
     ) -> None:
         self.warm_pool = FakeWarmPool(
             max_group_prepared_capacity=max_group_prepared_capacity,
@@ -1138,7 +1138,7 @@ class FakeAutoScalingGroup(CloudFormationModel):
             instance_reuse_policy=instance_reuse_policy,
         )
 
-    def get_warm_pool(self) -> Optional[FakeWarmPool]:
+    def get_warm_pool(self) -> FakeWarmPool | None:
         return self.warm_pool
 
 
@@ -1158,22 +1158,22 @@ class AutoScalingBackend(BaseBackend):
         self,
         name: str,
         image_id: str,
-        key_name: Optional[str],
+        key_name: str | None,
         kernel_id: str,
         ramdisk_id: str,
         security_groups: list[str],
-        user_data: Optional[Base64EncodedString],
+        user_data: Base64EncodedString | None,
         instance_type: str,
         instance_monitoring: bool,
-        instance_profile_name: Optional[str],
-        spot_price: Optional[str],
+        instance_profile_name: str | None,
+        spot_price: str | None,
         ebs_optimized: bool,
         associate_public_ip_address: bool,
         block_device_mappings: list[dict[str, Any]],
-        instance_id: Optional[str] = None,
-        metadata_options: Optional[str] = None,
-        classic_link_vpc_id: Optional[str] = None,
-        classic_link_vpc_security_groups: Optional[str] = None,
+        instance_id: str | None = None,
+        metadata_options: str | None = None,
+        classic_link_vpc_id: str | None = None,
+        classic_link_vpc_security_groups: str | None = None,
     ) -> FakeLaunchConfiguration:
         valid_requests = [
             instance_id is not None,
@@ -1211,7 +1211,7 @@ class AutoScalingBackend(BaseBackend):
         return launch_configuration
 
     def describe_launch_configurations(
-        self, names: Optional[list[str]]
+        self, names: list[str] | None
     ) -> list[FakeLaunchConfiguration]:
         configurations = self.launch_configurations.values()
         if names:
@@ -1229,14 +1229,14 @@ class AutoScalingBackend(BaseBackend):
     def put_scheduled_update_group_action(
         self,
         name: str,
-        desired_capacity: Union[None, str, int],
-        max_size: Union[None, str, int],
-        min_size: Union[None, str, int],
+        desired_capacity: None | str | int,
+        max_size: None | str | int,
+        min_size: None | str | int,
         scheduled_action_name: str,
-        start_time: Optional[str],
-        end_time: Optional[str],
-        recurrence: Optional[str],
-        timezone: Optional[str],
+        start_time: str | None,
+        end_time: str | None,
+        recurrence: str | None,
+        timezone: str | None,
     ) -> FakeScheduledAction:
         max_size = make_int(max_size)
         min_size = make_int(min_size)
@@ -1286,8 +1286,8 @@ class AutoScalingBackend(BaseBackend):
 
     def describe_scheduled_actions(
         self,
-        autoscaling_group_name: Optional[str] = None,
-        scheduled_action_names: Optional[list[str]] = None,
+        autoscaling_group_name: str | None = None,
+        scheduled_action_names: list[str] | None = None,
     ) -> list[FakeScheduledAction]:
         scheduled_actions = []
         for scheduled_action in self.scheduled_actions.values():
@@ -1337,24 +1337,24 @@ class AutoScalingBackend(BaseBackend):
         self,
         name: str,
         availability_zones: list[str],
-        desired_capacity: Union[None, str, int],
-        max_size: Union[None, str, int],
-        min_size: Union[None, str, int],
+        desired_capacity: None | str | int,
+        max_size: None | str | int,
+        min_size: None | str | int,
         launch_config_name: str,
         launch_template: dict[str, Any],
-        vpc_zone_identifier: Optional[str],
-        default_cooldown: Optional[int],
-        health_check_period: Union[None, str, int],
-        health_check_type: Optional[str],
+        vpc_zone_identifier: str | None,
+        default_cooldown: int | None,
+        health_check_period: None | str | int,
+        health_check_type: str | None,
         load_balancers: list[str],
         target_group_arns: list[str],
-        placement_group: Optional[str],
+        placement_group: str | None,
         termination_policies: list[str],
         tags: list[dict[str, str]],
         capacity_rebalance: bool = False,
         new_instances_protected_from_scale_in: bool = False,
-        instance_id: Optional[str] = None,
-        mixed_instances_policy: Optional[dict[str, Any]] = None,
+        instance_id: str | None = None,
+        mixed_instances_policy: dict[str, Any] | None = None,
     ) -> FakeAutoScalingGroup:
         max_size = make_int(max_size)
         min_size = make_int(min_size)
@@ -1419,16 +1419,16 @@ class AutoScalingBackend(BaseBackend):
         self,
         name: str,
         availability_zones: list[str],
-        desired_capacity: Optional[int],
-        max_size: Optional[int],
-        min_size: Optional[int],
+        desired_capacity: int | None,
+        max_size: int | None,
+        min_size: int | None,
         launch_config_name: str,
         launch_template: dict[str, Any],
         vpc_zone_identifier: str,
         health_check_period: int,
         health_check_type: str,
-        new_instances_protected_from_scale_in: Optional[bool] = None,
-        mixed_instances_policy: Optional[dict[str, Any]] = None,
+        new_instances_protected_from_scale_in: bool | None = None,
+        mixed_instances_policy: dict[str, Any] | None = None,
     ) -> FakeAutoScalingGroup:
         """
         The parameter DefaultCooldown, PlacementGroup, TerminationPolicies are not yet implemented
@@ -1459,7 +1459,7 @@ class AutoScalingBackend(BaseBackend):
         return group
 
     def describe_auto_scaling_groups(
-        self, names: list[str], filters: Optional[list[dict[str, str]]] = None
+        self, names: list[str], filters: list[dict[str, str]] | None = None
     ) -> list[FakeAutoScalingGroup]:
         groups = list(self.autoscaling_groups.values())
 
@@ -1580,21 +1580,19 @@ class AutoScalingBackend(BaseBackend):
         return activities
 
     def set_desired_capacity(
-        self, group_name: str, desired_capacity: Optional[int]
+        self, group_name: str, desired_capacity: int | None
     ) -> None:
         group = self.autoscaling_groups[group_name]
         group.set_desired_capacity(desired_capacity)
         self.update_attached_elbs(group_name)
 
-    def change_capacity(
-        self, group_name: str, scaling_adjustment: Optional[int]
-    ) -> None:
+    def change_capacity(self, group_name: str, scaling_adjustment: int | None) -> None:
         group = self.autoscaling_groups[group_name]
         desired_capacity = group.desired_capacity + scaling_adjustment  # type: ignore[operator]
         self.set_desired_capacity(group_name, desired_capacity)
 
     def change_capacity_percent(
-        self, group_name: str, scaling_adjustment: Optional[int]
+        self, group_name: str, scaling_adjustment: int | None
     ) -> None:
         """http://docs.aws.amazon.com/AutoScaling/latest/DeveloperGuide/as-scale-based-on-demand.html
         If PercentChangeInCapacity returns a value between 0 and 1,
@@ -1616,7 +1614,7 @@ class AutoScalingBackend(BaseBackend):
         name: str,
         as_name: str,
         transition: str,
-        timeout: Optional[int],
+        timeout: int | None,
         result: str,
     ) -> LifecycleHook:
         lifecycle_hook = LifecycleHook(name, as_name, transition, timeout, result)
@@ -1625,7 +1623,7 @@ class AutoScalingBackend(BaseBackend):
         return lifecycle_hook
 
     def describe_lifecycle_hooks(
-        self, as_name: str, lifecycle_hook_names: Optional[list[str]] = None
+        self, as_name: str, lifecycle_hook_names: list[str] | None = None
     ) -> list[LifecycleHook]:
         return [
             lifecycle_hook
@@ -1647,8 +1645,8 @@ class AutoScalingBackend(BaseBackend):
         adjustment_type: str,
         as_name: str,
         min_adjustment_magnitude: str,
-        scaling_adjustment: Optional[int],
-        cooldown: Optional[int],
+        scaling_adjustment: int | None,
+        cooldown: int | None,
         target_tracking_config: dict[str, Any],
         step_adjustments: str,
         estimated_instance_warmup: str,
@@ -1675,9 +1673,9 @@ class AutoScalingBackend(BaseBackend):
 
     def describe_policies(
         self,
-        autoscaling_group_name: Optional[str] = None,
-        policy_names: Optional[list[str]] = None,
-        policy_types: Optional[list[str]] = None,
+        autoscaling_group_name: str | None = None,
+        policy_names: list[str] | None = None,
+        policy_types: list[str] | None = None,
     ) -> list[FakeScalingPolicy]:
         return [
             policy
@@ -1848,7 +1846,7 @@ class AutoScalingBackend(BaseBackend):
         self,
         group_name: str,
         instance_ids: list[str],
-        protected_from_scale_in: Optional[bool],
+        protected_from_scale_in: bool | None,
     ) -> None:
         group = self.autoscaling_groups[group_name]
         protected_instances = [
@@ -1954,10 +1952,10 @@ class AutoScalingBackend(BaseBackend):
     def put_warm_pool(
         self,
         group_name: str,
-        max_group_prepared_capacity: Optional[int],
-        min_size: Optional[int],
-        pool_state: Optional[str],
-        instance_reuse_policy: Optional[dict[str, bool]],
+        max_group_prepared_capacity: int | None,
+        min_size: int | None,
+        pool_state: str | None,
+        instance_reuse_policy: dict[str, bool] | None,
     ) -> None:
         group = self.describe_auto_scaling_groups([group_name])[0]
         group.put_warm_pool(
@@ -1967,7 +1965,7 @@ class AutoScalingBackend(BaseBackend):
             instance_reuse_policy=instance_reuse_policy,
         )
 
-    def describe_warm_pool(self, group_name: str) -> Optional[FakeWarmPool]:
+    def describe_warm_pool(self, group_name: str) -> FakeWarmPool | None:
         """
         Pagination is not yet implemented. Does not create/return any Instances currently.
         """

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -20,7 +20,7 @@ from collections.abc import Iterable
 from datetime import datetime
 from gzip import GzipFile
 from sys import platform
-from typing import Any, Optional, TypedDict, Union
+from typing import Any, TypedDict
 
 import requests.exceptions
 
@@ -127,7 +127,7 @@ class _DockerDataVolumeContext:
 
     def __init__(self, lambda_func: LambdaFunction):
         self._lambda_func = lambda_func
-        self._vol_ref: Optional[_VolumeRefCount] = None
+        self._vol_ref: _VolumeRefCount | None = None
 
     @property
     def name(self) -> str:
@@ -193,7 +193,7 @@ class _DockerDataVolumeLayerContext:
     def __init__(self, lambda_func: LambdaFunction):
         self._lambda_func = lambda_func
         self._layers: list[LayerDataType] = self._lambda_func.layers
-        self._vol_ref: Optional[_VolumeRefCount] = None
+        self._vol_ref: _VolumeRefCount | None = None
 
     @property
     def name(self) -> str:
@@ -271,7 +271,7 @@ class _DockerDataVolumeLayerContext:
                     raise  # multiple processes trying to use same volume?
 
 
-def _zipfile_content(zipfile_content: Union[str, bytes]) -> tuple[bytes, int, str, str]:
+def _zipfile_content(zipfile_content: str | bytes) -> tuple[bytes, int, str, str]:
     try:
         to_unzip_code = base64.b64decode(bytes(zipfile_content, "utf-8"))  # type: ignore[arg-type]
     except Exception:
@@ -292,7 +292,7 @@ def _s3_content(key: Any) -> tuple[bytes, int, str, str]:
 
 def _validate_s3_bucket_and_key(
     account_id: str, partition: str, data: dict[str, Any]
-) -> Optional[FakeKey]:
+) -> FakeKey | None:
     key = None
     try:
         # FIXME: does not validate bucket region
@@ -444,7 +444,7 @@ class LayerVersion(CloudFormationModel):
         self.created_date = utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "+0000"
         self.version: int = 1
         self._attached = False
-        self._layer: Optional[Layer] = None
+        self._layer: Layer | None = None
 
         if "ZipFile" in self.content:
             (
@@ -559,9 +559,9 @@ class LambdaAlias(BaseModel):
 
     def update(
         self,
-        description: Optional[str],
-        function_version: Optional[str],
-        routing_config: Optional[str],
+        description: str | None,
+        function_version: str | None,
+        routing_config: str | None,
     ) -> None:
         if description is not None:
             self.description = description
@@ -620,7 +620,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         account_id: str,
         spec: dict[str, Any],
         region: str,
-        version: Union[str, int] = 1,
+        version: str | int = 1,
     ):
         DockerModel.__init__(self)
         # required
@@ -635,7 +635,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         self.logs_backend = logs_backends[account_id][self.region]
         self.environment_vars = spec.get("Environment", {}).get("Variables", {})
         self.policy = Policy(self)  # type: ignore[no-untyped-call]
-        self.url_config: Optional[FunctionUrlConfig] = None
+        self.url_config: FunctionUrlConfig | None = None
         self.state = "Active"
         self.reserved_concurrency = spec.get("ReservedConcurrentExecutions", None)
 
@@ -731,7 +731,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         self._ephemeral_storage = ephemeral_storage
 
     @property
-    def vpc_config(self) -> Optional[dict[str, Any]]:  # type: ignore[misc]
+    def vpc_config(self) -> dict[str, Any] | None:  # type: ignore[misc]
         if not self._vpc_config:
             return None
         config = self._vpc_config.copy()
@@ -963,7 +963,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         except Exception:
             return s
 
-    def _invoke_lambda(self, event: Optional[str] = None) -> tuple[str, bool, str]:
+    def _invoke_lambda(self, event: str | None = None) -> tuple[str, bool, str]:
         import docker
         import docker.errors
 
@@ -1118,7 +1118,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
 
     def invoke(
         self, body: str, request_headers: Any, response_headers: Any
-    ) -> Union[str, bytes]:
+    ) -> str | bytes:
         if body:
             body = json.loads(body)
         else:
@@ -1328,9 +1328,7 @@ class EventSourceMapping(CloudFormationModel):
         self.function_arn: str = spec["FunctionArn"]
         self.last_modified = time.mktime(utcnow().timetuple())
 
-    def _get_service_source_from_arn(
-        self, event_source_arn: Optional[str] = None
-    ) -> str:
+    def _get_service_source_from_arn(self, event_source_arn: str | None = None) -> str:
         arn = event_source_arn or self.event_source_arn
         service = arn.split(":")[2].lower()
         if service == "sqs" and arn.endswith(".fifo"):
@@ -1355,7 +1353,7 @@ class EventSourceMapping(CloudFormationModel):
         return self._batch_size
 
     @batch_size.setter
-    def batch_size(self, new_batch_size: Optional[int]) -> None:
+    def batch_size(self, new_batch_size: int | None) -> None:
         batch_size_service_map = {
             "kinesis": (100, 10000),
             "dynamodb": (100, 10000),
@@ -1516,7 +1514,7 @@ class LambdaStorage:
     def _get_latest(self, name: str) -> LambdaFunction:
         return self._functions[name]["latest"]
 
-    def _get_version(self, name: str, version: str) -> Optional[LambdaFunction]:
+    def _get_version(self, name: str, version: str) -> LambdaFunction | None:
         for config in self._functions[name]["versions"]:
             if str(config.version) == version:
                 return config
@@ -1601,7 +1599,7 @@ class LambdaStorage:
         return self._get_latest(name)
 
     def get_function_by_name_with_qualifier(
-        self, name: str, qualifier: Optional[str] = None
+        self, name: str, qualifier: str | None = None
     ) -> LambdaFunction:
         """
         Get function by name with an optional qualifier
@@ -1658,11 +1656,11 @@ class LambdaStorage:
         aliases = self._get_function_aliases(function_name)
         return sorted(aliases.values(), key=lambda alias: alias.name)
 
-    def get_arn(self, arn: str) -> Optional[LambdaFunction]:
+    def get_arn(self, arn: str) -> LambdaFunction | None:
         [arn_without_qualifier, _, _] = self.split_function_arn(arn)
         return self._arns.get(arn_without_qualifier, None)
 
-    def split_function_arn(self, arn: str) -> tuple[str, str, Optional[str]]:
+    def split_function_arn(self, arn: str) -> tuple[str, str, str | None]:
         """
         Handy utility to parse an ARN into:
         - ARN without qualifier
@@ -1700,7 +1698,7 @@ class LambdaStorage:
             return self.get_function_by_name_forbid_qualifier(name_or_arn)
 
     def get_function_by_name_or_arn_with_qualifier(
-        self, name_or_arn: str, qualifier: Optional[str] = None
+        self, name_or_arn: str, qualifier: str | None = None
     ) -> LambdaFunction:
         """
         Get function by name or arn with an optional qualifier
@@ -1716,7 +1714,7 @@ class LambdaStorage:
             return self.get_function_by_name_with_qualifier(name_or_arn, qualifier)
 
     def construct_unknown_function_exception(
-        self, name_or_arn: str, qualifier: Optional[str] = None
+        self, name_or_arn: str, qualifier: str | None = None
     ) -> UnknownFunctionException:
         if re.match(ARN_PARTITION_REGEX, name_or_arn):
             arn = name_or_arn
@@ -1751,7 +1749,7 @@ class LambdaStorage:
 
     def publish_version(
         self, name_or_arn: str, description: str = ""
-    ) -> Optional[LambdaFunction]:
+    ) -> LambdaFunction | None:
         function = self.get_function_by_name_or_arn_forbid_qualifier(name_or_arn)
         name = function.function_name
         if name not in self._functions:
@@ -1778,7 +1776,7 @@ class LambdaStorage:
         self._arns[fn.function_arn] = fn
         return fn
 
-    def del_function(self, name_or_arn: str, qualifier: Optional[str] = None) -> None:
+    def del_function(self, name_or_arn: str, qualifier: str | None = None) -> None:
         # Qualifier may be explicitly passed or part of function name or ARN, extract it here
         if re.match(ARN_PARTITION_REGEX, name_or_arn):
             # Extract from ARN
@@ -1887,9 +1885,7 @@ class LayerStorage:
             return list(iter(self._layers[layer_name].layer_versions.values()))
         return []
 
-    def get_layer_version_by_arn(
-        self, layer_version_arn: str
-    ) -> Optional[LayerVersion]:
+    def get_layer_version_by_arn(self, layer_version_arn: str) -> LayerVersion | None:
         split_arn = split_layer_arn(layer_version_arn)
         if split_arn.layer_name in self._layers:
             return self._layers[split_arn.layer_name].layer_versions.get(
@@ -2162,16 +2158,16 @@ class LambdaBackend(BaseBackend):
     def list_layer_versions(self, layer_name: str) -> Iterable[LayerVersion]:
         return self._layers.get_layer_versions(layer_name)
 
-    def layers_versions_by_arn(self, layer_version_arn: str) -> Optional[LayerVersion]:
+    def layers_versions_by_arn(self, layer_version_arn: str) -> LayerVersion | None:
         return self._layers.get_layer_version_by_arn(layer_version_arn)
 
     def publish_version(
         self, function_name: str, description: str = ""
-    ) -> Optional[LambdaFunction]:
+    ) -> LambdaFunction | None:
         return self._lambdas.publish_version(function_name, description)
 
     def get_function(
-        self, function_name_or_arn: str, qualifier: Optional[str] = None
+        self, function_name_or_arn: str, qualifier: str | None = None
     ) -> LambdaFunction:
         return self._lambdas.get_function_by_name_or_arn_with_qualifier(
             function_name_or_arn, qualifier
@@ -2183,15 +2179,15 @@ class LambdaBackend(BaseBackend):
     def list_aliases(self, function_name: str) -> Iterable[LambdaAlias]:
         return self._lambdas.list_aliases(function_name)
 
-    def get_event_source_mapping(self, uuid: str) -> Optional[EventSourceMapping]:
+    def get_event_source_mapping(self, uuid: str) -> EventSourceMapping | None:
         return self._event_source_mappings.get(uuid)
 
-    def delete_event_source_mapping(self, uuid: str) -> Optional[EventSourceMapping]:
+    def delete_event_source_mapping(self, uuid: str) -> EventSourceMapping | None:
         return self._event_source_mappings.pop(uuid, None)
 
     def update_event_source_mapping(
         self, uuid: str, spec: dict[str, Any]
-    ) -> Optional[EventSourceMapping]:
+    ) -> EventSourceMapping | None:
         esm = self.get_event_source_mapping(uuid)
         if not esm:
             return None
@@ -2250,16 +2246,14 @@ class LambdaBackend(BaseBackend):
             esms = list(filter(lambda x: x.function_name == function_name, esms))
         return esms
 
-    def get_function_by_arn(self, function_arn: str) -> Optional[LambdaFunction]:
+    def get_function_by_arn(self, function_arn: str) -> LambdaFunction | None:
         return self._lambdas.get_arn(function_arn)
 
-    def delete_function(
-        self, function_name: str, qualifier: Optional[str] = None
-    ) -> None:
+    def delete_function(self, function_name: str, qualifier: str | None = None) -> None:
         self._lambdas.del_function(function_name, qualifier)
 
     def list_functions(
-        self, func_version: Optional[str] = None
+        self, func_version: str | None = None
     ) -> Iterable[LambdaFunction]:
         if func_version == "ALL":
             return self._lambdas.all()
@@ -2354,8 +2348,8 @@ class LambdaBackend(BaseBackend):
         self,
         function_name: str,
         message: str,
-        subject: Optional[str] = None,
-        qualifier: Optional[str] = None,
+        subject: str | None = None,
+        qualifier: str | None = None,
     ) -> None:
         event = {
             "Records": [
@@ -2389,7 +2383,7 @@ class LambdaBackend(BaseBackend):
 
     def send_dynamodb_items(
         self, function_arn: str, items: list[Any], source: str
-    ) -> Union[str, bytes]:
+    ) -> str | bytes:
         from moto.core.utils import unix_time
 
         records = []
@@ -2488,7 +2482,7 @@ class LambdaBackend(BaseBackend):
         fn = self.get_function(function_name)
         return fn.get_function_code_signing_config()
 
-    def get_policy(self, function_name: str, qualifier: Optional[str] = None) -> str:
+    def get_policy(self, function_name: str, qualifier: str | None = None) -> str:
         fn = self._lambdas.get_function_by_name_or_arn_with_qualifier(
             function_name, qualifier
         )
@@ -2496,7 +2490,7 @@ class LambdaBackend(BaseBackend):
 
     def update_function_code(
         self, function_name: str, qualifier: str, body: dict[str, Any]
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         fn: LambdaFunction = self.get_function(function_name, qualifier)
         fn.update_function_code(body)
 
@@ -2507,7 +2501,7 @@ class LambdaBackend(BaseBackend):
 
     def update_function_configuration(
         self, function_name: str, qualifier: str, body: dict[str, Any]
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         fn = self.get_function(function_name, qualifier)
 
         return fn.update_configuration(body)
@@ -2515,11 +2509,11 @@ class LambdaBackend(BaseBackend):
     def invoke(
         self,
         function_name: str,
-        qualifier: Optional[str],
+        qualifier: str | None,
         body: Any,
         headers: Any,
         response_headers: Any,
-    ) -> Optional[Union[str, bytes]]:
+    ) -> str | bytes | None:
         """
         Invoking a Function with PackageType=Image is not yet supported.
 
@@ -2564,7 +2558,7 @@ class LambdaBackend(BaseBackend):
         variable prior to testing.
         """
 
-        quota: Optional[str] = os.environ.get("MOTO_LAMBDA_CONCURRENCY_QUOTA")
+        quota: str | None = os.environ.get("MOTO_LAMBDA_CONCURRENCY_QUOTA")
         if quota is not None:
             # Enforce concurrency limits as described above
             available = int(quota) - int(reserved_concurrency)
@@ -2580,12 +2574,12 @@ class LambdaBackend(BaseBackend):
         fn.reserved_concurrency = reserved_concurrency
         return fn.reserved_concurrency
 
-    def delete_function_concurrency(self, function_name: str) -> Optional[str]:
+    def delete_function_concurrency(self, function_name: str) -> str | None:
         fn = self.get_function(function_name)
         fn.reserved_concurrency = None
         return fn.reserved_concurrency
 
-    def get_function_concurrency(self, function_name: str) -> Optional[str]:
+    def get_function_concurrency(self, function_name: str) -> str | None:
         fn = self.get_function(function_name)
         return fn.reserved_concurrency
 

--- a/moto/awslambda/policy.py
+++ b/moto/awslambda/policy.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import json
 from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
-    Optional,
     TypeVar,
-    Union,
 )
 
 from moto.awslambda.exceptions import (
@@ -22,7 +22,7 @@ TYPE_IDENTITY = TypeVar("TYPE_IDENTITY")
 
 
 class Policy:
-    def __init__(self, parent: Union["LambdaFunction", "LayerVersion"]):
+    def __init__(self, parent: LambdaFunction | LayerVersion):
         self.revision = str(mock_random.uuid4())
         self.statements: list[dict[str, Any]] = []
         self.parent = parent
@@ -45,9 +45,7 @@ class Policy:
         }
 
     # adds the raw JSON statement to the policy
-    def add_statement(
-        self, raw: str, qualifier: Optional[str] = None
-    ) -> tuple[Any, str]:
+    def add_statement(self, raw: str, qualifier: str | None = None) -> tuple[Any, str]:
         policy = json.loads(raw, object_hook=self.decode_policy)
         if len(policy.revision) > 0 and self.revision != policy.revision:
             raise PreconditionFailedException(
@@ -83,7 +81,7 @@ class Policy:
 
     # converts AddPermission request to PolicyStatement
     # https://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-    def decode_policy(self, obj: dict[str, Any]) -> "Policy":
+    def decode_policy(self, obj: dict[str, Any]) -> Policy:
         # Circumvent circular cimport
         from moto.awslambda.models import LayerVersion
 

--- a/moto/awslambda/responses.py
+++ b/moto/awslambda/responses.py
@@ -1,7 +1,7 @@
 import json
 import re
 import sys
-from typing import Any, Union
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.responses import TYPE_RESPONSE, ActionResult, BaseResponse
@@ -48,7 +48,7 @@ class LambdaResponse(BaseResponse):
             return 404, {"status": 404}, "{}"
 
     @amz_crc32
-    def invoke(self) -> tuple[int, dict[str, str], Union[str, bytes]]:
+    def invoke(self) -> tuple[int, dict[str, str], str | bytes]:
         response_headers: dict[str, str] = {}
 
         # URL Decode in case it's a ARN:
@@ -88,7 +88,7 @@ class LambdaResponse(BaseResponse):
             return 404, response_headers, "{}"
 
     @amz_crc32
-    def invoke_async(self) -> tuple[int, dict[str, str], Union[str, bytes]]:
+    def invoke_async(self) -> tuple[int, dict[str, str], str | bytes]:
         response_headers: dict[str, Any] = {}
 
         function_index = -3 if self.path.endswith("/") else -2

--- a/moto/awslambda/utils.py
+++ b/moto/awslambda/utils.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 from functools import partial
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from moto.utilities.utils import PARTITION_NAMES, get_partition
 
@@ -33,7 +33,7 @@ make_function_ver_arn = partial(make_ver_arn, "function")
 make_layer_ver_arn = partial(make_ver_arn, "layer")
 
 
-def split_arn(arn_type: Union[type[ARN], type[LAYER_ARN]], arn: str) -> Any:
+def split_arn(arn_type: type[ARN] | type[LAYER_ARN], arn: str) -> Any:
     for partition in PARTITION_NAMES:
         arn = arn.replace(f"arn:{partition}:lambda:", "")
 

--- a/moto/awslambda_simple/models.py
+++ b/moto/awslambda_simple/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.awslambda.models import LambdaBackend
 from moto.core.base_backend import BackendDict
@@ -17,11 +17,11 @@ class LambdaSimpleBackend(LambdaBackend):
     def invoke(
         self,
         function_name: str,
-        qualifier: Optional[str],
+        qualifier: str | None,
         body: Any,
         headers: Any,
         response_headers: Any,
-    ) -> Optional[Union[str, bytes]]:
+    ) -> str | bytes | None:
         default_result = body or "Simple Lambda happy path OK"
         if self.lambda_simple_results_queue:
             default_result = self.lambda_simple_results_queue.pop(0)

--- a/moto/backends.py
+++ b/moto/backends.py
@@ -1,7 +1,7 @@
 import importlib
 import os
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Optional, Union, overload
+from typing import TYPE_CHECKING, Union, overload
 
 import moto
 
@@ -192,7 +192,7 @@ def list_of_moto_modules() -> Iterable[str]:
             yield backend
 
 
-def get_service_from_url(url: str) -> Optional[str]:
+def get_service_from_url(url: str) -> str | None:
     from moto.backend_index import backend_url_patterns
 
     for service, pattern in backend_url_patterns:

--- a/moto/backup/models.py
+++ b/moto/backup/models.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -20,7 +20,7 @@ class ReportPlan(BaseModel):
     def __init__(
         self,
         name: str,
-        report_plan_description: Optional[str],
+        report_plan_description: str | None,
         report_delivery_channel: dict[str, Any],
         report_setting: dict[str, Any],
         backend: "BackupBackend",
@@ -50,7 +50,7 @@ class Plan(BaseModel):
         self.backup_plan = backup_plan
         adv_settings = backup_plan.get("AdvancedBackupSettings")
         self.advanced_backup_settings = adv_settings or []
-        self.deletion_date: Optional[float] = None
+        self.deletion_date: float | None = None
         # Deletion Date is updated when the backup_plan is deleted
         self.last_execution_date = None  # start_restore_job not yet supported
         rules = backup_plan["Rules"]
@@ -114,10 +114,10 @@ class Vault(BaseModel):
         self.creator_request_id = creator_request_id
         self.num_of_recovery_points = 0  # start_backup_job not yet supported
         self.locked = False
-        self.min_retention_days: Optional[int] = None
-        self.max_retention_days: Optional[int] = None
-        self.lock_date: Optional[float] = None
-        self.changeable_for_days: Optional[int] = None
+        self.min_retention_days: int | None = None
+        self.max_retention_days: int | None = None
+        self.lock_date: float | None = None
+        self.changeable_for_days: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         dct = {
@@ -177,7 +177,7 @@ class BackupBackend(BaseBackend):
         self.plans[plan.backup_plan_id] = plan
         return plan
 
-    def get_backup_plan(self, backup_plan_id: str, version_id: Optional[Any]) -> Plan:
+    def get_backup_plan(self, backup_plan_id: str, version_id: Any | None) -> Plan:
         msg = "Failed reading Backup plan with provided version"
         if backup_plan_id not in self.plans:
             raise ResourceNotFoundException(msg=msg)
@@ -246,9 +246,9 @@ class BackupBackend(BaseBackend):
     def put_backup_vault_lock_configuration(
         self,
         backup_vault_name: str,
-        min_retention_days: Optional[int],
-        max_retention_days: Optional[int],
-        changeable_for_days: Optional[int],
+        min_retention_days: int | None,
+        max_retention_days: int | None,
+        changeable_for_days: int | None,
     ) -> None:
         if backup_vault_name not in self.vaults:
             raise ResourceNotFoundException(
@@ -338,7 +338,7 @@ class BackupBackend(BaseBackend):
     def create_report_plan(
         self,
         report_plan_name: str,
-        report_plan_description: Optional[str],
+        report_plan_description: str | None,
         report_delivery_channel: dict[str, Any],
         report_setting: dict[str, Any],
     ) -> ReportPlan:

--- a/moto/batch/models.py
+++ b/moto/batch/models.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from itertools import cycle
 from sys import platform
 from time import sleep
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -131,9 +131,9 @@ class JobQueue(CloudFormationModel):
         state: str,
         environments: list[ComputeEnvironment],
         env_order_json: list[dict[str, Any]],
-        schedule_policy: Optional[str],
+        schedule_policy: str | None,
         backend: "BatchBackend",
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ):
         """
         :param name: Job queue name
@@ -219,18 +219,18 @@ class JobDefinition(CloudFormationModel):
     def __init__(
         self,
         name: str,
-        parameters: Optional[dict[str, Any]],
+        parameters: dict[str, Any] | None,
         _type: str,
-        container_properties: Optional[dict[str, Any]],
-        node_properties: Optional[dict[str, Any]],
-        eks_properties: Optional[dict[str, Any]],
+        container_properties: dict[str, Any] | None,
+        node_properties: dict[str, Any] | None,
+        eks_properties: dict[str, Any] | None,
         tags: dict[str, str],
         retry_strategy: dict[str, str],
         timeout: dict[str, int],
         backend: "BatchBackend",
         platform_capabilities: list[str],
         propagate_tags: bool,
-        revision: Optional[int] = 0,
+        revision: int | None = 0,
     ):
         self.name = name
         self.retry_strategy = retry_strategy
@@ -401,11 +401,11 @@ class JobDefinition(CloudFormationModel):
 
     def update(
         self,
-        parameters: Optional[dict[str, Any]],
+        parameters: dict[str, Any] | None,
         _type: str,
-        container_properties: Optional[dict[str, Any]],
-        node_properties: Optional[dict[str, Any]],
-        eks_properties: Optional[dict[str, Any]],
+        container_properties: dict[str, Any] | None,
+        node_properties: dict[str, Any] | None,
+        eks_properties: dict[str, Any] | None,
         retry_strategy: dict[str, Any],
         tags: dict[str, str],
         timeout: dict[str, int],
@@ -523,15 +523,15 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         job_queue: JobQueue,
         backend: "BatchBackend",
         log_backend: LogsBackend,
-        container_overrides: Optional[dict[str, Any]],
-        eks_properties_override: Optional[dict[str, Any]],
-        depends_on: Optional[list[dict[str, str]]],
-        parameters: Optional[dict[str, str]],
+        container_overrides: dict[str, Any] | None,
+        eks_properties_override: dict[str, Any] | None,
+        depends_on: list[dict[str, str]] | None,
+        parameters: dict[str, str] | None,
         all_jobs: dict[str, "Job"],
-        timeout: Optional[dict[str, int]],
+        timeout: dict[str, int] | None,
         array_properties: dict[str, Any],
-        provided_job_id: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        provided_job_id: str | None = None,
+        tags: dict[str, str] | None = None,
     ):
         threading.Thread.__init__(self)
         DockerModel.__init__(self)
@@ -553,7 +553,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         self.job_started_at = datetime(1970, 1, 1)
         self.job_stopped_at = datetime(1970, 1, 1)
         self.job_stopped = False
-        self.job_stopped_reason: Optional[str] = None
+        self.job_stopped_reason: str | None = None
         self.depends_on = depends_on
         self.parameters = {**self.job_definition.parameters, **(parameters or {})}
         self.timeout = timeout
@@ -565,7 +565,7 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         )
 
         self.stop = False
-        self.exit_code: Optional[int] = None
+        self.exit_code: int | None = None
 
         self.daemon = True
 
@@ -574,11 +574,11 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
         self._log_backend = log_backend
         self._log_group = "/aws/batch/job"
         self._stream_name = f"{self.job_definition.name}/default/{self.job_id}"
-        self.log_stream_name: Optional[str] = None
+        self.log_stream_name: str | None = None
 
         self.attempts: list[dict[str, Any]] = []
-        self.latest_attempt: Optional[dict[str, Any]] = None
-        self._child_jobs: Optional[list[Job]] = None
+        self.latest_attempt: dict[str, Any] | None = None
+        self._child_jobs: list[Job] | None = None
 
         tag_list = self.backend.tagger.convert_dict_to_tags_input(tags or {})
         # Validate the tag list. Maximum entires in the map is 50
@@ -751,14 +751,14 @@ class Job(threading.Thread, BaseModel, DockerModel, ManagedState):
 
         return [{"name": k, "value": v} for k, v in env_dict.items()]
 
-    def _get_attempt_duration(self) -> Optional[int]:
+    def _get_attempt_duration(self) -> int | None:
         if self.timeout:
             return self.timeout["attemptDurationSeconds"]
         if self.job_definition.timeout:
             return self.job_definition.timeout["attemptDurationSeconds"]
         return None
 
-    def _add_parameters_to_command(self, command: Union[str, list[str]]) -> list[str]:
+    def _add_parameters_to_command(self, command: str | list[str]) -> list[str]:
         if isinstance(command, str):
             command = [command]
 
@@ -1222,18 +1222,16 @@ class BatchBackend(BaseBackend):
 
         super().reset()
 
-    def get_compute_environment_by_arn(self, arn: str) -> Optional[ComputeEnvironment]:
+    def get_compute_environment_by_arn(self, arn: str) -> ComputeEnvironment | None:
         return self._compute_environments.get(arn)
 
-    def get_compute_environment_by_name(
-        self, name: str
-    ) -> Optional[ComputeEnvironment]:
+    def get_compute_environment_by_name(self, name: str) -> ComputeEnvironment | None:
         for comp_env in self._compute_environments.values():
             if comp_env.name == name:
                 return comp_env
         return None
 
-    def get_compute_environment(self, identifier: str) -> Optional[ComputeEnvironment]:
+    def get_compute_environment(self, identifier: str) -> ComputeEnvironment | None:
         """
         Get compute environment by name or ARN
         :param identifier: Name or ARN
@@ -1246,16 +1244,16 @@ class BatchBackend(BaseBackend):
             identifier
         ) or self.get_compute_environment_by_name(identifier)
 
-    def get_job_queue_by_arn(self, arn: str) -> Optional[JobQueue]:
+    def get_job_queue_by_arn(self, arn: str) -> JobQueue | None:
         return self._job_queues.get(arn)
 
-    def get_job_queue_by_name(self, name: str) -> Optional[JobQueue]:
+    def get_job_queue_by_name(self, name: str) -> JobQueue | None:
         for comp_env in self._job_queues.values():
             if comp_env.name == name:
                 return comp_env
         return None
 
-    def get_job_queue(self, identifier: str) -> Optional[JobQueue]:
+    def get_job_queue(self, identifier: str) -> JobQueue | None:
         """
         Get job queue by name or ARN
         :param identifier: Name or ARN
@@ -1268,10 +1266,10 @@ class BatchBackend(BaseBackend):
             identifier
         )
 
-    def get_job_definition_by_arn(self, arn: str) -> Optional[JobDefinition]:
+    def get_job_definition_by_arn(self, arn: str) -> JobDefinition | None:
         return self._job_definitions.get(arn)
 
-    def get_job_definition_by_name(self, name: str) -> Optional[JobDefinition]:
+    def get_job_definition_by_name(self, name: str) -> JobDefinition | None:
         latest_revision = -1
         latest_job = None
         for job_def in self._job_definitions.values():
@@ -1282,13 +1280,13 @@ class BatchBackend(BaseBackend):
 
     def get_job_definition_by_name_revision(
         self, name: str, revision: str
-    ) -> Optional[JobDefinition]:
+    ) -> JobDefinition | None:
         for job_def in self._job_definitions.values():
             if job_def.name == name and job_def.revision == int(revision):
                 return job_def
         return None
 
-    def get_job_definition(self, identifier: str) -> Optional[JobDefinition]:
+    def get_job_definition(self, identifier: str) -> JobDefinition | None:
         """
         Get job definitions by name or ARN
         :param identifier: Name or ARN
@@ -1327,14 +1325,14 @@ class BatchBackend(BaseBackend):
 
         return result
 
-    def get_job_by_id(self, identifier: str) -> Optional[Job]:
+    def get_job_by_id(self, identifier: str) -> Job | None:
         try:
             return self._jobs[identifier]
         except KeyError:
             return None
 
     def describe_compute_environments(
-        self, environments: Optional[list[str]] = None
+        self, environments: list[str] | None = None
     ) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
@@ -1374,7 +1372,7 @@ class BatchBackend(BaseBackend):
         state: str,
         compute_resources: dict[str, Any],
         service_role: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> ComputeEnvironment:
         # Validate
         if COMPUTE_ENVIRONMENT_NAME_REGEX.match(compute_environment_name) is None:
@@ -1629,9 +1627,9 @@ class BatchBackend(BaseBackend):
     def update_compute_environment(
         self,
         compute_environment_name: str,
-        state: Optional[str],
-        compute_resources: Optional[Any],
-        service_role: Optional[str],
+        state: str | None,
+        compute_resources: Any | None,
+        service_role: str | None,
     ) -> tuple[str, str]:
         # Validate
         compute_env = self.get_compute_environment(compute_environment_name)
@@ -1668,10 +1666,10 @@ class BatchBackend(BaseBackend):
         self,
         queue_name: str,
         priority: str,
-        schedule_policy: Optional[str],
+        schedule_policy: str | None,
         state: str,
         compute_env_order: list[dict[str, str]],
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> JobQueue:
         for variable, var_name in (
             (queue_name, "jobQueueName"),
@@ -1723,7 +1721,7 @@ class BatchBackend(BaseBackend):
         return queue
 
     def describe_job_queues(
-        self, job_queues: Optional[list[str]] = None
+        self, job_queues: list[str] | None = None
     ) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
@@ -1745,10 +1743,10 @@ class BatchBackend(BaseBackend):
     def update_job_queue(
         self,
         queue_name: str,
-        priority: Optional[str],
-        state: Optional[str],
-        compute_env_order: Optional[list[dict[str, Any]]],
-        schedule_policy: Optional[str],
+        priority: str | None,
+        state: str | None,
+        compute_env_order: list[dict[str, Any]] | None,
+        schedule_policy: str | None,
     ) -> tuple[str, str]:
         if queue_name is None:
             raise ClientException("jobQueueName must be provided")
@@ -1809,9 +1807,9 @@ class BatchBackend(BaseBackend):
         _type: str,
         tags: dict[str, str],
         retry_strategy: dict[str, Any],
-        container_properties: Optional[dict[str, Any]],
-        node_properties: Optional[dict[str, Any]],
-        eks_properties: Optional[dict[str, Any]],
+        container_properties: dict[str, Any] | None,
+        node_properties: dict[str, Any] | None,
+        eks_properties: dict[str, Any] | None,
         timeout: dict[str, int],
         platform_capabilities: list[str],
         propagate_tags: bool,
@@ -1869,9 +1867,9 @@ class BatchBackend(BaseBackend):
 
     def describe_job_definitions(
         self,
-        job_def_name: Optional[str] = None,
-        job_def_list: Optional[list[str]] = None,
-        status: Optional[str] = None,
+        job_def_name: str | None = None,
+        job_def_list: list[str] | None = None,
+        status: str | None = None,
     ) -> list[JobDefinition]:
         """
         Pagination is not yet implemented
@@ -1904,12 +1902,12 @@ class BatchBackend(BaseBackend):
         job_def_id: str,
         job_queue: str,
         array_properties: dict[str, int],
-        depends_on: Optional[list[dict[str, str]]] = None,
-        container_overrides: Optional[dict[str, Any]] = None,
-        eks_properties_override: Optional[dict[str, Any]] = None,
-        timeout: Optional[dict[str, int]] = None,
-        parameters: Optional[dict[str, str]] = None,
-        tags: Optional[dict[str, str]] = None,
+        depends_on: list[dict[str, str]] | None = None,
+        container_overrides: dict[str, Any] | None = None,
+        eks_properties_override: dict[str, Any] | None = None,
+        timeout: dict[str, int] | None = None,
+        parameters: dict[str, str] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> tuple[str, str, str]:
         """
         Parameters RetryStrategy and Parameters are not yet implemented.
@@ -1975,7 +1973,7 @@ class BatchBackend(BaseBackend):
             job.start()
         return job_name, job.job_id, job.arn
 
-    def describe_jobs(self, jobs: Optional[list[str]]) -> list[dict[str, Any]]:
+    def describe_jobs(self, jobs: list[str] | None) -> list[dict[str, Any]]:
         job_filter = set()
         if jobs is not None:
             job_filter = set(jobs)
@@ -1995,10 +1993,10 @@ class BatchBackend(BaseBackend):
 
     def list_jobs(
         self,
-        job_queue_name: Optional[str],
-        array_job_id: Optional[str],
-        job_status: Optional[str] = None,
-        filters: Optional[list[dict[str, Any]]] = None,
+        job_queue_name: str | None,
+        array_job_id: str | None,
+        job_status: str | None = None,
+        filters: list[dict[str, Any]] | None = None,
     ) -> list[Job]:
         """
         TODO: Pagination is not yet implemented

--- a/moto/batch/utils.py
+++ b/moto/batch/utils.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from moto.utilities.utils import get_partition
 
@@ -82,7 +82,7 @@ class JobStatus(str, Enum):
         ]
 
     @classmethod
-    def status_transitions(self) -> list[tuple[Optional[str], str]]:
+    def status_transitions(self) -> list[tuple[str | None, str]]:
         return [
             (JobStatus.SUBMITTED.value, JobStatus.PENDING.value),
             (JobStatus.PENDING.value, JobStatus.RUNNABLE.value),

--- a/moto/batch_simple/models.py
+++ b/moto/batch_simple/models.py
@@ -1,7 +1,7 @@
 import datetime
 from os import getenv
 from time import sleep
-from typing import Any, Optional
+from typing import Any
 
 from moto.batch.exceptions import ClientException
 from moto.batch.models import BatchBackend, Job, batch_backends
@@ -53,12 +53,12 @@ class BatchSimpleBackend(BatchBackend):
         job_def_id: str,
         job_queue: str,
         array_properties: dict[str, Any],
-        depends_on: Optional[list[dict[str, str]]] = None,
-        container_overrides: Optional[dict[str, Any]] = None,
-        eks_properties_override: Optional[dict[str, Any]] = None,
-        timeout: Optional[dict[str, int]] = None,
-        parameters: Optional[dict[str, str]] = None,
-        tags: Optional[dict[str, str]] = None,
+        depends_on: list[dict[str, str]] | None = None,
+        container_overrides: dict[str, Any] | None = None,
+        eks_properties_override: dict[str, Any] | None = None,
+        timeout: dict[str, int] | None = None,
+        parameters: dict[str, str] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> tuple[str, str, str]:
         # Look for job definition
         job_def = self.get_job_definition(job_def_id)

--- a/moto/bedrock/models.py
+++ b/moto/bedrock/models.py
@@ -29,13 +29,13 @@ class ModelCustomizationJob(BaseModel):
         hyper_parameters: dict[str, str],
         region_name: str,
         account_id: str,
-        client_request_token: Optional[str],
-        customization_type: Optional[str],
-        custom_model_kms_key_id: Optional[str],
-        job_tags: Optional[list[dict[str, str]]],
-        custom_model_tags: Optional[list[dict[str, str]]],
-        validation_data_config: Optional[dict[str, Any]],
-        vpc_config: Optional[dict[str, Any]],
+        client_request_token: str | None,
+        customization_type: str | None,
+        custom_model_kms_key_id: str | None,
+        job_tags: list[dict[str, str]] | None,
+        custom_model_tags: list[dict[str, str]] | None,
+        validation_data_config: dict[str, Any] | None,
+        vpc_config: dict[str, Any] | None,
     ):
         self.job_name = job_name
         self.custom_model_name = custom_model_name
@@ -135,10 +135,10 @@ class CustomModel(BaseModel):
         base_model_name: str,
         region_name: str,
         account_id: str,
-        customization_type: Optional[str],
-        model_kms_key_arn: Optional[str],
-        validation_data_config: Optional[dict[str, Any]],
-        validation_metrics: Optional[list[dict[str, float]]],
+        customization_type: str | None,
+        model_kms_key_arn: str | None,
+        validation_data_config: dict[str, Any] | None,
+        validation_metrics: list[dict[str, float]] | None,
     ):
         self.model_name = model_name
         self.job_name = job_name
@@ -224,13 +224,13 @@ class BedrockBackend(BaseBackend):
         training_data_config: dict[str, Any],
         output_data_config: dict[str, str],
         hyper_parameters: dict[str, str],
-        client_request_token: Optional[str],
-        customization_type: Optional[str],
-        custom_model_kms_key_id: Optional[str],
-        job_tags: Optional[list[dict[str, str]]],
-        custom_model_tags: Optional[list[dict[str, str]]],
-        validation_data_config: Optional[dict[str, Any]],
-        vpc_config: Optional[dict[str, Any]],
+        client_request_token: str | None,
+        customization_type: str | None,
+        custom_model_kms_key_id: str | None,
+        job_tags: list[dict[str, str]] | None,
+        custom_model_tags: list[dict[str, str]] | None,
+        validation_data_config: dict[str, Any] | None,
+        vpc_config: dict[str, Any] | None,
     ) -> str:
         if job_name in self.model_customization_jobs.keys():
             raise ResourceInUseException(
@@ -304,12 +304,12 @@ class BedrockBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_model_customization_jobs(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        status_equals: Optional[str],
-        name_contains: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        status_equals: str | None,
+        name_contains: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[ModelCustomizationJob]:
         customization_jobs_fetched = list(self.model_customization_jobs.values())
 
@@ -363,7 +363,7 @@ class BedrockBackend(BaseBackend):
 
         return customization_jobs_fetched
 
-    def get_model_invocation_logging_configuration(self) -> Optional[dict[str, Any]]:
+    def get_model_invocation_logging_configuration(self) -> dict[str, Any] | None:
         if self.model_invocation_logging_configuration:
             return self.model_invocation_logging_configuration.logging_config
         else:
@@ -403,13 +403,13 @@ class BedrockBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_custom_models(
         self,
-        creation_time_before: Optional[datetime],
-        creation_time_after: Optional[datetime],
-        name_contains: Optional[str],
-        base_model_arn_equals: Optional[str],
-        foundation_model_arn_equals: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_before: datetime | None,
+        creation_time_after: datetime | None,
+        name_contains: str | None,
+        base_model_arn_equals: str | None,
+        foundation_model_arn_equals: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[CustomModel]:
         """
         The foundation_model_arn_equals-argument is not yet supported

--- a/moto/bedrockagent/models.py
+++ b/moto/bedrockagent/models.py
@@ -1,6 +1,6 @@
 """AgentsforBedrockBackend class with methods for supported APIs."""
 
-from typing import Any, Optional
+from typing import Any
 
 from moto.bedrockagent.exceptions import (
     ConflictException,
@@ -23,13 +23,13 @@ class Agent(BaseModel):
         agent_resource_role_arn: str,
         region_name: str,
         account_id: str,
-        client_token: Optional[str],
-        instruction: Optional[str],
-        foundation_model: Optional[str],
-        description: Optional[str],
-        idle_session_ttl_in_seconds: Optional[int],
-        customer_encryption_key_arn: Optional[str],
-        prompt_override_configuration: Optional[dict[str, Any]],
+        client_token: str | None,
+        instruction: str | None,
+        foundation_model: str | None,
+        description: str | None,
+        idle_session_ttl_in_seconds: int | None,
+        customer_encryption_key_arn: str | None,
+        prompt_override_configuration: dict[str, Any] | None,
     ):
         self.agent_name = agent_name
         self.client_token = client_token
@@ -96,8 +96,8 @@ class KnowledgeBase(BaseModel):
         account_id: str,
         knowledge_base_configuration: dict[str, Any],
         storage_configuration: dict[str, Any],
-        client_token: Optional[str],
-        description: Optional[str],
+        client_token: str | None,
+        description: str | None,
     ):
         self.client_token = client_token
         self.name = name
@@ -192,14 +192,14 @@ class AgentsforBedrockBackend(BaseBackend):
         self,
         agent_name: str,
         agent_resource_role_arn: str,
-        client_token: Optional[str],
-        instruction: Optional[str],
-        foundation_model: Optional[str],
-        description: Optional[str],
-        idle_session_ttl_in_seconds: Optional[int],
-        customer_encryption_key_arn: Optional[str],
-        tags: Optional[dict[str, str]],
-        prompt_override_configuration: Optional[dict[str, Any]],
+        client_token: str | None,
+        instruction: str | None,
+        foundation_model: str | None,
+        description: str | None,
+        idle_session_ttl_in_seconds: int | None,
+        customer_encryption_key_arn: str | None,
+        tags: dict[str, str] | None,
+        prompt_override_configuration: dict[str, Any] | None,
     ) -> Agent:
         agent = Agent(
             agent_name,
@@ -229,7 +229,7 @@ class AgentsforBedrockBackend(BaseBackend):
         return list(self.agents.values())
 
     def delete_agent(
-        self, agent_id: str, skip_resource_in_use_check: Optional[bool]
+        self, agent_id: str, skip_resource_in_use_check: bool | None
     ) -> tuple[str, str]:
         if agent_id in self.agents:
             if (
@@ -251,9 +251,9 @@ class AgentsforBedrockBackend(BaseBackend):
         role_arn: str,
         knowledge_base_configuration: dict[str, Any],
         storage_configuration: dict[str, Any],
-        client_token: Optional[str],
-        description: Optional[str],
-        tags: Optional[dict[str, str]],
+        client_token: str | None,
+        description: str | None,
+        tags: dict[str, str] | None,
     ) -> KnowledgeBase:
         knowledge_base = KnowledgeBase(
             name,

--- a/moto/bedrockagentcorecontrol/models.py
+++ b/moto/bedrockagentcorecontrol/models.py
@@ -1,7 +1,7 @@
 """BedrockAgentCoreControl models."""
 
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -23,12 +23,12 @@ class AgentRuntime(BaseModel, ManagedState):
         agent_runtime_artifact: dict[str, Any],
         role_arn: str,
         network_configuration: dict[str, Any],
-        description: Optional[str],
-        authorizer_configuration: Optional[dict[str, Any]],
-        request_header_configuration: Optional[dict[str, Any]],
-        protocol_configuration: Optional[dict[str, Any]],
-        lifecycle_configuration: Optional[dict[str, Any]],
-        environment_variables: Optional[dict[str, str]],
+        description: str | None,
+        authorizer_configuration: dict[str, Any] | None,
+        request_header_configuration: dict[str, Any] | None,
+        protocol_configuration: dict[str, Any] | None,
+        lifecycle_configuration: dict[str, Any] | None,
+        environment_variables: dict[str, str] | None,
     ):
         ManagedState.__init__(
             self,
@@ -81,12 +81,12 @@ class AgentRuntime(BaseModel, ManagedState):
         agent_runtime_artifact: dict[str, Any],
         role_arn: str,
         network_configuration: dict[str, Any],
-        description: Optional[str],
-        authorizer_configuration: Optional[dict[str, Any]],
-        request_header_configuration: Optional[dict[str, Any]],
-        protocol_configuration: Optional[dict[str, Any]],
-        lifecycle_configuration: Optional[dict[str, Any]],
-        environment_variables: Optional[dict[str, str]],
+        description: str | None,
+        authorizer_configuration: dict[str, Any] | None,
+        request_header_configuration: dict[str, Any] | None,
+        protocol_configuration: dict[str, Any] | None,
+        lifecycle_configuration: dict[str, Any] | None,
+        environment_variables: dict[str, str] | None,
     ) -> None:
         self.agent_runtime_artifact = agent_runtime_artifact
         self.role_arn = role_arn
@@ -130,8 +130,8 @@ class AgentRuntimeEndpoint(BaseModel, ManagedState):
         account_id: str,
         agent_runtime: "AgentRuntime",
         name: str,
-        agent_runtime_version: Optional[str],
-        description: Optional[str],
+        agent_runtime_version: str | None,
+        description: str | None,
     ):
         ManagedState.__init__(
             self,
@@ -159,8 +159,8 @@ class AgentRuntimeEndpoint(BaseModel, ManagedState):
 
     def update(
         self,
-        agent_runtime_version: Optional[str],
-        description: Optional[str],
+        agent_runtime_version: str | None,
+        description: str | None,
     ) -> None:
         if agent_runtime_version is not None:
             self.target_version = agent_runtime_version
@@ -191,13 +191,13 @@ class Gateway(BaseModel, ManagedState):
         role_arn: str,
         protocol_type: str,
         authorizer_type: str,
-        description: Optional[str],
-        protocol_configuration: Optional[dict[str, Any]],
-        authorizer_configuration: Optional[dict[str, Any]],
-        kms_key_arn: Optional[str],
-        interceptor_configurations: Optional[list[dict[str, Any]]],
-        policy_engine_configuration: Optional[dict[str, Any]],
-        exception_level: Optional[str],
+        description: str | None,
+        protocol_configuration: dict[str, Any] | None,
+        authorizer_configuration: dict[str, Any] | None,
+        kms_key_arn: str | None,
+        interceptor_configurations: list[dict[str, Any]] | None,
+        policy_engine_configuration: dict[str, Any] | None,
+        exception_level: str | None,
     ):
         ManagedState.__init__(
             self,
@@ -233,13 +233,13 @@ class Gateway(BaseModel, ManagedState):
         role_arn: str,
         protocol_type: str,
         authorizer_type: str,
-        description: Optional[str],
-        protocol_configuration: Optional[dict[str, Any]],
-        authorizer_configuration: Optional[dict[str, Any]],
-        kms_key_arn: Optional[str],
-        interceptor_configurations: Optional[list[dict[str, Any]]],
-        policy_engine_configuration: Optional[dict[str, Any]],
-        exception_level: Optional[str],
+        description: str | None,
+        protocol_configuration: dict[str, Any] | None,
+        authorizer_configuration: dict[str, Any] | None,
+        kms_key_arn: str | None,
+        interceptor_configurations: list[dict[str, Any]] | None,
+        policy_engine_configuration: dict[str, Any] | None,
+        exception_level: str | None,
     ) -> None:
         self.name = name
         self.role_arn = role_arn
@@ -314,9 +314,9 @@ class GatewayTarget(BaseModel, ManagedState):
         gateway: Gateway,
         name: str,
         target_configuration: dict[str, Any],
-        description: Optional[str],
-        credential_provider_configurations: Optional[list[dict[str, Any]]],
-        metadata_configuration: Optional[dict[str, Any]],
+        description: str | None,
+        credential_provider_configurations: list[dict[str, Any]] | None,
+        metadata_configuration: dict[str, Any] | None,
     ):
         ManagedState.__init__(
             self,
@@ -343,9 +343,9 @@ class GatewayTarget(BaseModel, ManagedState):
         self,
         name: str,
         target_configuration: dict[str, Any],
-        description: Optional[str],
-        credential_provider_configurations: Optional[list[dict[str, Any]]],
-        metadata_configuration: Optional[dict[str, Any]],
+        description: str | None,
+        credential_provider_configurations: list[dict[str, Any]] | None,
+        metadata_configuration: dict[str, Any] | None,
     ) -> None:
         self.name = name
         self.target_configuration = target_configuration
@@ -395,10 +395,10 @@ class Memory(BaseModel, ManagedState):
         account_id: str,
         name: str,
         event_expiry_duration: int,
-        description: Optional[str],
-        encryption_key_arn: Optional[str],
-        memory_execution_role_arn: Optional[str],
-        memory_strategies: Optional[list[dict[str, Any]]],
+        description: str | None,
+        encryption_key_arn: str | None,
+        memory_execution_role_arn: str | None,
+        memory_strategies: list[dict[str, Any]] | None,
     ):
         ManagedState.__init__(
             self,
@@ -453,10 +453,10 @@ class Memory(BaseModel, ManagedState):
 
     def update(
         self,
-        description: Optional[str],
-        event_expiry_duration: Optional[int],
-        memory_execution_role_arn: Optional[str],
-        memory_strategies: Optional[dict[str, Any]],
+        description: str | None,
+        event_expiry_duration: int | None,
+        memory_execution_role_arn: str | None,
+        memory_strategies: dict[str, Any] | None,
     ) -> None:
         if description is not None:
             self.description = description
@@ -539,13 +539,13 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         agent_runtime_artifact: dict[str, Any],
         role_arn: str,
         network_configuration: dict[str, Any],
-        description: Optional[str],
-        authorizer_configuration: Optional[dict[str, Any]],
-        request_header_configuration: Optional[dict[str, Any]],
-        protocol_configuration: Optional[dict[str, Any]],
-        lifecycle_configuration: Optional[dict[str, Any]],
-        environment_variables: Optional[dict[str, str]],
-        tags: Optional[dict[str, str]],
+        description: str | None,
+        authorizer_configuration: dict[str, Any] | None,
+        request_header_configuration: dict[str, Any] | None,
+        protocol_configuration: dict[str, Any] | None,
+        lifecycle_configuration: dict[str, Any] | None,
+        environment_variables: dict[str, str] | None,
+        tags: dict[str, str] | None,
     ) -> AgentRuntime:
         runtime = AgentRuntime(
             region_name=self.region_name,
@@ -580,12 +580,12 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         agent_runtime_artifact: dict[str, Any],
         role_arn: str,
         network_configuration: dict[str, Any],
-        description: Optional[str],
-        authorizer_configuration: Optional[dict[str, Any]],
-        request_header_configuration: Optional[dict[str, Any]],
-        protocol_configuration: Optional[dict[str, Any]],
-        lifecycle_configuration: Optional[dict[str, Any]],
-        environment_variables: Optional[dict[str, str]],
+        description: str | None,
+        authorizer_configuration: dict[str, Any] | None,
+        request_header_configuration: dict[str, Any] | None,
+        protocol_configuration: dict[str, Any] | None,
+        lifecycle_configuration: dict[str, Any] | None,
+        environment_variables: dict[str, str] | None,
     ) -> AgentRuntime:
         runtime = self._get_runtime(agent_runtime_id)
         runtime.update(
@@ -625,9 +625,9 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         self,
         agent_runtime_id: str,
         name: str,
-        agent_runtime_version: Optional[str],
-        description: Optional[str],
-        tags: Optional[dict[str, str]],
+        agent_runtime_version: str | None,
+        description: str | None,
+        tags: dict[str, str] | None,
     ) -> AgentRuntimeEndpoint:
         runtime = self._get_runtime(agent_runtime_id)
         key = (agent_runtime_id, name)
@@ -667,8 +667,8 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         self,
         agent_runtime_id: str,
         endpoint_name: str,
-        agent_runtime_version: Optional[str],
-        description: Optional[str],
+        agent_runtime_version: str | None,
+        description: str | None,
     ) -> AgentRuntimeEndpoint:
         endpoint = self.get_agent_runtime_endpoint(agent_runtime_id, endpoint_name)
         endpoint.update(
@@ -708,14 +708,14 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         role_arn: str,
         protocol_type: str,
         authorizer_type: str,
-        description: Optional[str],
-        protocol_configuration: Optional[dict[str, Any]],
-        authorizer_configuration: Optional[dict[str, Any]],
-        kms_key_arn: Optional[str],
-        interceptor_configurations: Optional[list[dict[str, Any]]],
-        policy_engine_configuration: Optional[dict[str, Any]],
-        exception_level: Optional[str],
-        tags: Optional[dict[str, str]],
+        description: str | None,
+        protocol_configuration: dict[str, Any] | None,
+        authorizer_configuration: dict[str, Any] | None,
+        kms_key_arn: str | None,
+        interceptor_configurations: list[dict[str, Any]] | None,
+        policy_engine_configuration: dict[str, Any] | None,
+        exception_level: str | None,
+        tags: dict[str, str] | None,
     ) -> Gateway:
         gateway = Gateway(
             region_name=self.region_name,
@@ -752,13 +752,13 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         role_arn: str,
         protocol_type: str,
         authorizer_type: str,
-        description: Optional[str],
-        protocol_configuration: Optional[dict[str, Any]],
-        authorizer_configuration: Optional[dict[str, Any]],
-        kms_key_arn: Optional[str],
-        interceptor_configurations: Optional[list[dict[str, Any]]],
-        policy_engine_configuration: Optional[dict[str, Any]],
-        exception_level: Optional[str],
+        description: str | None,
+        protocol_configuration: dict[str, Any] | None,
+        authorizer_configuration: dict[str, Any] | None,
+        kms_key_arn: str | None,
+        interceptor_configurations: list[dict[str, Any]] | None,
+        policy_engine_configuration: dict[str, Any] | None,
+        exception_level: str | None,
     ) -> Gateway:
         gateway = self._get_gateway(gateway_identifier)
         gateway.update(
@@ -800,9 +800,9 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         gateway_identifier: str,
         name: str,
         target_configuration: dict[str, Any],
-        description: Optional[str],
-        credential_provider_configurations: Optional[list[dict[str, Any]]],
-        metadata_configuration: Optional[dict[str, Any]],
+        description: str | None,
+        credential_provider_configurations: list[dict[str, Any]] | None,
+        metadata_configuration: dict[str, Any] | None,
     ) -> GatewayTarget:
         gateway = self._get_gateway(gateway_identifier)
         target = GatewayTarget(
@@ -832,9 +832,9 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         target_id: str,
         name: str,
         target_configuration: dict[str, Any],
-        description: Optional[str],
-        credential_provider_configurations: Optional[list[dict[str, Any]]],
-        metadata_configuration: Optional[dict[str, Any]],
+        description: str | None,
+        credential_provider_configurations: list[dict[str, Any]] | None,
+        metadata_configuration: dict[str, Any] | None,
     ) -> GatewayTarget:
         gateway = self._get_gateway(gateway_identifier)
         target = self._get_gateway_target(gateway.gateway_id, target_id)
@@ -874,11 +874,11 @@ class BedrockAgentCoreControlBackend(BaseBackend):
         self,
         name: str,
         event_expiry_duration: int,
-        description: Optional[str],
-        encryption_key_arn: Optional[str],
-        memory_execution_role_arn: Optional[str],
-        memory_strategies: Optional[list[dict[str, Any]]],
-        tags: Optional[dict[str, str]],
+        description: str | None,
+        encryption_key_arn: str | None,
+        memory_execution_role_arn: str | None,
+        memory_strategies: list[dict[str, Any]] | None,
+        tags: dict[str, str] | None,
     ) -> Memory:
         memory = Memory(
             region_name=self.region_name,
@@ -906,10 +906,10 @@ class BedrockAgentCoreControlBackend(BaseBackend):
     def update_memory(
         self,
         memory_id: str,
-        description: Optional[str],
-        event_expiry_duration: Optional[int],
-        memory_execution_role_arn: Optional[str],
-        memory_strategies: Optional[dict[str, Any]],
+        description: str | None,
+        event_expiry_duration: int | None,
+        memory_execution_role_arn: str | None,
+        memory_strategies: dict[str, Any] | None,
     ) -> Memory:
         memory = self._get_memory(memory_id)
         memory.update(

--- a/moto/ce/models.py
+++ b/moto/ce/models.py
@@ -1,7 +1,7 @@
 """CostExplorerBackend class with methods for supported APIs."""
 
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -30,7 +30,7 @@ class CostCategoryDefinition(BaseModel):
         account_id: str,
         region_name: str,
         name: str,
-        effective_start: Optional[str],
+        effective_start: str | None,
         rule_version: str,
         rules: list[dict[str, Any]],
         default_value: str,
@@ -47,7 +47,7 @@ class CostCategoryDefinition(BaseModel):
     def update(
         self,
         rule_version: str,
-        effective_start: Optional[str],
+        effective_start: str | None,
         rules: list[dict[str, Any]],
         default_value: str,
         split_charge_rules: list[dict[str, Any]],
@@ -83,7 +83,7 @@ class CostExplorerBackend(BaseBackend):
     def create_cost_category_definition(
         self,
         name: str,
-        effective_start: Optional[str],
+        effective_start: str | None,
         rule_version: str,
         rules: list[dict[str, Any]],
         default_value: str,
@@ -130,7 +130,7 @@ class CostExplorerBackend(BaseBackend):
     def update_cost_category_definition(
         self,
         cost_category_arn: str,
-        effective_start: Optional[str],
+        effective_start: str | None,
         rule_version: str,
         rules: list[dict[str, Any]],
         default_value: str,

--- a/moto/cloudformation/exceptions.py
+++ b/moto/cloudformation/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import ServiceException
 
 
@@ -21,7 +19,7 @@ class AlreadyExistsException(CloudFormationError):
 class ValidationError(CloudFormationError):
     code = "ValidationError"
 
-    def __init__(self, name_or_id: Optional[str] = None, message: Optional[str] = None):
+    def __init__(self, name_or_id: str | None = None, message: str | None = None):
         # FIXME: The "stack does not exist" message should be provided by the caller, not here.
         if message is None:
             message = f"Stack with id {name_or_id} does not exist"

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -4,7 +4,7 @@ import json
 from collections import OrderedDict
 from collections.abc import Iterable
 from datetime import timedelta
-from typing import Any, Optional, Union
+from typing import Any
 
 import yaml
 from yaml.parser import ParserError
@@ -46,12 +46,12 @@ class StackSet(BaseModel):
         name: str,
         template: str,
         region: str,
-        description: Optional[str],
+        description: str | None,
         parameters: dict[str, str],
         permission_model: str,
-        tags: Optional[dict[str, str]],
-        admin_role: Optional[str],
-        execution_role: Optional[str],
+        tags: dict[str, str] | None,
+        admin_role: str | None,
+        execution_role: str | None,
     ):
         self.id = stackset_id
         self.arn = generate_stackset_arn(stackset_id, region, account_id)
@@ -93,8 +93,8 @@ class StackSet(BaseModel):
         operation_id: str,
         action: str,
         status: str,
-        accounts: Optional[list[str]] = None,
-        regions: Optional[list[str]] = None,
+        accounts: list[str] | None = None,
+        regions: list[str] | None = None,
     ) -> dict[str, Any]:
         accounts = accounts or []
         regions = regions or []
@@ -161,7 +161,7 @@ class StackSet(BaseModel):
         self,
         accounts: list[str],
         regions: list[str],
-        deployment_targets: Optional[dict[str, Any]],
+        deployment_targets: dict[str, Any] | None,
         parameters: list[dict[str, Any]],
     ) -> str:
         if self.permission_model == "SERVICE_MANAGED":
@@ -234,7 +234,7 @@ class StackInstance(BaseModel):
         stack_name: str,
         name: str,
         template: str,
-        parameters: Optional[list[dict[str, Any]]],
+        parameters: list[dict[str, Any]] | None,
         permission_model: str,
     ):
         self.account_id = account_id
@@ -325,7 +325,7 @@ class StackInstances(BaseModel):
         self,
         accounts: list[str],
         regions: list[str],
-        parameters: Optional[list[dict[str, Any]]],
+        parameters: list[dict[str, Any]] | None,
         deployment_targets: dict[str, Any],
         permission_model: str,
     ) -> list[dict[str, Any]]:
@@ -363,7 +363,7 @@ class StackInstances(BaseModel):
         self,
         accounts: list[str],
         regions: list[str],
-        parameters: Optional[list[dict[str, Any]]],
+        parameters: list[dict[str, Any]] | None,
     ) -> Any:
         for account in accounts:
             for region in regions:
@@ -396,17 +396,17 @@ class Stack(CloudFormationModel):
         self,
         stack_id: str,
         name: str,
-        template: Union[str, dict[str, Any]],
+        template: str | dict[str, Any],
         parameters: dict[str, str],
         account_id: str,
         region_name: str,
-        notification_arns: Optional[list[str]] = None,
-        tags: Optional[dict[str, str]] = None,
-        role_arn: Optional[str] = None,
-        cross_stack_resources: Optional[dict[str, Export]] = None,
-        enable_termination_protection: Optional[bool] = False,
-        timeout_in_mins: Optional[int] = None,
-        stack_policy_body: Optional[str] = None,
+        notification_arns: list[str] | None = None,
+        tags: dict[str, str] | None = None,
+        role_arn: str | None = None,
+        cross_stack_resources: dict[str, Export] | None = None,
+        enable_termination_protection: bool | None = False,
+        timeout_in_mins: int | None = None,
+        stack_policy_body: str | None = None,
     ):
         self.stack_id = stack_id
         self.name = name
@@ -468,8 +468,8 @@ class Stack(CloudFormationModel):
     def _add_stack_event(
         self,
         resource_status: str,
-        resource_status_reason: Optional[str] = None,
-        resource_properties: Optional[str] = None,
+        resource_status_reason: str | None = None,
+        resource_properties: str | None = None,
     ) -> None:
         event = Event(
             stack_id=self.stack_id,
@@ -518,8 +518,8 @@ class Stack(CloudFormationModel):
         return self.resource_map.values()
 
     @property
-    def outputs(self) -> Optional[list[dict[str, Any]]]:
-        def get_export_name(output_value: Any) -> Optional[str]:
+    def outputs(self) -> list[dict[str, Any]] | None:
+        def get_export_name(output_value: Any) -> str | None:
             for export in self.exports:
                 if output_value == export.value:
                     return export.name
@@ -542,7 +542,7 @@ class Stack(CloudFormationModel):
         return self.output_map.exports
 
     @property
-    def template_description(self) -> Optional[str]:
+    def template_description(self) -> str | None:
         return self.template_dict.get("Description")
 
     def add_custom_resource(self, custom_resource: CustomModel) -> None:
@@ -570,9 +570,9 @@ class Stack(CloudFormationModel):
     def update(
         self,
         template: str,
-        role_arn: Optional[str] = None,
-        parameters: Optional[dict[str, Any]] = None,
-        tags: Optional[dict[str, str]] = None,
+        role_arn: str | None = None,
+        parameters: dict[str, Any] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> None:
         self._add_stack_event(
             "UPDATE_IN_PROGRESS", resource_status_reason="User Initiated"
@@ -683,9 +683,9 @@ class ChangeSet(BaseModel):
         template: str,
         parameters: dict[str, str],
         description: str,
-        notification_arns: Optional[list[str]] = None,
-        tags: Optional[dict[str, str]] = None,
-        role_arn: Optional[str] = None,
+        notification_arns: list[str] | None = None,
+        tags: dict[str, str] | None = None,
+        role_arn: str | None = None,
     ):
         self.change_set_type = change_set_type
         self.change_set_id = change_set_id
@@ -705,9 +705,9 @@ class ChangeSet(BaseModel):
         self.creation_time = utcnow()
         self.changes = self.diff()
 
-        self.status: Optional[str] = None
-        self.execution_status: Optional[str] = None
-        self.status_reason: Optional[str] = None
+        self.status: str | None = None
+        self.execution_status: str | None = None
+        self.status_reason: str | None = None
 
     def _parse_template(self) -> None:
         yaml.add_multi_constructor("", yaml_tag_constructor)
@@ -745,8 +745,8 @@ class Event(BaseModel):
         physical_resource_id: str,
         resource_type: str,
         resource_status: str,
-        resource_status_reason: Optional[str],
-        resource_properties: Optional[str],
+        resource_status_reason: str | None,
+        resource_properties: str | None,
     ):
         self.stack_id = stack_id
         self.stack_name = stack_name
@@ -782,7 +782,7 @@ ClientRequestToken='{self.client_request_token}'"""
 
 
 def filter_stacks(
-    all_stacks: list[Stack], status_filter: Optional[list[str]]
+    all_stacks: list[Stack], status_filter: list[str] | None
 ) -> list[Stack]:
     filtered_stacks = []
     if not status_filter:
@@ -819,7 +819,7 @@ class CloudFormationBackend(BaseBackend):
 
     def _resolve_update_parameters(
         self,
-        instance: Union[Stack, StackSet],
+        instance: Stack | StackSet,
         incoming_params: list[dict[str, str]],
     ) -> dict[str, str]:
         parameters = {
@@ -843,9 +843,9 @@ class CloudFormationBackend(BaseBackend):
         parameters: dict[str, str],
         tags: dict[str, str],
         permission_model: str,
-        admin_role: Optional[str],
-        exec_role: Optional[str],
-        description: Optional[str],
+        admin_role: str | None,
+        exec_role: str | None,
+        description: str | None,
     ) -> StackSet:
         """
         The following parameters are not yet implemented: StackId, AdministrationRoleARN, AutoDeployment, ExecutionRoleName, CallAs, ClientRequestToken, ManagedExecution
@@ -880,7 +880,7 @@ class CloudFormationBackend(BaseBackend):
         raise StackSetNotFoundException(name)
 
     def delete_stack_set(self, name: str) -> None:
-        stackset_to_delete: Optional[StackSet] = None
+        stackset_to_delete: StackSet | None = None
         if name in self.stacksets:
             stackset_to_delete = self.stacksets[name]
         for stackset in self.stacksets.values():
@@ -923,7 +923,7 @@ class CloudFormationBackend(BaseBackend):
         accounts: list[str],
         regions: list[str],
         parameters: list[dict[str, str]],
-        deployment_targets: Optional[dict[str, Any]],
+        deployment_targets: dict[str, Any] | None,
     ) -> str:
         """
         The following parameters are not yet implemented: DeploymentTargets.AccountFilterType, DeploymentTargets.AccountsUrl, OperationPreferences, CallAs
@@ -996,12 +996,12 @@ class CloudFormationBackend(BaseBackend):
         name: str,
         template: str,
         parameters: dict[str, Any],
-        notification_arns: Optional[list[str]] = None,
-        tags: Optional[dict[str, str]] = None,
-        role_arn: Optional[str] = None,
-        enable_termination_protection: Optional[bool] = False,
-        timeout_in_mins: Optional[int] = None,
-        stack_policy_body: Optional[str] = None,
+        notification_arns: list[str] | None = None,
+        tags: dict[str, str] | None = None,
+        role_arn: str | None = None,
+        enable_termination_protection: bool | None = False,
+        timeout_in_mins: int | None = None,
+        stack_policy_body: str | None = None,
     ) -> Stack:
         """
         The functionality behind EnableTerminationProtection is not yet implemented.
@@ -1042,9 +1042,9 @@ class CloudFormationBackend(BaseBackend):
         parameters: dict[str, str],
         description: str,
         change_set_type: str,
-        notification_arns: Optional[list[str]] = None,
-        tags: Optional[dict[str, str]] = None,
-        role_arn: Optional[str] = None,
+        notification_arns: list[str] | None = None,
+        tags: dict[str, str] | None = None,
+        role_arn: str | None = None,
     ) -> tuple[str, str]:
         validate_create_change_set(change_set_name)
         if change_set_type == "UPDATE":
@@ -1114,7 +1114,7 @@ class CloudFormationBackend(BaseBackend):
                     break
             del self.change_sets[to_delete]
 
-    def describe_change_set(self, change_set_name: str) -> Optional[ChangeSet]:
+    def describe_change_set(self, change_set_name: str) -> ChangeSet | None:
         change_set = None
         if change_set_name in self.change_sets:
             # This means arn was passed in
@@ -1128,7 +1128,7 @@ class CloudFormationBackend(BaseBackend):
         return change_set
 
     def execute_change_set(
-        self, change_set_name: str, stack_name: Optional[str] = None
+        self, change_set_name: str, stack_name: str | None = None
     ) -> None:
         if change_set_name in self.change_sets:
             # This means arn was passed in
@@ -1193,7 +1193,7 @@ class CloudFormationBackend(BaseBackend):
     def list_change_sets(self) -> Iterable[ChangeSet]:
         return self.change_sets.values()
 
-    def list_stacks(self, status_filter: Optional[list[str]] = None) -> list[Stack]:
+    def list_stacks(self, status_filter: list[str] | None = None) -> list[Stack]:
         total_stacks = list(self.stacks.values()) + list(self.deleted_stacks.values())
         return filter_stacks(total_stacks, status_filter)
 
@@ -1213,9 +1213,9 @@ class CloudFormationBackend(BaseBackend):
         self,
         name: str,
         template: str,
-        role_arn: Optional[str],
+        role_arn: str | None,
         parameters: list[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> Stack:
         stack = self.get_stack(name)
         resolved_parameters = self._resolve_update_parameters(
@@ -1290,9 +1290,7 @@ class CloudFormationBackend(BaseBackend):
                 if stack.name == name_or_stack_id:
                     self.delete_stack(stack.stack_id)
 
-    def list_exports(
-        self, tokenstr: Optional[str]
-    ) -> tuple[list[Export], Optional[str]]:
+    def list_exports(self, tokenstr: str | None) -> tuple[list[Export], str | None]:
         all_exports = list(self.exports.values())
         if tokenstr is None:
             exports = all_exports[0:100]
@@ -1306,7 +1304,7 @@ class CloudFormationBackend(BaseBackend):
     def describe_stack_events(self, stack_name: str) -> list[Event]:
         return self.get_stack(stack_name).events
 
-    def get_template(self, name_or_stack_id: str) -> Union[str, dict[str, Any]]:
+    def get_template(self, name_or_stack_id: str) -> str | dict[str, Any]:
         return self.get_stack(name_or_stack_id).template
 
     def validate_template(self, template: str) -> list[Any]:

--- a/moto/cloudformation/parsing.py
+++ b/moto/cloudformation/parsing.py
@@ -11,9 +11,7 @@ from collections.abc import Iterable, Iterator
 from functools import lru_cache
 from typing import (
     Any,
-    Optional,
     TypeVar,
-    Union,
 )
 
 # This ugly section of imports is necessary because we
@@ -283,7 +281,7 @@ def resource_class_from_type(resource_type: str) -> type[CloudFormationModel]:
     return get_model_map()[resource_type]
 
 
-def resource_name_property_from_type(resource_type: str) -> Optional[str]:
+def resource_name_property_from_type(resource_type: str) -> str | None:
     for model in get_model_list():
         if model.cloudformation_type() == resource_type:
             return model.cloudformation_name_type()
@@ -373,7 +371,7 @@ def parse_and_create_resource(
     resources_map: "ResourceMap",
     account_id: str,
     region_name: str,
-) -> Optional[CF_MODEL]:
+) -> CF_MODEL | None:
     condition = resource_json.get("Condition")
     if condition and not resources_map.lazy_condition_map[condition]:
         # If this has a False condition, don't create the resource
@@ -405,8 +403,8 @@ def parse_and_update_resource(
     resources_map: "ResourceMap",
     account_id: str,
     region_name: str,
-) -> Optional[CF_MODEL]:
-    resource_tuple: Optional[tuple[type[CloudFormationModel], dict[str, Any], str]] = (
+) -> CF_MODEL | None:
+    resource_tuple: tuple[type[CloudFormationModel], dict[str, Any], str] | None = (
         parse_resource_and_generate_name(logical_id, resource_json, resources_map)
     )
     if not resource_tuple:
@@ -444,7 +442,7 @@ def parse_and_delete_resource(
 
 
 def parse_condition(  # type: ignore[return]
-    condition: Union[dict[str, Any], bool],
+    condition: dict[str, Any] | bool,
     resources_map: "ResourceMap",
     condition_map: dict[str, Any],
 ) -> bool:
@@ -481,7 +479,7 @@ def parse_condition(  # type: ignore[return]
 
 def parse_output(
     output_logical_id: str, output_json: Any, resources_map: "ResourceMap"
-) -> Optional[Output]:
+) -> Output | None:
     if "Condition" in output_json and not resources_map.lazy_condition_map.get(
         output_json["Condition"]
     ):
@@ -528,7 +526,7 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
         region_name: str,
         account_id: str,
         template: dict[str, Any],
-        cross_stack_resources: Optional[dict[str, "Export"]],
+        cross_stack_resources: dict[str, "Export"] | None,
     ):
         self._template = template
         self._resource_json_map: dict[str, Any] = (
@@ -553,7 +551,7 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
             "AWS::Partition": "aws",
         }
 
-    def __getitem__(self, key: str) -> Optional[CF_MODEL]:
+    def __getitem__(self, key: str) -> CF_MODEL | None:
         resource_logical_id = key
 
         if resource_logical_id in self._parsed_resources:
@@ -662,7 +660,7 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
                 if value_type == "CommaDelimitedList" or value_type.startswith("List"):
                     value = value.split(",")
 
-                def _parse_number_parameter(num_string: str) -> Union[int, float]:
+                def _parse_number_parameter(num_string: str) -> int | float:
                     """CloudFormation NUMBER types can be an int or float.
                     Try int first and then fall back to float if that fails
                     """
@@ -773,7 +771,7 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
     def build_resource_diff(
         self,
         other_template: dict[str, Any],
-        parameters: Optional[dict[str, Any]] = None,
+        parameters: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         old = self._resource_json_map
         new = other_template["Resources"]
@@ -830,7 +828,7 @@ class ResourceMap(collections_abc.Mapping):  # type: ignore[type-arg]
         return resources_by_action
 
     def update(
-        self, template: dict[str, Any], parameters: Optional[dict[str, Any]] = None
+        self, template: dict[str, Any], parameters: dict[str, Any] | None = None
     ) -> None:
         resource_names_by_action = self.build_resource_diff(template, parameters)
 
@@ -970,7 +968,7 @@ class OutputMap(collections_abc.Mapping):  # type: ignore[type-arg]
         self._resource_map = resources
         self._parsed_outputs: dict[str, Output] = {}
 
-    def __getitem__(self, key: str) -> Optional[Output]:
+    def __getitem__(self, key: str) -> Output | None:
         output_logical_id = key
 
         if output_logical_id in self._parsed_outputs:

--- a/moto/cloudformation/responses.py
+++ b/moto/cloudformation/responses.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Optional
+from typing import Any
 
 import yaml
 from yaml.parser import ParserError
@@ -391,7 +391,7 @@ class CloudFormationResponse(BaseResponse):
 
     def _validate_different_update(
         self,
-        incoming_params: Optional[list[dict[str, Any]]],
+        incoming_params: list[dict[str, Any]] | None,
         stack_body: str,
         old_stack: Stack,
     ) -> None:
@@ -434,7 +434,7 @@ class CloudFormationResponse(BaseResponse):
         # boto3 is supposed to let you clear the tags by passing an empty value, but the request body doesn't
         # end up containing anything we can use to differentiate between passing an empty value versus not
         # passing anything. so until that changes, moto won't be able to clear tags, only update them.
-        tags: Optional[dict[str, str]] = {
+        tags: dict[str, str] | None = {
             item["Key"]: item["Value"] for item in self._get_param("Tags", [])
         }
         # so that if we don't pass the parameter, we don't clear all the tags accidentally

--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -1,5 +1,5 @@
 import string
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -420,7 +420,7 @@ class CloudFrontBackend(BaseBackend):
 
     def _distribution_with_caller_reference(
         self, reference: str
-    ) -> Optional[Distribution]:
+    ) -> Distribution | None:
         for dist in self.distributions.values():
             config = dist.distribution_config
             if config.caller_reference == reference:

--- a/moto/cloudhsmv2/models.py
+++ b/moto/cloudhsmv2/models.py
@@ -1,7 +1,7 @@
 """CloudHSMV2Backend class with methods for supported APIs."""
 
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import utcnow
@@ -13,12 +13,12 @@ from .exceptions import ResourceNotFoundException
 class Cluster:
     def __init__(
         self,
-        backup_retention_policy: Optional[dict[str, str]],
+        backup_retention_policy: dict[str, str] | None,
         hsm_type: str,
-        source_backup_id: Optional[str],
+        source_backup_id: str | None,
         subnet_ids: list[str],
         network_type: str = "IPV4",
-        tag_list: Optional[list[dict[str, str]]] = None,
+        tag_list: list[dict[str, str]] | None = None,
         mode: str = "DEFAULT",
         region_name: str = "us-east-1",
     ):
@@ -73,10 +73,10 @@ class Backup:
         cluster_id: str,
         hsm_type: str,
         mode: str,
-        tag_list: Optional[list[dict[str, str]]],
-        source_backup: Optional[str] = None,
-        source_cluster: Optional[str] = None,
-        source_region: Optional[str] = None,
+        tag_list: list[dict[str, str]] | None,
+        source_backup: str | None = None,
+        source_cluster: str | None = None,
+        source_region: str | None = None,
         never_expires: bool = False,
         region_name: str = "us-east-1",
     ):
@@ -153,7 +153,7 @@ class CloudHSMV2Backend(BaseBackend):
 
     def list_tags(
         self, resource_id: str, next_token: str, max_results: int
-    ) -> tuple[list[dict[str, str]], Optional[str]]:
+    ) -> tuple[list[dict[str, str]], str | None]:
         """
         Pagination is not yet implemented
         """
@@ -194,13 +194,13 @@ class CloudHSMV2Backend(BaseBackend):
 
     def create_cluster(
         self,
-        backup_retention_policy: Optional[dict[str, str]],
+        backup_retention_policy: dict[str, str] | None,
         hsm_type: str,
-        source_backup_id: Optional[str],
+        source_backup_id: str | None,
         subnet_ids: list[str],
-        network_type: Optional[str],
-        tag_list: Optional[list[dict[str, str]]],
-        mode: Optional[str],
+        network_type: str | None,
+        tag_list: list[dict[str, str]] | None,
+        mode: str | None,
     ) -> dict[str, Any]:
         cluster = Cluster(
             backup_retention_policy=backup_retention_policy,
@@ -237,7 +237,7 @@ class CloudHSMV2Backend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_clusters(
-        self, filters: Optional[dict[str, list[str]]] = None
+        self, filters: dict[str, list[str]] | None = None
     ) -> list[dict[str, str]]:
         clusters = list(self.clusters.values())
 
@@ -253,15 +253,15 @@ class CloudHSMV2Backend(BaseBackend):
         clusters = sorted(clusters, key=lambda x: x.create_timestamp)
         return [c.to_dict() for c in clusters]
 
-    def get_resource_policy(self, resource_arn: str) -> Optional[str]:
+    def get_resource_policy(self, resource_arn: str) -> str | None:
         return self.resource_policies.get(resource_arn)
 
     @paginate(PAGINATION_MODEL)
     def describe_backups(
         self,
-        filters: Optional[dict[str, list[str]]],
-        shared: Optional[bool],
-        sort_ascending: Optional[bool],
+        filters: dict[str, list[str]] | None,
+        shared: bool | None,
+        sort_ascending: bool | None,
     ) -> list[Backup]:
         backups = list(self.backups.values())
 

--- a/moto/cloudtrail/models.py
+++ b/moto/cloudtrail/models.py
@@ -2,7 +2,7 @@ import re
 import time
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -29,10 +29,10 @@ def datetime2int(date: datetime) -> int:
 class TrailStatus:
     def __init__(self) -> None:
         self.is_logging = False
-        self.latest_delivery_time: Optional[int] = None
-        self.latest_delivery_attempt: Optional[str] = ""
-        self.started: Optional[datetime] = None
-        self.stopped: Optional[datetime] = None
+        self.latest_delivery_time: int | None = None
+        self.latest_delivery_attempt: str | None = ""
+        self.started: datetime | None = None
+        self.stopped: datetime | None = None
 
     def start_logging(self) -> None:
         self.is_logging = True
@@ -117,7 +117,7 @@ class Trail(BaseModel):
         return f"arn:{get_partition(self.region_name)}:cloudtrail:{self.region_name}:{self.account_id}:trail/{self.trail_name}"
 
     @property
-    def topic_arn(self) -> Optional[str]:
+    def topic_arn(self) -> str | None:
         if self.sns_topic_name:
             return f"arn:{get_partition(self.region_name)}:sns:{self.region_name}:{self.account_id}:{self.sns_topic_name}"
         return None
@@ -184,16 +184,16 @@ class Trail(BaseModel):
 
     def update(
         self,
-        s3_bucket_name: Optional[str],
-        s3_key_prefix: Optional[str],
-        sns_topic_name: Optional[str],
-        include_global_service_events: Optional[bool],
-        is_multi_region_trail: Optional[bool],
-        enable_log_file_validation: Optional[bool],
-        is_organization_trail: Optional[bool],
-        cw_log_group_arn: Optional[str],
-        cw_role_arn: Optional[str],
-        kms_key_id: Optional[str],
+        s3_bucket_name: str | None,
+        s3_key_prefix: str | None,
+        sns_topic_name: str | None,
+        include_global_service_events: bool | None,
+        is_multi_region_trail: bool | None,
+        enable_log_file_validation: bool | None,
+        is_organization_trail: bool | None,
+        cw_log_group_arn: str | None,
+        cw_role_arn: str | None,
+        kms_key_id: str | None,
     ) -> None:
         if s3_bucket_name is not None:
             self.bucket_name = s3_bucket_name

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -2,7 +2,7 @@ import json
 import math
 from collections.abc import Iterable
 from datetime import datetime, timedelta
-from typing import Any, Optional, SupportsFloat
+from typing import Any, SupportsFloat
 from uuid import uuid4
 
 from moto.core.base_backend import BaseBackend
@@ -35,7 +35,7 @@ _EMPTY_LIST: Any = ()
 
 
 class Dimension:
-    def __init__(self, name: Optional[str], value: Optional[str]):
+    def __init__(self, name: str | None, value: str | None):
         self.name = name
         self.value = value
 
@@ -72,8 +72,8 @@ class MetricDataQuery:
         label: str,
         period: str,
         return_data: str,
-        expression: Optional[str] = None,
-        metric_stat: Optional[MetricStat] = None,
+        expression: str | None = None,
+        metric_stat: MetricStat | None = None,
     ):
         self.id = query_id
         self.label = label
@@ -124,25 +124,25 @@ class Alarm(BaseModel):
         name: str,
         namespace: str,
         metric_name: str,
-        metric_data_queries: Optional[list[MetricDataQuery]],
+        metric_data_queries: list[MetricDataQuery] | None,
         comparison_operator: str,
         evaluation_periods: int,
-        datapoints_to_alarm: Optional[int],
+        datapoints_to_alarm: int | None,
         period: int,
         threshold: float,
         statistic: str,
-        extended_statistic: Optional[str],
+        extended_statistic: str | None,
         description: str,
         dimensions: list[dict[str, str]],
         alarm_actions: list[str],
-        ok_actions: Optional[list[str]],
-        insufficient_data_actions: Optional[list[str]],
-        unit: Optional[str],
+        ok_actions: list[str] | None,
+        insufficient_data_actions: list[str] | None,
+        unit: str | None,
         actions_enabled: bool,
-        treat_missing_data: Optional[str],
-        evaluate_low_sample_count_percentile: Optional[str],
-        threshold_metric_id: Optional[str],
-        rule: Optional[str],
+        treat_missing_data: str | None,
+        evaluate_low_sample_count_percentile: str | None,
+        threshold_metric_id: str | None,
+        rule: str | None,
     ):
         self.region_name = region_name
         self.name = name
@@ -224,7 +224,7 @@ class MetricDatumBase(BaseModel):
         namespace: str,
         name: str,
         dimensions: list[dict[str, str]],
-        timestamp: Optional[datetime],
+        timestamp: datetime | None,
         unit: Any = None,
     ):
         self.namespace = namespace
@@ -237,10 +237,10 @@ class MetricDatumBase(BaseModel):
 
     def filter(
         self,
-        namespace: Optional[str],
-        name: Optional[str],
+        namespace: str | None,
+        name: str | None,
         dimensions: list[dict[str, str]],
-        already_present_metrics: Optional[list["MetricDatumBase"]] = None,
+        already_present_metrics: list["MetricDatumBase"] | None = None,
     ) -> bool:
         if namespace and namespace != self.namespace:
             return False
@@ -277,7 +277,7 @@ class MetricDatum(MetricDatumBase):
         name: str,
         value: float,
         dimensions: list[dict[str, str]],
-        timestamp: Optional[datetime],
+        timestamp: datetime | None,
         unit: Any = None,
     ):
         super().__init__(namespace, name, dimensions, timestamp, unit)
@@ -298,7 +298,7 @@ class MetricAggregatedDatum(MetricDatumBase):
         sample_count: float,
         sum_stat: float,
         dimensions: list[dict[str, str]],
-        timestamp: Optional[datetime],
+        timestamp: datetime | None,
         unit: Any = None,
     ):
         super().__init__(namespace, name, dimensions, timestamp, unit)
@@ -383,13 +383,13 @@ class Statistics:
     Helper class to calculate statics for a list of metrics (MetricDatum, or MetricAggregatedDatum)
     """
 
-    def __init__(self, stats: list[str], dt: datetime, unit: Optional[str] = None):
+    def __init__(self, stats: list[str], dt: datetime, unit: str | None = None):
         self.timestamp: datetime = dt or utcnow()
         self.metric_data: list[MetricDatumBase] = []
         self.stats = stats
         self.unit = unit
 
-    def get_statistics_for_type(self, stat: str) -> Optional[SupportsFloat]:
+    def get_statistics_for_type(self, stat: str) -> SupportsFloat | None:
         """Calculates the statistic for the metric_data provided
 
         :param stat: the statistic that should be returned, case-sensitive (Sum, Average, Minium, Maximum, SampleCount)
@@ -424,21 +424,21 @@ class Statistics:
         ]
 
     @property
-    def sample_count(self) -> Optional[SupportsFloat]:
+    def sample_count(self) -> SupportsFloat | None:
         if "SampleCount" not in self.stats:
             return None
 
         return self.calc_sample_count()
 
     @property
-    def sum(self) -> Optional[SupportsFloat]:
+    def sum(self) -> SupportsFloat | None:
         if "Sum" not in self.stats:
             return None
 
         return self.calc_sum()
 
     @property
-    def minimum(self) -> Optional[SupportsFloat]:
+    def minimum(self) -> SupportsFloat | None:
         if "Minimum" not in self.stats:
             return None
         if not self.metric_single_values_list and not self.metric_aggregated_list:
@@ -450,7 +450,7 @@ class Statistics:
         return min(metrics)
 
     @property
-    def maximum(self) -> Optional[SupportsFloat]:
+    def maximum(self) -> SupportsFloat | None:
         if "Maximum" not in self.stats:
             return None
 
@@ -463,7 +463,7 @@ class Statistics:
         return max(metrics)
 
     @property
-    def average(self) -> Optional[SupportsFloat]:
+    def average(self) -> SupportsFloat | None:
         if "Average" not in self.stats:
             return None
 
@@ -493,8 +493,8 @@ class InsightRule(BaseModel):
         definition: str,
         name: str,
         state: str,
-        schema: Optional[str],
-        managed_rule: Optional[bool],
+        schema: str | None,
+        managed_rule: bool | None,
     ):
         self.definition = definition
         self.name = name
@@ -541,18 +541,18 @@ class CloudWatchBackend(BaseBackend):
         description: str,
         dimensions: list[dict[str, str]],
         alarm_actions: list[str],
-        metric_data_queries: Optional[list[MetricDataQuery]] = None,
-        datapoints_to_alarm: Optional[int] = None,
-        extended_statistic: Optional[str] = None,
-        ok_actions: Optional[list[str]] = None,
-        insufficient_data_actions: Optional[list[str]] = None,
-        unit: Optional[str] = None,
+        metric_data_queries: list[MetricDataQuery] | None = None,
+        datapoints_to_alarm: int | None = None,
+        extended_statistic: str | None = None,
+        ok_actions: list[str] | None = None,
+        insufficient_data_actions: list[str] | None = None,
+        unit: str | None = None,
         actions_enabled: bool = True,
-        treat_missing_data: Optional[str] = None,
-        evaluate_low_sample_count_percentile: Optional[str] = None,
-        threshold_metric_id: Optional[str] = None,
-        rule: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        treat_missing_data: str | None = None,
+        evaluate_low_sample_count_percentile: str | None = None,
+        threshold_metric_id: str | None = None,
+        rule: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> Alarm:
         if extended_statistic and not extended_statistic.startswith("p"):
             raise InvalidParameterValue(
@@ -871,7 +871,7 @@ class CloudWatchBackend(BaseBackend):
         period: int,
         stats: list[str],
         dimensions: list[dict[str, str]],
-        unit: Optional[str] = None,
+        unit: str | None = None,
     ) -> list[Statistics]:
         start_time = start_time.replace(microsecond=0)
         end_time = end_time.replace(microsecond=0)
@@ -936,7 +936,7 @@ class CloudWatchBackend(BaseBackend):
             if key.startswith(prefix):
                 yield value
 
-    def delete_dashboards(self, dashboards: list[str]) -> Optional[str]:
+    def delete_dashboards(self, dashboards: list[str]) -> str | None:
         to_delete = set(dashboards)
         all_dashboards = set(self.dashboards.keys())
 
@@ -951,7 +951,7 @@ class CloudWatchBackend(BaseBackend):
 
         return None
 
-    def get_dashboard(self, dashboard: str) -> Optional[Dashboard]:
+    def get_dashboard(self, dashboard: str) -> Dashboard | None:
         return self.dashboards.get(dashboard)
 
     def set_alarm_state(
@@ -977,11 +977,11 @@ class CloudWatchBackend(BaseBackend):
 
     def list_metrics(
         self,
-        next_token: Optional[str],
+        next_token: str | None,
         namespace: str,
         metric_name: str,
         dimensions: list[dict[str, str]],
-    ) -> tuple[Optional[str], list[MetricDatumBase]]:
+    ) -> tuple[str | None, list[MetricDatumBase]]:
         if next_token:
             if next_token not in self.paged_metric_data:
                 raise InvalidParameterValue("Request parameter NextToken is invalid")
@@ -1028,7 +1028,7 @@ class CloudWatchBackend(BaseBackend):
 
     def _get_paginated(
         self, metrics: list[MetricDatumBase]
-    ) -> tuple[Optional[str], list[MetricDatumBase]]:
+    ) -> tuple[str | None, list[MetricDatumBase]]:
         if len(metrics) > 500:
             next_token = str(mock_random.uuid4())
             self.paged_metric_data[next_token] = metrics[500:]
@@ -1089,7 +1089,7 @@ class CloudWatchBackend(BaseBackend):
         name: str,
         state: str,
         definition: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> InsightRule:
         rule = InsightRule(
             account_id=self.account_id,
@@ -1109,8 +1109,8 @@ class CloudWatchBackend(BaseBackend):
 
     def describe_insight_rules(
         self,
-        next_token: Optional[str] = "",
-        max_results: Optional[int] = 500,
+        next_token: str | None = "",
+        max_results: int | None = 500,
     ) -> list[InsightRule]:
         rules = list(self.insight_rules.values())
 

--- a/moto/codebuild/models.py
+++ b/moto/codebuild/models.py
@@ -1,6 +1,6 @@
 import datetime
 from collections import defaultdict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -16,8 +16,8 @@ class CodeBuildProjectMetadata(BaseModel):
         account_id: str,
         region_name: str,
         project_name: str,
-        source_version: Optional[str],
-        artifacts: Optional[dict[str, Any]],
+        source_version: str | None,
+        artifacts: dict[str, Any] | None,
         build_id: str,
         service_role: str,
     ):
@@ -97,18 +97,18 @@ class CodeBuild(BaseModel):
         account_id: str,
         region: str,
         project_name: str,
-        description: Optional[str],
+        description: str | None,
         project_source: dict[str, Any],
         artifacts: dict[str, Any],
         environment: dict[str, Any],
         serviceRole: str = "some_role",
-        tags: Optional[list[dict[str, str]]] = None,
-        cache: Optional[dict[str, Any]] = None,
-        timeout: Optional[int] = 0,
-        queued_timeout: Optional[int] = 0,
-        source_version: Optional[str] = None,
-        logs_config: Optional[dict[str, Any]] = None,
-        vpc_config: Optional[dict[str, Any]] = None,
+        tags: list[dict[str, str]] | None = None,
+        cache: dict[str, Any] | None = None,
+        timeout: int | None = 0,
+        queued_timeout: int | None = 0,
+        source_version: str | None = None,
+        logs_config: dict[str, Any] | None = None,
+        vpc_config: dict[str, Any] | None = None,
     ):
         self.arn = f"arn:{get_partition(region)}:codebuild:{region}:{account_id}:project/{project_name}"
         self.service_role = serviceRole
@@ -161,18 +161,18 @@ class CodeBuildBackend(BaseBackend):
     def create_project(
         self,
         project_name: str,
-        description: Optional[str],
+        description: str | None,
         project_source: dict[str, Any],
         artifacts: dict[str, Any],
         environment: dict[str, Any],
         service_role: str,
-        tags: Optional[list[dict[str, str]]],
-        cache: Optional[dict[str, Any]],
-        timeout: Optional[int],
-        queued_timeout: Optional[int],
-        source_version: Optional[str],
-        logs_config: Optional[dict[str, Any]],
-        vpc_config: Optional[dict[str, Any]],
+        tags: list[dict[str, str]] | None,
+        cache: dict[str, Any] | None,
+        timeout: int | None,
+        queued_timeout: int | None,
+        source_version: str | None,
+        logs_config: dict[str, Any] | None,
+        vpc_config: dict[str, Any] | None,
     ) -> dict[str, Any]:
         self.codebuild_projects[project_name] = CodeBuild(
             self.account_id,
@@ -219,8 +219,8 @@ class CodeBuildBackend(BaseBackend):
     def start_build(
         self,
         project_name: str,
-        source_version: Optional[str] = None,
-        artifact_override: Optional[dict[str, Any]] = None,
+        source_version: str | None = None,
+        artifact_override: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         project = self.codebuild_projects[project_name]
         build_id = f"{project_name}:{mock_random.uuid4()}"
@@ -310,7 +310,7 @@ class CodeBuildBackend(BaseBackend):
         self.build_metadata.pop(project_name, None)
         self.codebuild_projects.pop(project_name, None)
 
-    def stop_build(self, build_id: str) -> Optional[dict[str, Any]]:  # type: ignore[return]
+    def stop_build(self, build_id: str) -> dict[str, Any] | None:  # type: ignore[return]
         for metadata in self.build_metadata_history.values():
             for build in metadata:
                 if build["id"] == build_id:

--- a/moto/codecommit/models.py
+++ b/moto/codecommit/models.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds
@@ -61,7 +59,7 @@ class CodeCommitBackend(BaseBackend):
 
         return repository.repository_metadata
 
-    def delete_repository(self, repository_name: str) -> Optional[str]:
+    def delete_repository(self, repository_name: str) -> str | None:
         repository = self.repositories.get(repository_name)
 
         if repository:

--- a/moto/codedeploy/models.py
+++ b/moto/codedeploy/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -59,8 +59,8 @@ class CodeDeployDefault(str, Enum):
 class AlarmConfiguration(BaseModel):
     def __init__(
         self,
-        alarms: Optional[list[dict[str, Any]]] = None,
-        enabled: Optional[bool] = False,
+        alarms: list[dict[str, Any]] | None = None,
+        enabled: bool | None = False,
         ignore_poll_alarm_failure: bool = False,
     ):
         self.alarms = alarms or []
@@ -73,23 +73,23 @@ class DeploymentGroup(BaseModel):
         self,
         application: Application,
         deployment_group_name: str,
-        deployment_config_name: Optional[str],
-        ec2_tag_filters: Optional[list[Any]],
-        on_premises_instance_tag_filters: Optional[list[Any]],
-        auto_scaling_groups: Optional[list[str]],
+        deployment_config_name: str | None,
+        ec2_tag_filters: list[Any] | None,
+        on_premises_instance_tag_filters: list[Any] | None,
+        auto_scaling_groups: list[str] | None,
         service_role_arn: str,
-        trigger_configurations: Optional[list[Any]],
-        alarm_configuration: Optional[AlarmConfiguration],
-        auto_rollback_configuration: Optional[dict[str, Any]],
-        outdated_instances_strategy: Optional[str],
-        deployment_style: Optional[Any],
-        blue_green_deployment_configuration: Optional[Any],
-        load_balancer_info: Optional[Any],
-        ec2_tag_set: Optional[Any],
-        ecs_services: Optional[list[Any]],
-        on_premises_tag_set: Optional[Any],
-        tags: Optional[list[dict[str, str]]],
-        termination_hook_enabled: Optional[bool],
+        trigger_configurations: list[Any] | None,
+        alarm_configuration: AlarmConfiguration | None,
+        auto_rollback_configuration: dict[str, Any] | None,
+        outdated_instances_strategy: str | None,
+        deployment_style: Any | None,
+        blue_green_deployment_configuration: Any | None,
+        load_balancer_info: Any | None,
+        ec2_tag_set: Any | None,
+        ecs_services: list[Any] | None,
+        on_premises_tag_set: Any | None,
+        tags: list[dict[str, str]] | None,
+        termination_hook_enabled: bool | None,
     ):
         self.application = application
         self.deployment_group_name = deployment_group_name
@@ -148,15 +148,15 @@ class DeploymentInfo(BaseModel):
         application: Application,
         deployment_group: DeploymentGroup,
         revision: str,
-        deployment_config_name: Optional[str],
-        description: Optional[str],
-        ignore_application_stop_failures: Optional[bool],
-        targetInstances: Optional[dict[str, Any]],
-        auto_rollback_configuration: Optional[dict[str, Any]],
-        update_outdated_instances_only: Optional[bool],
-        file_exists_behavior: Optional[str],
-        override_alarm_configuration: Optional[AlarmConfiguration],
-        creator: Optional[str],
+        deployment_config_name: str | None,
+        description: str | None,
+        ignore_application_stop_failures: bool | None,
+        targetInstances: dict[str, Any] | None,
+        auto_rollback_configuration: dict[str, Any] | None,
+        update_outdated_instances_only: bool | None,
+        file_exists_behavior: str | None,
+        override_alarm_configuration: AlarmConfiguration | None,
+        creator: str | None,
     ):
         self.application = application
         self.deployment_group = deployment_group
@@ -317,14 +317,14 @@ class CodeDeployBackend(BaseBackend):
         application_name: str,
         deployment_group_name: str,
         revision: str,
-        deployment_config_name: Optional[str] = None,
-        description: Optional[str] = None,
-        ignore_application_stop_failures: Optional[bool] = None,
-        target_instances: Optional[Any] = None,
-        auto_rollback_configuration: Optional[Any] = None,
-        update_outdated_instances_only: Optional[bool] = None,
-        file_exists_behavior: Optional[str] = None,
-        override_alarm_configuration: Optional[Any] = None,
+        deployment_config_name: str | None = None,
+        description: str | None = None,
+        ignore_application_stop_failures: bool | None = None,
+        target_instances: Any | None = None,
+        auto_rollback_configuration: Any | None = None,
+        update_outdated_instances_only: bool | None = None,
+        file_exists_behavior: str | None = None,
+        override_alarm_configuration: Any | None = None,
     ) -> str:
         if application_name not in self.applications:
             raise ApplicationDoesNotExistException(
@@ -385,23 +385,23 @@ class CodeDeployBackend(BaseBackend):
         self,
         application_name: str,
         deployment_group_name: str,
-        deployment_config_name: Optional[str],
-        ec2_tag_filters: Optional[list[dict[str, str]]],
-        on_premises_instance_tag_filters: Optional[list[dict[str, str]]],
-        auto_scaling_groups: Optional[list[str]],
+        deployment_config_name: str | None,
+        ec2_tag_filters: list[dict[str, str]] | None,
+        on_premises_instance_tag_filters: list[dict[str, str]] | None,
+        auto_scaling_groups: list[str] | None,
         service_role_arn: str,
-        trigger_configurations: Optional[list[dict[str, Any]]] = None,
-        alarm_configuration: Optional[AlarmConfiguration] = None,
-        auto_rollback_configuration: Optional[dict[str, Any]] = None,
-        outdated_instances_strategy: Optional[str] = None,
-        deployment_style: Optional[dict[str, str]] = None,
-        blue_green_deployment_configuration: Optional[dict[str, Any]] = None,
-        load_balancer_info: Optional[dict[str, Any]] = None,
-        ec2_tag_set: Optional[dict[str, Any]] = None,
-        ecs_services: Optional[list[dict[str, str]]] = None,
-        on_premises_tag_set: Optional[dict[str, Any]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        termination_hook_enabled: Optional[bool] = None,
+        trigger_configurations: list[dict[str, Any]] | None = None,
+        alarm_configuration: AlarmConfiguration | None = None,
+        auto_rollback_configuration: dict[str, Any] | None = None,
+        outdated_instances_strategy: str | None = None,
+        deployment_style: dict[str, str] | None = None,
+        blue_green_deployment_configuration: dict[str, Any] | None = None,
+        load_balancer_info: dict[str, Any] | None = None,
+        ec2_tag_set: dict[str, Any] | None = None,
+        ecs_services: list[dict[str, str]] | None = None,
+        on_premises_tag_set: dict[str, Any] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        termination_hook_enabled: bool | None = None,
     ) -> str:
         if application_name not in self.applications:
             raise ApplicationDoesNotExistException(

--- a/moto/cognitoidentity/models.py
+++ b/moto/cognitoidentity/models.py
@@ -2,7 +2,7 @@ import datetime
 import json
 import re
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -102,13 +102,13 @@ class CognitoIdentityBackend(BaseBackend):
         self,
         identity_pool_id: str,
         identity_pool_name: str,
-        allow_unauthenticated: Optional[bool],
-        login_providers: Optional[dict[str, str]],
-        provider_name: Optional[str],
-        provider_arns: Optional[list[str]],
-        identity_providers: Optional[list[dict[str, Any]]],
-        saml_providers: Optional[list[str]],
-        tags: Optional[dict[str, str]],
+        allow_unauthenticated: bool | None,
+        login_providers: dict[str, str] | None,
+        provider_name: str | None,
+        provider_arns: list[str] | None,
+        identity_providers: list[dict[str, Any]] | None,
+        saml_providers: list[str] | None,
+        tags: dict[str, str] | None,
     ) -> str:
         """
         The AllowClassic-parameter has not yet been implemented

--- a/moto/cognitoidp/exceptions.py
+++ b/moto/cognitoidp/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -11,7 +9,7 @@ class AliasExistsException(JsonRESTError):
 
 
 class ResourceNotFoundError(JsonRESTError):
-    def __init__(self, message: Optional[str]):
+    def __init__(self, message: str | None):
         super().__init__(error_type="ResourceNotFoundException", message=message or "")
 
 
@@ -31,7 +29,7 @@ class GroupExistsException(JsonRESTError):
 
 
 class NotAuthorizedError(JsonRESTError):
-    def __init__(self, message: Optional[str]):
+    def __init__(self, message: str | None):
         super().__init__(error_type="NotAuthorizedException", message=message or "")
 
 
@@ -46,7 +44,7 @@ class ExpiredCodeException(JsonRESTError):
 
 
 class InvalidParameterException(JsonRESTError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 400
         super().__init__(
             "InvalidParameterException", msg or "A parameter is specified incorrectly."

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import enum
 import re
 import time
 from collections import OrderedDict
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from cryptography.hazmat.primitives.twofactor import InvalidToken
 from joserfc import jwk, jwt
@@ -270,7 +272,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
         default_constraints: Any,
         show_empty_constraints: bool = False,
     ) -> None:
-        def numeric_limit(num: Optional[str], constraint_type: str) -> Optional[int]:
+        def numeric_limit(num: str | None, constraint_type: str) -> int | None:
             if not num:
                 return  # type: ignore[return-value]
             parsed = None
@@ -284,7 +286,7 @@ class CognitoIdpUserPoolAttribute(BaseModel):
                 )
             return parsed
 
-        self.string_constraints: Optional[dict[str, Any]] = (
+        self.string_constraints: dict[str, Any] | None = (
             {} if show_empty_constraints else None
         )
         self.number_constraints = None
@@ -412,8 +414,8 @@ class CognitoIdpUserPool(BaseModel):
         self.last_modified_date = utcnow()
 
         self.mfa_config = extended_config.get("MfaConfiguration") or "OFF"
-        self.sms_mfa_config: Optional[dict[str, Any]] = None
-        self.token_mfa_config: Optional[dict[str, bool]] = None
+        self.sms_mfa_config: dict[str, Any] | None = None
+        self.token_mfa_config: dict[str, bool] | None = None
 
         self.schema_attributes = {}
         for schema in self.extended_config.pop("Schema", {}):
@@ -440,7 +442,7 @@ class CognitoIdpUserPool(BaseModel):
         self.groups: dict[str, CognitoIdpGroup] = OrderedDict()
         self.users: dict[str, CognitoIdpUser] = OrderedDict()
         self.resource_servers: dict[str, CognitoResourceServer] = OrderedDict()
-        self.refresh_tokens: dict[str, Optional[tuple[str, str, str]]] = {}
+        self.refresh_tokens: dict[str, tuple[str, str, str] | None] = {}
         self.access_tokens: dict[str, tuple[str, str]] = {}
         self.id_tokens: dict[str, tuple[str, str]] = {}
 
@@ -448,11 +450,11 @@ class CognitoIdpUserPool(BaseModel):
         self.json_web_key = jwk.RSAKey.import_key(jwks_file)
 
     @property
-    def backend(self) -> "CognitoIdpBackend":
+    def backend(self) -> CognitoIdpBackend:
         return cognitoidp_backends[self.account_id][self.region]
 
     @property
-    def domain(self) -> Optional["CognitoIdpUserPoolDomain"]:
+    def domain(self) -> CognitoIdpUserPoolDomain | None:
         return next(
             (
                 upd
@@ -511,7 +513,7 @@ class CognitoIdpUserPool(BaseModel):
             user_pool_json["Domain"] = self.domain.domain
         return user_pool_json
 
-    def _get_user(self, username: str) -> "CognitoIdpUser":
+    def _get_user(self, username: str) -> CognitoIdpUser:
         """Find a user within a user pool by Username or any UsernameAttributes
         (`email` or `phone_number` or both)"""
         if self.extended_config.get("UsernameAttributes"):
@@ -531,7 +533,7 @@ class CognitoIdpUserPool(BaseModel):
         username: str,
         token_use: str,
         expires_in: int = 60 * 60,
-        extra_data: Optional[dict[str, Any]] = None,
+        extra_data: dict[str, Any] | None = None,
     ) -> tuple[str, int]:
         now = int(time.time())
         payload = {
@@ -682,7 +684,7 @@ class CognitoIdpUserPoolDomain(BaseModel):
         self,
         user_pool_id: str,
         domain: str,
-        custom_domain_config: Optional[dict[str, Any]] = None,
+        custom_domain_config: dict[str, Any] | None = None,
     ):
         self.user_pool_id = user_pool_id
         self.domain = domain
@@ -720,7 +722,7 @@ class CognitoIdpUserPoolClient(BaseModel):
         self,
         user_pool_id: str,
         generate_secret: bool,
-        extended_config: Optional[dict[str, Any]],
+        extended_config: dict[str, Any] | None,
     ):
         self.user_pool_id = user_pool_id
         self.id = generate_id(
@@ -762,7 +764,7 @@ class CognitoIdpUserPoolClient(BaseModel):
 
 
 class CognitoIdpIdentityProvider(BaseModel):
-    def __init__(self, name: str, extended_config: Optional[dict[str, Any]]):
+    def __init__(self, name: str, extended_config: dict[str, Any] | None):
         self.name = name
         self.extended_config = extended_config or {}
         self.creation_date = utcnow()
@@ -810,9 +812,9 @@ class CognitoIdpGroup(BaseModel):
 
     def update(
         self,
-        description: Optional[str],
-        role_arn: Optional[str],
-        precedence: Optional[int],
+        description: str | None,
+        role_arn: str | None,
+        precedence: int | None,
     ) -> None:
         if description is not None:
             self.description = description
@@ -838,8 +840,8 @@ class CognitoIdpUser(BaseModel):
     def __init__(
         self,
         user_pool_id: str,
-        username: Optional[str],
-        password: Optional[str],
+        username: str | None,
+        password: str | None,
         status: str,
         attributes: list[dict[str, str]],
     ):
@@ -856,8 +858,8 @@ class CognitoIdpUser(BaseModel):
         self.sms_mfa_enabled = False
         self.software_token_mfa_enabled = False
         self.token_verified = False
-        self.confirmation_code: Optional[str] = None
-        self.preferred_mfa_setting: Optional[str] = None
+        self.confirmation_code: str | None = None
+        self.preferred_mfa_setting: str | None = None
 
         # Groups this user is a member of.
         # Note that these links are bidirectional.
@@ -882,7 +884,7 @@ class CognitoIdpUser(BaseModel):
         self,
         extended: bool = False,
         attributes_key: str = "Attributes",
-        attributes_to_get: Optional[list[str]] = None,
+        attributes_to_get: list[str] | None = None,
     ) -> dict[str, Any]:
         user_mfa_setting_list = []
         if self.software_token_mfa_enabled:
@@ -1051,7 +1053,7 @@ class CognitoIdpBackend(BaseBackend):
         self,
         user_pool_id: str,
         domain: str,
-        custom_domain_config: Optional[dict[str, str]] = None,
+        custom_domain_config: dict[str, str] | None = None,
     ) -> CognitoIdpUserPoolDomain:
         self.describe_user_pool(user_pool_id)
 
@@ -1061,9 +1063,7 @@ class CognitoIdpBackend(BaseBackend):
         self.user_pool_domains[domain] = user_pool_domain
         return user_pool_domain
 
-    def describe_user_pool_domain(
-        self, domain: str
-    ) -> Optional[CognitoIdpUserPoolDomain]:
+    def describe_user_pool_domain(self, domain: str) -> CognitoIdpUserPoolDomain | None:
         if domain not in self.user_pool_domains:
             return None
 
@@ -1772,7 +1772,7 @@ class CognitoIdpBackend(BaseBackend):
 
     def forgot_password(
         self, client_id: str, username: str
-    ) -> tuple[Optional[str], dict[str, Any]]:
+    ) -> tuple[str | None, dict[str, Any]]:
         """
         The ForgotPassword operation is partially broken in AWS. If the input is 100% correct it works fine.
 
@@ -1790,7 +1790,7 @@ class CognitoIdpBackend(BaseBackend):
         else:
             raise ResourceNotFoundError("Username/client id combination not found.")
 
-        confirmation_code: Optional[str] = None
+        confirmation_code: str | None = None
         if user:
             # An unfortunate bit of magic - confirmation_code is opt-in, as it's returned
             # via a "x-moto-forgot-password-confirmation-code" http header, which is not the AWS way (should be SES, SNS, Cognito built-in email)
@@ -1807,7 +1807,7 @@ class CognitoIdpBackend(BaseBackend):
         return confirmation_code, {"CodeDeliveryDetails": code_delivery_details}
 
     def _get_code_delivery_details(
-        self, recovery_settings: Any, user: Optional[CognitoIdpUser], username: str
+        self, recovery_settings: Any, user: CognitoIdpUser | None, username: str
     ) -> dict[str, str]:
         selected_recovery = min(
             recovery_settings["RecoveryMechanisms"],
@@ -2046,7 +2046,7 @@ class CognitoIdpBackend(BaseBackend):
             auth_flow=auth_flow, valid_flows=user_auth_flows
         )
 
-        user_pool: Optional[CognitoIdpUserPool] = None
+        user_pool: CognitoIdpUserPool | None = None
         client: CognitoIdpUserPoolClient = None  # type: ignore[assignment]
         for p in self.user_pools.values():
             if client_id in p.clients:
@@ -2376,12 +2376,10 @@ class CognitoIdpBackend(BaseBackend):
 
         raise NotAuthorizedError(access_token)
 
-    def _find_attr(self, name: str, attrs: list[dict[str, str]]) -> Optional[str]:
+    def _find_attr(self, name: str, attrs: list[dict[str, str]]) -> str | None:
         return next((a["Value"] for a in attrs if a["Name"] == name), None)
 
-    def _verify_email_is_not_used(
-        self, user_pool_id: str, email: Optional[str]
-    ) -> None:
+    def _verify_email_is_not_used(self, user_pool_id: str, email: str | None) -> None:
         if not email:
             # We're not updating emails
             return

--- a/moto/cognitoidp/utils.py
+++ b/moto/cognitoidp/utils.py
@@ -3,7 +3,7 @@ import hashlib
 import hmac
 import re
 import string
-from typing import Any, Optional
+from typing import Any
 
 from cryptography.hazmat.primitives.hashes import SHA1
 from cryptography.hazmat.primitives.twofactor.totp import TOTP
@@ -78,7 +78,7 @@ def check_secret_hash(
     app_client_secret: str,
     app_client_id: str,
     username: str,
-    secret_hash: Optional[str],
+    secret_hash: str | None,
 ) -> bool:
     key = bytes(str(app_client_secret).encode("latin-1"))
     msg = bytes(str(username + app_client_id).encode("latin-1"))
@@ -105,7 +105,7 @@ def expand_attrs(attrs: dict[str, Any]) -> list[dict[str, Any]]:
 ID_HASH_STRATEGY = "HASH"
 
 
-def generate_id(strategy: Optional[str], *args: Any) -> str:
+def generate_id(strategy: str | None, *args: Any) -> str:
     if strategy == ID_HASH_STRATEGY:
         return _generate_id_hash(args)
     else:

--- a/moto/comprehend/models.py
+++ b/moto/comprehend/models.py
@@ -4,7 +4,7 @@ import random
 import uuid
 from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -239,11 +239,11 @@ class ComprehendJob(BaseModel):
         account_id: str,
         region_name: str,
         job_type: str,
-        job_name: Optional[str],
+        job_name: str | None,
         input_s3_config: dict[str, Any],
         output_s3_config: dict[str, Any],
         data_access_role_arn: str,
-        language_code: Optional[str],
+        language_code: str | None,
         **kwargs: Any,
     ):
         self.job_id = str(uuid.uuid4())
@@ -537,9 +537,9 @@ class ComprehendBackend(BaseBackend):
 
     def list_document_classifiers(
         self,
-        filter: Optional[dict[str, Any]] = None,
-        next_token: Optional[str] = None,
-        max_results: Optional[int] = None,
+        filter: dict[str, Any] | None = None,
+        next_token: str | None = None,
+        max_results: int | None = None,
     ) -> tuple[list[dict[str, Any]], None]:
         """
         List document classifiers with optional filtering.
@@ -568,9 +568,9 @@ class ComprehendBackend(BaseBackend):
 
     def list_endpoints(
         self,
-        filter: Optional[dict[str, Any]] = None,
-        next_token: Optional[str] = None,
-        max_results: Optional[int] = None,
+        filter: dict[str, Any] | None = None,
+        next_token: str | None = None,
+        max_results: int | None = None,
     ) -> tuple[list[dict[str, Any]], None]:
         """
         List endpoints with optional filtering.
@@ -597,9 +597,9 @@ class ComprehendBackend(BaseBackend):
 
     def list_flywheels(
         self,
-        filter: Optional[dict[str, Any]] = None,
-        next_token: Optional[str] = None,
-        max_results: Optional[int] = None,
+        filter: dict[str, Any] | None = None,
+        next_token: str | None = None,
+        max_results: int | None = None,
     ) -> tuple[list[dict[str, Any]], None]:
         """
         List flywheels with optional filtering.
@@ -650,7 +650,7 @@ class ComprehendBackend(BaseBackend):
         self,
         resource_arn: str,
         resource_policy: str,
-        policy_revision_id: Optional[str] = None,
+        policy_revision_id: str | None = None,
     ) -> str:
         """
         The PolicyRevisionId-parameter for conditional updates is not yet implemented.
@@ -678,7 +678,7 @@ class ComprehendBackend(BaseBackend):
         return policy_details
 
     def delete_resource_policy(
-        self, resource_arn: str, policy_revision_id: Optional[str] = None
+        self, resource_arn: str, policy_revision_id: str | None = None
     ) -> None:
         """
         The PolicyRevisionId-parameter for conditional deletion is not yet implemented.
@@ -719,7 +719,7 @@ class ComprehendBackend(BaseBackend):
         return self.jobs[job_id]
 
     def _list_jobs(
-        self, job_type: str, job_filter: Optional[dict[str, Any]]
+        self, job_type: str, job_filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         """Generic method to list and filter jobs."""
         # Pagination is not yet implemented
@@ -752,7 +752,7 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_pii_entities_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("PiiEntitiesDetection", filter)
 
@@ -766,7 +766,7 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_key_phrases_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("KeyPhrasesDetection", filter)
 
@@ -780,7 +780,7 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_sentiment_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("SentimentDetection", filter)
 
@@ -794,7 +794,7 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_dominant_language_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("DominantLanguageDetection", filter)
 
@@ -808,7 +808,7 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_entities_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("EntitiesDetection", filter)
 
@@ -819,7 +819,7 @@ class ComprehendBackend(BaseBackend):
         return self._get_job(job_id)
 
     def list_topics_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("TopicsDetection", filter)
 
@@ -830,7 +830,7 @@ class ComprehendBackend(BaseBackend):
         return self._get_job(job_id)
 
     def list_document_classification_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("DocumentClassification", filter)
 
@@ -848,7 +848,7 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_events_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("EventsDetection", filter)
 
@@ -862,7 +862,7 @@ class ComprehendBackend(BaseBackend):
         self._get_job(job_id).stop()
 
     def list_targeted_sentiment_detection_jobs(
-        self, filter: Optional[dict[str, Any]]
+        self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("TargetedSentimentDetection", filter)
 

--- a/moto/config/exceptions.py
+++ b/moto/config/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.exceptions import JsonRESTError
 
@@ -18,7 +18,7 @@ class NameTooLongException(JsonRESTError):
 class InvalidConfigurationRecorderNameException(JsonRESTError):
     code = 400
 
-    def __init__(self, name: Optional[str]):
+    def __init__(self, name: str | None):
         message = (
             f"The configuration recorder name '{name}' is not valid, blank string."
         )
@@ -84,7 +84,7 @@ class NoSuchConfigurationRecorderException(JsonRESTError):
 class InvalidDeliveryChannelNameException(JsonRESTError):
     code = 400
 
-    def __init__(self, name: Optional[str]):
+    def __init__(self, name: str | None):
         message = f"The delivery channel name '{name}' is not valid, blank string."
         super().__init__("InvalidDeliveryChannelNameException", message)
 
@@ -136,7 +136,7 @@ class InvalidSNSTopicARNException(JsonRESTError):
 class InvalidDeliveryFrequency(JsonRESTError):
     code = 400
 
-    def __init__(self, value: Optional[str], good_list: Any):
+    def __init__(self, value: str | None, good_list: Any):
         message = (
             f"1 validation error detected: Value '{value}' at "
             "'deliveryChannel.configSnapshotDeliveryProperties.deliveryFrequency' failed to satisfy "

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -4,7 +4,7 @@ import json
 import re
 import time
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.config.exceptions import (
     DuplicateTags,
@@ -231,12 +231,12 @@ class ConfigRecorderStatus(ConfigEmptyDictable):
 
         self.name = name
         self.recording = False
-        self.last_start_time: Optional[int] = None
-        self.last_stop_time: Optional[int] = None
-        self.last_status: Optional[str] = None
-        self.last_error_code: Optional[str] = None
-        self.last_error_message: Optional[str] = None
-        self.last_status_change_time: Optional[int] = None
+        self.last_start_time: int | None = None
+        self.last_stop_time: int | None = None
+        self.last_status: str | None = None
+        self.last_error_code: str | None = None
+        self.last_error_message: str | None = None
+        self.last_status_change_time: int | None = None
 
     def start(self) -> None:
         self.recording = True
@@ -262,10 +262,10 @@ class ConfigDeliveryChannel(ConfigEmptyDictable):
         self,
         name: str,
         s3_bucket_name: str,
-        prefix: Optional[str] = None,
-        sns_arn: Optional[str] = None,
-        s3_kms_key_arn: Optional[str] = None,
-        snapshot_properties: Optional[ConfigDeliverySnapshotProperties] = None,
+        prefix: str | None = None,
+        sns_arn: str | None = None,
+        s3_kms_key_arn: str | None = None,
+        snapshot_properties: ConfigDeliverySnapshotProperties | None = None,
     ):
         super().__init__()
 
@@ -293,9 +293,9 @@ class RecordingGroup(ConfigEmptyDictable):
         self,
         all_supported: bool = True,
         include_global_resource_types: bool = False,
-        resource_types: Optional[list[str]] = None,
-        exclusion_by_resource_types: Optional[dict[str, list[str]]] = None,
-        recording_strategy: Optional[dict[str, str]] = None,
+        resource_types: list[str] | None = None,
+        exclusion_by_resource_types: dict[str, list[str]] | None = None,
+        recording_strategy: dict[str, str] | None = None,
     ):
         super().__init__()
 
@@ -312,7 +312,7 @@ class ConfigRecorder(ConfigEmptyDictable):
         role_arn: str,
         recording_group: RecordingGroup,
         name: str = "default",
-        status: Optional[ConfigRecorderStatus] = None,
+        status: ConfigRecorderStatus | None = None,
     ):
         super().__init__()
 
@@ -330,8 +330,8 @@ class AccountAggregatorSource(ConfigEmptyDictable):
     def __init__(
         self,
         account_ids: list[str],
-        aws_regions: Optional[list[str]] = None,
-        all_aws_regions: Optional[bool] = None,
+        aws_regions: list[str] | None = None,
+        all_aws_regions: bool | None = None,
     ):
         super().__init__(capitalize_start=True)
 
@@ -363,8 +363,8 @@ class OrganizationAggregationSource(ConfigEmptyDictable):
     def __init__(
         self,
         role_arn: str,
-        aws_regions: Optional[list[str]] = None,
-        all_aws_regions: Optional[bool] = None,
+        aws_regions: list[str] | None = None,
+        all_aws_regions: bool | None = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
@@ -397,9 +397,9 @@ class ConfigAggregator(ConfigEmptyDictable):
         name: str,
         account_id: str,
         region: str,
-        account_sources: Optional[list[AccountAggregatorSource]] = None,
-        org_source: Optional[OrganizationAggregationSource] = None,
-        tags: Optional[dict[str, str]] = None,
+        account_sources: list[AccountAggregatorSource] | None = None,
+        org_source: OrganizationAggregationSource | None = None,
+        tags: dict[str, str] | None = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
@@ -458,9 +458,9 @@ class OrganizationConformancePack(ConfigEmptyDictable):
         region: str,
         name: str,
         delivery_s3_bucket: str,
-        delivery_s3_key_prefix: Optional[str] = None,
-        input_parameters: Optional[list[dict[str, Any]]] = None,
-        excluded_accounts: Optional[list[str]] = None,
+        delivery_s3_key_prefix: str | None = None,
+        input_parameters: list[dict[str, Any]] | None = None,
+        excluded_accounts: list[str] | None = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
@@ -505,10 +505,10 @@ class Scope(ConfigEmptyDictable):
 
     def __init__(
         self,
-        compliance_resource_types: Optional[list[str]] = None,
-        tag_key: Optional[str] = None,
-        tag_value: Optional[str] = None,
-        compliance_resource_id: Optional[str] = None,
+        compliance_resource_types: list[str] | None = None,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+        compliance_resource_id: str | None = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
         self.tags = None
@@ -563,9 +563,9 @@ class SourceDetail(ConfigEmptyDictable):
 
     def __init__(
         self,
-        event_source: Optional[str] = None,
-        message_type: Optional[str] = None,
-        maximum_execution_frequency: Optional[str] = None,
+        event_source: str | None = None,
+        message_type: str | None = None,
+        maximum_execution_frequency: str | None = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
@@ -645,7 +645,7 @@ class Source(ConfigEmptyDictable):
         region: str,
         owner: str,
         source_identifier: str,
-        source_details: Optional[SourceDetail] = None,
+        source_details: SourceDetail | None = None,
     ):
         super().__init__(capitalize_start=True, capitalize_arn=False)
         if owner not in Source.OWNERS:
@@ -899,7 +899,7 @@ class ConfigRule(ConfigEmptyDictable):
 
 
 class RetentionConfiguration(ConfigEmptyDictable):
-    def __init__(self, retention_period_in_days: int, name: Optional[str] = None):
+    def __init__(self, retention_period_in_days: int, name: str | None = None):
         super().__init__(capitalize_start=True, capitalize_arn=False)
 
         self.name = name or "default"
@@ -917,7 +917,7 @@ class ConfigBackend(BaseBackend):
         self.config_schema = get_service_model("config")
         self.query_results: dict[str, list[dict[str, Any]]] = {}
         self.query_results_queue: list[list[dict[str, Any]]] = []
-        self.retention_configuration: Optional[RetentionConfiguration] = None
+        self.retention_configuration: RetentionConfiguration | None = None
         self._custom_resources: dict[str, dict[str, Any]] = {}
         self._expression_results: dict[str, list[dict[str, Any]]] = {}
         self.config_rules: dict[str, ConfigRule] = {}
@@ -953,8 +953,8 @@ class ConfigBackend(BaseBackend):
         if len(config_aggr_name) > 256:
             raise NameTooLongException(config_aggr_name, "configurationAggregatorName")
 
-        account_sources: Optional[list[AccountAggregatorSource]] = None
-        org_source: Optional[OrganizationAggregationSource] = None
+        account_sources: list[AccountAggregatorSource] | None = None
+        org_source: OrganizationAggregationSource | None = None
 
         # Tag validation:
         tags = validate_tags(config_aggregator.get("Tags", []))
@@ -1032,7 +1032,7 @@ class ConfigBackend(BaseBackend):
         return aggregator.to_dict()
 
     def describe_configuration_aggregators(
-        self, names: list[str], token: str, limit: Optional[int]
+        self, names: list[str], token: str, limit: int | None
     ) -> dict[str, Any]:
         limit = DEFAULT_PAGE_SIZE if not limit or limit < 0 else limit
         agg_list = []
@@ -1110,7 +1110,7 @@ class ConfigBackend(BaseBackend):
         return agg_auth.to_dict()
 
     def describe_aggregation_authorizations(
-        self, token: Optional[str], limit: Optional[int]
+        self, token: str | None, limit: int | None
     ) -> dict[str, Any]:
         limit = DEFAULT_PAGE_SIZE if not limit or limit < 0 else limit
         result: dict[str, Any] = {"AggregationAuthorizations": []}
@@ -1285,7 +1285,7 @@ class ConfigBackend(BaseBackend):
         )
 
     def describe_configuration_recorders(
-        self, recorder_names: Optional[list[str]]
+        self, recorder_names: list[str] | None
     ) -> list[dict[str, Any]]:
         recorders: list[dict[str, Any]] = []
 
@@ -1532,8 +1532,8 @@ class ConfigBackend(BaseBackend):
         aggregator_name: str,
         resource_type: str,
         filters: dict[str, str],
-        limit: Optional[int],
-        next_token: Optional[str],
+        limit: int | None,
+        next_token: str | None,
     ) -> dict[str, Any]:
         """Queries AWS Config listing function that must exist for resource backend.
 
@@ -1774,9 +1774,9 @@ class ConfigBackend(BaseBackend):
 
     def put_evaluations(
         self,
-        evaluations: Optional[list[dict[str, Any]]] = None,
-        result_token: Optional[str] = None,
-        test_mode: Optional[bool] = False,
+        evaluations: list[dict[str, Any]] | None = None,
+        result_token: str | None = None,
+        test_mode: bool | None = False,
     ) -> dict[str, list[Any]]:
         if not evaluations:
             raise InvalidParameterValueException(
@@ -1933,7 +1933,7 @@ class ConfigBackend(BaseBackend):
 
     def _match_arn(
         self, resource_arn: str
-    ) -> Union[ConfigRule, ConfigAggregator, ConfigAggregationAuthorization]:
+    ) -> ConfigRule | ConfigAggregator | ConfigAggregationAuthorization:
         """Return config instance that has a matching ARN."""
         # The allowed resources are ConfigRule, ConfigurationAggregator,
         # and AggregatorAuthorization.
@@ -2002,7 +2002,7 @@ class ConfigBackend(BaseBackend):
         }
 
     def put_config_rule(
-        self, config_rule: dict[str, Any], tags: Optional[list[dict[str, str]]] = None
+        self, config_rule: dict[str, Any], tags: list[dict[str, str]] | None = None
     ) -> str:
         """Add/Update config rule for evaluating resource compliance.
 
@@ -2066,7 +2066,7 @@ class ConfigBackend(BaseBackend):
         return ""
 
     def describe_config_rules(
-        self, config_rule_names: Optional[list[str]], next_token: Optional[str]
+        self, config_rule_names: list[str] | None, next_token: str | None
     ) -> dict[str, Any]:
         """Return details for the given ConfigRule names or for all rules."""
         result: dict[str, Any] = {"ConfigRules": []}
@@ -2130,7 +2130,7 @@ class ConfigBackend(BaseBackend):
         return {"RetentionConfiguration": self.retention_configuration.to_dict()}
 
     def describe_retention_configurations(
-        self, retention_configuration_names: Optional[list[str]]
+        self, retention_configuration_names: list[str] | None
     ) -> list[dict[str, Any]]:
         """
         This will return the retention configuration if one is present.
@@ -2176,9 +2176,9 @@ class ConfigBackend(BaseBackend):
     def select_resource_config(
         self,
         expression: str,
-        limit: Optional[int] = None,
-        next_token: Optional[str] = None,
-    ) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, str]]], Optional[str]]:
+        limit: int | None = None,
+        next_token: str | None = None,
+    ) -> tuple[list[dict[str, Any]], dict[str, list[dict[str, str]]], str | None]:
         """
         This method doesn't actually execute SQL but uses predefined results
         that can be configured through the moto API. Modeled after AWS Athena's approach.
@@ -2211,7 +2211,7 @@ class ConfigBackend(BaseBackend):
         resource_id: str,
         resource_name: str,
         configuration: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> None:
         if resource_type.split("::")[0].lower() in [
             "amzn",

--- a/moto/connect/models.py
+++ b/moto/connect/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -37,8 +37,8 @@ class Instance(BaseModel):
         outbound_calls_enabled: bool,
         account_id: str,
         region: str,
-        instance_alias: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        instance_alias: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> None:
         self.id = str(uuid.uuid4())
         self.arn = f"arn:aws:connect:{region}:{account_id}:instance/{self.id}"
@@ -155,8 +155,8 @@ class ConnectBackend(BaseBackend):
         identity_management_type: str,
         inbound_calls_enabled: bool,
         outbound_calls_enabled: bool,
-        instance_alias: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        instance_alias: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> dict[str, str]:
         """Create a new Connect instance."""
         if not identity_management_type:
@@ -194,8 +194,8 @@ class ConnectBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
     def list_instances(
         self,
-        max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
+        max_results: int | None = None,
+        next_token: str | None = None,
     ) -> list[dict[str, str]]:
         sorted_instances = sorted(
             self.instances.values(),
@@ -218,7 +218,7 @@ class ConnectBackend(BaseBackend):
         self,
         instance_id: str,
         data_set_id: str,
-        target_account_id: Optional[str] = None,
+        target_account_id: str | None = None,
     ) -> dict[str, str]:
         """Associate an analytics data set with a Connect instance.
 
@@ -292,9 +292,9 @@ class ConnectBackend(BaseBackend):
     def list_analytics_data_associations(
         self,
         instance_id: str,
-        data_set_id: Optional[str] = None,
-        max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
+        data_set_id: str | None = None,
+        max_results: int | None = None,
+        next_token: str | None = None,
     ) -> list[dict[str, str]]:
         """List analytics data associations for a Connect instance."""
         if not instance_id:

--- a/moto/connect/responses.py
+++ b/moto/connect/responses.py
@@ -1,7 +1,7 @@
 """Handles incoming connect requests, invokes methods, returns responses."""
 
 import json
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core.responses import BaseResponse
@@ -58,7 +58,7 @@ class ConnectResponse(BaseResponse):
         next_token = self._get_param("nextToken")
 
         results: list[dict[str, str]]
-        token: Optional[str]
+        token: str | None
         results, token = self.connect_backend.list_analytics_data_associations(
             instance_id=instance_id,
             data_set_id=data_set_id,
@@ -102,7 +102,7 @@ class ConnectResponse(BaseResponse):
         next_token = self._get_param("nextToken")
 
         results: list[dict[str, Any]]
-        token: Optional[str]
+        token: str | None
         results, token = self.connect_backend.list_instances(
             max_results=max_results,
             next_token=next_token,

--- a/moto/connectcampaigns/models.py
+++ b/moto/connectcampaigns/models.py
@@ -1,7 +1,7 @@
 """ConnectCampaignServiceBackend class with methods for supported APIs."""
 
 import uuid
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import unquote
 
 from moto.core import DEFAULT_ACCOUNT_ID
@@ -31,7 +31,7 @@ class ConnectCampaign(BaseModel):
         dialer_config: dict[str, Any],
         outbound_call_config: dict[str, Any],
         region: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> None:
         self.id = str(uuid.uuid4())
         self.name = name
@@ -86,7 +86,7 @@ class ConnectInstanceOnboardingJobStatus(BaseModel):
         self,
         connect_instance_id: str,
         status: str = "SUCCEEDED",
-        failure_code: Optional[str] = None,
+        failure_code: str | None = None,
     ) -> None:
         self.connect_instance_id = connect_instance_id
         self.status = status
@@ -115,7 +115,7 @@ class ConnectCampaignServiceBackend(BaseBackend):
         connect_instance_id: str,
         dialer_config: dict[str, Any],
         outbound_call_config: dict[str, Any],
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> tuple[str, str, dict[str, str]]:
         campaign = ConnectCampaign(
             name=name,
@@ -230,9 +230,9 @@ class ConnectCampaignServiceBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_campaigns(
         self,
-        filters: Optional[dict[str, dict[str, str]]],
-        max_results: Optional[int],
-        next_token: Optional[str],
+        filters: dict[str, dict[str, str]] | None,
+        max_results: int | None,
+        next_token: str | None,
     ) -> list[dict[str, str]]:
         filtered_campaigns = list(self.campaigns.values())
 

--- a/moto/connectcampaigns/responses.py
+++ b/moto/connectcampaigns/responses.py
@@ -1,7 +1,6 @@
 """Handles incoming connectcampaigns requests, invokes methods, returns responses."""
 
 import json
-from typing import Optional
 
 from moto.core.responses import BaseResponse
 
@@ -139,7 +138,7 @@ class ConnectCampaignServiceResponse(BaseResponse):
         next_token = self._get_param("nextToken")
         filters = self._get_param("filters", {})
 
-        campaigns_result: tuple[list[dict[str, str]], Optional[str]] = (
+        campaigns_result: tuple[list[dict[str, str]], str | None] = (
             self.connectcampaigns_backend.list_campaigns(
                 filters=filters,
                 max_results=max_results,

--- a/moto/core/authorization.py
+++ b/moto/core/authorization.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager
 from typing import (
     TYPE_CHECKING,
     ClassVar,
-    Optional,
     TypeVar,
 )
 from urllib.parse import urlparse
@@ -71,7 +70,7 @@ class ActionAuthenticatorMixin:
         self._authenticate_and_authorize_action(IAMRequest, resource)
 
     def _authenticate_and_authorize_s3_action(
-        self, bucket_name: Optional[str] = None, key_name: Optional[str] = None
+        self, bucket_name: str | None = None, key_name: str | None = None
     ) -> None:
         arn = f"{bucket_name or '*'}/{key_name}" if key_name else (bucket_name or "*")
         resource = f"arn:{get_partition(self.region)}:s3:::{arn}"  # type: ignore[attr-defined]

--- a/moto/core/base_backend.py
+++ b/moto/core/base_backend.py
@@ -7,7 +7,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
-    Optional,
     TypeVar,
 )
 from uuid import uuid4
@@ -145,7 +144,7 @@ class BaseBackend:
         private_dns_names: bool = True,
         special_service_name: str = "",
         policy_supported: bool = True,
-        base_endpoint_dns_names: Optional[list[str]] = None,
+        base_endpoint_dns_names: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """List of dicts representing default VPC endpoints for this service."""
         if special_service_name:
@@ -203,7 +202,7 @@ class AccountSpecificBackend(dict[str, SERVICE_BACKEND]):
         account_id: str,
         backend: type,
         use_boto3_regions: bool,
-        additional_regions: Optional[list[str]],
+        additional_regions: list[str] | None,
     ):
         self._id = str(uuid4())
         self.service_name = service_name
@@ -328,7 +327,7 @@ class BackendDict(dict[str, AccountSpecificBackend[SERVICE_BACKEND]]):
         backend: type[SERVICE_BACKEND],
         service_name: str,
         use_boto3_regions: bool = True,
-        additional_regions: Optional[list[str]] = None,
+        additional_regions: list[str] | None = None,
     ):
         self.backend = backend
         self.service_name = service_name

--- a/moto/core/botocore_stubber.py
+++ b/moto/core/botocore_stubber.py
@@ -1,6 +1,6 @@
 import re
 from io import BytesIO
-from typing import Any, Optional, Union
+from typing import Any
 
 from botocore.awsrequest import AWSResponse
 
@@ -13,7 +13,7 @@ from moto.core.utils import get_equivalent_url_in_aws_domain
 
 
 class MockRawResponse(BytesIO):
-    def __init__(self, response_input: Union[str, bytes]):
+    def __init__(self, response_input: str | bytes):
         if isinstance(response_input, str):
             response_input = response_input.encode("utf-8")
         super().__init__(response_input)
@@ -31,7 +31,7 @@ class BotocoreStubber:
 
     def __call__(
         self, event_name: str, request: Any, **kwargs: Any
-    ) -> Optional[AWSResponse]:
+    ) -> AWSResponse | None:
         if not self.enabled:
             return None
 
@@ -42,7 +42,7 @@ class BotocoreStubber:
         else:
             return response
 
-    def process_request(self, request: Any) -> Optional[TYPE_RESPONSE]:
+    def process_request(self, request: Any) -> TYPE_RESPONSE | None:
         # Handle non-standard AWS endpoint hostnames from ISO regions or custom
         # S3 endpoints.
         parsed_url, _ = get_equivalent_url_in_aws_domain(request.url)

--- a/moto/core/common_models.py
+++ b/moto/core/common_models.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Generic, Optional
+from typing import Any, Generic
 
 from .base_backend import SERVICE_BACKEND, BackendDict, InstanceTrackerMeta
 
@@ -105,14 +105,14 @@ class ConfigQueryModel(Generic[SERVICE_BACKEND]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[list[str]],
-        resource_name: Optional[str],
+        resource_ids: list[str] | None,
+        resource_name: str | None,
         limit: int,
-        next_token: Optional[str],
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-        aggregator: Optional[dict[str, Any]] = None,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        next_token: str | None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+        aggregator: dict[str, Any] | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         """For AWS Config. This will list all of the resources of the given type and optional resource name and region.
 
         This supports both aggregated and non-aggregated listing. The following notes the difference:
@@ -167,10 +167,10 @@ class ConfigQueryModel(Generic[SERVICE_BACKEND]):
         account_id: str,
         partition: str,
         resource_id: str,
-        resource_name: Optional[str] = None,
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        resource_name: str | None = None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+    ) -> dict[str, Any] | None:
         """For AWS Config. This will query the backend for the specific resource type configuration.
 
         This supports both aggregated, and non-aggregated fetching -- for batched fetching -- the Config batching requests

--- a/moto/core/common_types.py
+++ b/moto/core/common_types.py
@@ -1,4 +1,4 @@
-from typing import Any, TypeVar, Union
+from typing import Any, TypeVar
 
-TYPE_RESPONSE = tuple[int, dict[str, Any], Union[str, bytes]]
+TYPE_RESPONSE = tuple[int, dict[str, Any], str | bytes]
 TYPE_IF_NONE = TypeVar("TYPE_IF_NONE")

--- a/moto/core/config.py
+++ b/moto/core/config.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 
 class _docker_config(TypedDict, total=False):
@@ -15,7 +15,7 @@ class _core_config(TypedDict, total=False):
     mock_credentials: bool
     passthrough: _passthrough_config
     reset_boto3_session: bool
-    service_whitelist: Optional[list[str]]
+    service_whitelist: list[str] | None
 
 
 class _iam_config(TypedDict, total=False):

--- a/moto/core/custom_responses_mock.py
+++ b/moto/core/custom_responses_mock.py
@@ -1,7 +1,7 @@
 import types
 from http.client import responses as http_responses
 from io import BytesIO
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 import responses
@@ -124,7 +124,7 @@ def not_implemented_callback(request: Any) -> TYPE_RESPONSE:
 # This method should be used for Responses 0.12.1 < .. < 0.17.0
 def _find_first_match(
     self: Any, request: Any
-) -> tuple[Optional[responses.BaseResponse], list[str]]:
+) -> tuple[responses.BaseResponse | None, list[str]]:
     matches = []
     match_failed_reasons = []
     all_possibles = self._matches + responses._default_mock._matches  # type: ignore[attr-defined]

--- a/moto/core/decorator.py
+++ b/moto/core/decorator.py
@@ -1,32 +1,25 @@
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Optional, TypeVar, Union, overload
+from typing import ParamSpec, TypeVar, overload
 
 from moto import settings
 from moto.core.config import DefaultConfig
 from moto.core.models import MockAWS, ProxyModeMockAWS, ServerModeMockAWS
 
-if TYPE_CHECKING:
-    from typing_extensions import ParamSpec
-
-    P = ParamSpec("P")
-
+P = ParamSpec("P")
 T = TypeVar("T")
 
 
 @overload
-def mock_aws(func: "Callable[P, T]") -> "Callable[P, T]": ...
+def mock_aws(func: Callable[P, T]) -> Callable[P, T]: ...
 
 
 @overload
-def mock_aws(
-    func: None = None, config: Optional[DefaultConfig] = None
-) -> "MockAWS": ...
+def mock_aws(func: None = None, config: DefaultConfig | None = None) -> MockAWS: ...
 
 
 def mock_aws(
-    func: "Optional[Callable[P, T]]" = None,
-    config: Optional[DefaultConfig] = None,
-) -> Union["MockAWS", "Callable[P, T]"]:
+    func: Callable[P, T] | None = None, config: DefaultConfig | None = None
+) -> MockAWS | Callable[P, T]:
     clss = (
         ServerModeMockAWS
         if settings.TEST_SERVER_MODE

--- a/moto/core/exceptions.py
+++ b/moto/core/exceptions.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any
 
 from werkzeug.exceptions import HTTPException
 
@@ -151,14 +151,14 @@ class AuthFailureError(_RESTError):
 
 
 class AWSError(JsonRESTError):
-    TYPE: Optional[str] = None
+    TYPE: str | None = None
     STATUS = 400
 
     def __init__(
         self,
         message: str,
-        exception_type: Optional[str] = None,
-        status: Optional[int] = None,
+        exception_type: str | None = None,
+        status: int | None = None,
     ):
         super().__init__(exception_type or self.TYPE, message)  # type: ignore[arg-type]
         self.code = status or self.STATUS

--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -11,7 +11,6 @@ from types import FunctionType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Optional,
     TypeVar,
 )
 from unittest.mock import patch
@@ -51,12 +50,12 @@ class MockAWS(AbstractContextManager["MockAWS"]):
     _mocks_active = False
     _mock_init_lock = Lock()
 
-    def __init__(self, config: Optional[DefaultConfig] = None) -> None:
+    def __init__(self, config: DefaultConfig | None = None) -> None:
         self._fake_creds = {
             "AWS_ACCESS_KEY_ID": "FOOBARKEY",
             "AWS_SECRET_ACCESS_KEY": "FOOBARSECRET",
         }
-        self._orig_creds: dict[str, Optional[str]] = {}
+        self._orig_creds: dict[str, str | None] = {}
         self._default_session_mock = patch("boto3.DEFAULT_SESSION", None)
         current_user_config = default_user_config.copy()
         current_user_config.update(config or {})
@@ -318,7 +317,7 @@ def patch_resource(resource: Any) -> None:
         raise Exception(f"Argument {resource} should be of type boto3.resource")
 
 
-def override_responses_real_send(user_mock: Optional[responses.RequestsMock]) -> None:
+def override_responses_real_send(user_mock: responses.RequestsMock | None) -> None:
     """
     Moto creates it's own Responses-object responsible for intercepting AWS requests
     If a custom Responses-object is created by the user, Moto will hijack any of the pass-thru's set
@@ -385,7 +384,7 @@ class ServerModeMockAWS(MockAWS):
         self._client_patcher.start()
         self._resource_patcher.start()
 
-    def _get_region(self, *args: Any, **kwargs: Any) -> Optional[str]:
+    def _get_region(self, *args: Any, **kwargs: Any) -> str | None:
         if "region_name" in kwargs:
             return kwargs["region_name"]
         if type(args) is tuple and len(args) == 2:

--- a/moto/core/parse.py
+++ b/moto/core/parse.py
@@ -9,7 +9,7 @@ import re
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 from urllib.parse import unquote
 from xml.etree import ElementTree as ETree
 from xml.etree.ElementTree import ParseError as XMLParseError
@@ -693,7 +693,7 @@ class XFormedDict(MutableMapping[str, Any]):
     """
 
     def __init__(
-        self, data: Optional[dict[str, Any]] = None, **kwargs: dict[str, Any]
+        self, data: dict[str, Any] | None = None, **kwargs: dict[str, Any]
     ) -> None:
         self._xform_cache: dict[str, Any] = {}
         self._store: MutableMapping[str, Any] = OrderedDict()

--- a/moto/core/responses.py
+++ b/moto/core/responses.py
@@ -10,9 +10,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import (
     Any,
-    Optional,
     TypeVar,
-    Union,
     cast,
 )
 from urllib.parse import parse_qs, parse_qsl, unquote, urlparse
@@ -202,7 +200,7 @@ class BaseResponse(ActionAuthenticatorMixin):
         r"AWS.*(?P<access_key>(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9]))[:/]"
     )
 
-    def __init__(self, service_name: Optional[str] = None):
+    def __init__(self, service_name: str | None = None):
         super().__init__()
         self.service_name = service_name
         self.allow_request_decompression = True
@@ -317,7 +315,7 @@ class BaseResponse(ActionAuthenticatorMixin):
         self.method = request.method
         self.region = self.get_region_from_url(request, full_url)
         self.partition = get_partition(self.region)
-        self.uri_match: Optional[re.Match[str]] = None
+        self.uri_match: re.Match[str] | None = None
 
         self.headers = request.headers
         if "host" not in self.headers:
@@ -541,7 +539,7 @@ class BaseResponse(ActionAuthenticatorMixin):
                 se_headers["status"] = se_status
                 response = se_body, se_headers  # type: ignore[assignment]
             except HTTPException as http_error:
-                response_headers: dict[str, Union[str, int]] = dict(
+                response_headers: dict[str, str | int] = dict(
                     http_error.get_headers() or []
                 )
                 response_headers["status"] = http_error.code  # type: ignore[assignment]
@@ -621,7 +619,7 @@ class BaseResponse(ActionAuthenticatorMixin):
         self,
         param_name: str,
         if_none: TYPE_IF_NONE = None,  # type: ignore[assignment]
-    ) -> Union[int, TYPE_IF_NONE]:
+    ) -> int | TYPE_IF_NONE:
         val = self._get_param(param_name)
         if val is not None:
             return int(val)
@@ -631,7 +629,7 @@ class BaseResponse(ActionAuthenticatorMixin):
         self,
         param_name: str,
         if_none: TYPE_IF_NONE = None,  # type: ignore[assignment]
-    ) -> Union[float, TYPE_IF_NONE]:
+    ) -> float | TYPE_IF_NONE:
         val = self._get_param(param_name)
         if val is not None:
             return float(val)
@@ -641,7 +639,7 @@ class BaseResponse(ActionAuthenticatorMixin):
         self,
         param_name: str,
         if_none: TYPE_IF_NONE = None,  # type: ignore[assignment]
-    ) -> Union[bool, TYPE_IF_NONE]:
+    ) -> bool | TYPE_IF_NONE:
         val = self._get_param(param_name)
         if val is not None:
             val = str(val)

--- a/moto/core/responses_custom_registry.py
+++ b/moto/core/responses_custom_registry.py
@@ -1,6 +1,6 @@
 # This will only exist in responses >= 0.17
 from collections import defaultdict
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlunparse
 
 import responses
@@ -52,7 +52,7 @@ class CustomRegistry(responses.registries.FirstMatchRegistry):
     def reset(self) -> None:
         self._registered.clear()
 
-    def find(self, request: Any) -> tuple[Optional[responses.BaseResponse], list[str]]:
+    def find(self, request: Any) -> tuple[responses.BaseResponse | None, list[str]]:
         # We don't have to search through all possible methods - only the ones registered for this particular method
         all_possibles = (
             responses._default_mock._registry.registered

--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -62,9 +62,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import (
     Any,
-    Optional,
     TypedDict,
-    Union,
 )
 
 import xmltodict
@@ -93,7 +91,7 @@ class ResponseDict(TypedDict):
 
 
 class SerializationContext:
-    def __init__(self, request_id: Optional[str] = None) -> None:
+    def __init__(self, request_id: str | None = None) -> None:
         self.request_id = request_id or "request-id"
 
 
@@ -130,7 +128,7 @@ class TimestampSerializer:
         return value.strftime(self.ISO8601_MICRO_ZEROED)
 
     @staticmethod
-    def _timestamp_unixtimestamp(value: datetime) -> Union[int, float]:
+    def _timestamp_unixtimestamp(value: datetime) -> int | float:
         base_timestamp = calendar.timegm(value.timetuple())
         if value.microsecond:
             # Smithy spec: "Values that are more granular than millisecond
@@ -138,13 +136,13 @@ class TimestampSerializer:
             return base_timestamp + (value.microsecond // 1000) / 1000.0
         return base_timestamp
 
-    def _timestamp_rfc822(self, value: Union[datetime, float]) -> str:
+    def _timestamp_rfc822(self, value: datetime | float) -> str:
         if isinstance(value, datetime):
             value = self._timestamp_unixtimestamp(value)
         return formatdate(value, usegmt=True)
 
     def _convert_timestamp_to_str(
-        self, value: Union[int, str, datetime], timestamp_format: str
+        self, value: int | str | datetime, timestamp_format: str
     ) -> str:
         timestamp_format = timestamp_format.lower()
         converter = getattr(self, f"_timestamp_{timestamp_format}")
@@ -212,7 +210,7 @@ class HeaderSerializer:
         self._timestamp_serializer.serialize(wrapper, value, shape, "timestamp")
         self._default_serialize(serialized, wrapper["timestamp"], shape, key)
 
-    def _base64(self, value: Union[str, bytes]) -> str:
+    def _base64(self, value: str | bytes) -> str:
         if isinstance(value, str):
             value = value.encode(self.DEFAULT_ENCODING)
         return base64.b64encode(value).strip().decode(self.DEFAULT_ENCODING)
@@ -234,8 +232,8 @@ class ResponseSerializer:
     def __init__(
         self,
         operation_model: OperationModel,
-        context: Optional[SerializationContext] = None,
-        pretty_print: Optional[bool] = False,
+        context: SerializationContext | None = None,
+        pretty_print: bool | None = False,
         value_picker: Any = None,
     ) -> None:
         self.operation_model = operation_model
@@ -302,7 +300,7 @@ class ResponseSerializer:
         self,
         resp: ResponseDict,
         result: Any,
-        shape: Optional[StructureShape],
+        shape: StructureShape | None,
         serialized_result: MutableMapping[str, Any],
     ) -> ResponseDict:
         raise NotImplementedError("Must be implemented in subclass.")
@@ -323,7 +321,7 @@ class ResponseSerializer:
     def _is_error_result(result: object) -> bool:
         return isinstance(result, Exception)
 
-    def _base64(self, value: Union[str, bytes]) -> str:
+    def _base64(self, value: str | bytes) -> str:
         if isinstance(value, str):
             value = value.encode(self.DEFAULT_ENCODING)
         return base64.b64encode(value).strip().decode(self.DEFAULT_ENCODING)
@@ -444,7 +442,7 @@ class BaseJSONSerializer(ResponseSerializer):
         self,
         resp: ResponseDict,
         result: Any,
-        shape: Optional[StructureShape],
+        shape: StructureShape | None,
         serialized_result: MutableMapping[str, Any],
     ) -> ResponseDict:
         resp["body"] = self._serialize_body(serialized_result)
@@ -595,7 +593,7 @@ class BaseXMLSerializer(ResponseSerializer):
         self,
         resp: ResponseDict,
         result: Any,
-        shape: Optional[StructureShape],
+        shape: StructureShape | None,
         serialized_result: MutableMapping[str, Any],
     ) -> ResponseDict:
         if shape and "payload" in shape.serialization:
@@ -714,7 +712,7 @@ class BaseRestSerializer(ResponseSerializer):
     REQUIRES_EMPTY_BODY = False
 
     @staticmethod
-    def has_body_members(shape: Optional[StructureShape]) -> bool:
+    def has_body_members(shape: StructureShape | None) -> bool:
         if shape is not None:
             for member in shape.members.values():
                 if "location" not in member.serialization:
@@ -725,7 +723,7 @@ class BaseRestSerializer(ResponseSerializer):
         self,
         resp: ResponseDict,
         result: Any,
-        shape: Optional[StructureShape],
+        shape: StructureShape | None,
         serialized_result: MutableMapping[str, Any],
     ) -> ResponseDict:
         if "payload" in serialized_result:
@@ -850,7 +848,7 @@ class QuerySerializer(BaseXMLSerializer):
         self,
         resp: ResponseDict,
         result: Any,
-        shape: Optional[StructureShape],
+        shape: StructureShape | None,
         serialized_result: MutableMapping[str, Any],
     ) -> ResponseDict:
         response_key = f"{self.operation_model.name}Response"
@@ -1016,7 +1014,7 @@ class S3Serializer(RestXMLSerializer):
         self,
         resp: ResponseDict,
         result: Any,
-        shape: Optional[StructureShape],
+        shape: StructureShape | None,
         serialized_result: MutableMapping[str, Any],
     ) -> ResponseDict:
         # GetBucketLocation response cannot be modeled properly, so we handle it as a one-off here.

--- a/moto/core/utils.py
+++ b/moto/core/utils.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Callable
 from functools import cache
 from gzip import compress, decompress
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import ParseResult, urlparse
 
 from botocore.exceptions import ClientError
@@ -161,7 +161,7 @@ class convert_flask_to_responses_response:
 
 
 def iso_8601_datetime_with_milliseconds(
-    value: Optional[datetime.datetime] = None,
+    value: datetime.datetime | None = None,
 ) -> str:
     date_to_use = value or utcnow()
     return date_to_use.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
@@ -178,7 +178,7 @@ def iso_8601_datetime_without_milliseconds(value: datetime.datetime) -> str:
 
 def iso_8601_datetime_without_milliseconds_s3(
     value: datetime.datetime,
-) -> Optional[str]:
+) -> str | None:
     return value.strftime("%Y-%m-%dT%H:%M:%S.000Z") if value else None
 
 
@@ -227,14 +227,14 @@ def str_to_rfc_1123_datetime(value: str) -> datetime.datetime:
     return datetime.datetime.strptime(value, RFC1123)
 
 
-def unix_time(dt: Optional[datetime.datetime] = None) -> float:
+def unix_time(dt: datetime.datetime | None = None) -> float:
     dt = dt or utcnow()
     epoch = utcfromtimestamp(0)
     delta = dt - epoch
     return (delta.days * 86400) + (delta.seconds + (delta.microseconds / 1e6))
 
 
-def unix_time_millis(dt: Optional[datetime.datetime] = None) -> float:
+def unix_time_millis(dt: datetime.datetime | None = None) -> float:
     return unix_time(dt) * 1000.0
 
 
@@ -388,7 +388,7 @@ def aws_api_matches(pattern: str, string: Any) -> bool:
         return False
 
 
-def extract_region_from_aws_authorization(string: str) -> Optional[str]:
+def extract_region_from_aws_authorization(string: str) -> str | None:
     auth = string or ""
     region = re.sub(r".*Credential=[^/]+/[^/]+/([^/]+)/.*", r"\1", auth)
     if region == auth:

--- a/moto/databrew/models.py
+++ b/moto/databrew/models.py
@@ -3,7 +3,7 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend, InstanceTrackerMeta
 from moto.core.common_models import BaseModel
@@ -134,7 +134,7 @@ class DataBrewBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_recipes(
-        self, recipe_version: Optional[str] = None
+        self, recipe_version: str | None = None
     ) -> list["FakeRecipeVersion"]:
         # https://docs.aws.amazon.com/databrew/latest/dg/API_ListRecipes.html
         if recipe_version == FakeRecipe.LATEST_WORKING:
@@ -168,7 +168,7 @@ class DataBrewBackend(BaseBackend):
         return [r for r in recipe_versions if r is not None]
 
     def describe_recipe(
-        self, recipe_name: str, recipe_version: Optional[str] = None
+        self, recipe_name: str, recipe_version: str | None = None
     ) -> "FakeRecipeVersion":
         # https://docs.aws.amazon.com/databrew/latest/dg/API_DescribeRecipe.html
         self.validate_length(recipe_name, "name", 255)
@@ -196,9 +196,7 @@ class DataBrewBackend(BaseBackend):
             )
         return recipe
 
-    def publish_recipe(
-        self, recipe_name: str, description: Optional[str] = None
-    ) -> None:
+    def publish_recipe(self, recipe_name: str, description: str | None = None) -> None:
         # https://docs.aws.amazon.com/databrew/latest/dg/API_PublishRecipe.html
         self.validate_length(recipe_name, "name", 255)
         try:
@@ -406,7 +404,7 @@ class DataBrewBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_jobs(
-        self, dataset_name: Optional[str] = None, project_name: Optional[str] = None
+        self, dataset_name: str | None = None, project_name: str | None = None
     ) -> list["FakeJob"]:
         # https://docs.aws.amazon.com/databrew/latest/dg/API_ListJobs.html
         if dataset_name is not None:
@@ -469,9 +467,9 @@ class FakeRecipe(BaseModel):
             version=self.INITIAL_VERSION,
         )
         self.latest_working = self.versions[self.INITIAL_VERSION]
-        self.latest_published: Optional[FakeRecipeVersion] = None
+        self.latest_published: FakeRecipeVersion | None = None
 
-    def publish(self, description: Optional[str] = None) -> None:
+    def publish(self, description: str | None = None) -> None:
         self.latest_published = self.latest_working
         self.latest_working = deepcopy(self.latest_working)
         self.latest_published.publish(description)
@@ -484,7 +482,7 @@ class FakeRecipe(BaseModel):
         self.versions[self.latest_working.version] = self.latest_working
 
     def update(
-        self, description: Optional[str], steps: Optional[list[dict[str, Any]]]
+        self, description: str | None, steps: list[dict[str, Any]] | None
     ) -> None:
         if description is not None:
             self.latest_working.description = description
@@ -524,7 +522,7 @@ class FakeRecipeVersion(BaseModel):
         self.steps = recipe_steps
         self.created_time = datetime.now()
         self.tags = tags
-        self.published_date: Optional[datetime] = None
+        self.published_date: datetime | None = None
         self.version = version
 
     def as_dict(self) -> dict[str, Any]:
@@ -541,7 +539,7 @@ class FakeRecipeVersion(BaseModel):
 
         return dict_recipe
 
-    def publish(self, description: Optional[str]) -> None:
+    def publish(self, description: str | None) -> None:
         self.version = float(math.ceil(self.version))
         self.published_date = utcnow()
         if description is not None:

--- a/moto/datasync/exceptions.py
+++ b/moto/datasync/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -8,6 +6,6 @@ class DataSyncClientError(JsonRESTError):
 
 
 class InvalidRequestException(DataSyncClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 400
         super().__init__("InvalidRequestException", msg or "The request is not valid.")

--- a/moto/datasync/models.py
+++ b/moto/datasync/models.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -41,7 +41,7 @@ class Task(BaseModel):
         self.metadata = metadata
         # For simplicity Tasks are either available or running
         self.status = "AVAILABLE"
-        self.current_task_execution_arn: Optional[str] = None
+        self.current_task_execution_arn: str | None = None
         # Generate ARN
         self.arn = f"arn:{get_partition(region_name)}:datasync:{region_name}:111222333444:task/task-{str(arn_counter).zfill(17)}"
 

--- a/moto/dax/exceptions.py
+++ b/moto/dax/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -9,7 +7,7 @@ class InvalidParameterValueException(JsonRESTError):
 
 
 class ClusterNotFoundFault(JsonRESTError):
-    def __init__(self, name: Optional[str] = None):
+    def __init__(self, name: str | None = None):
         # DescribeClusters and DeleteCluster use a different message for the same error
         msg = f"Cluster {name} not found." if name else "Cluster not found."
         super().__init__("ClusterNotFoundFault", msg)

--- a/moto/directconnect/models.py
+++ b/moto/directconnect/models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -25,11 +25,11 @@ from .exceptions import (
 
 @dataclass
 class MacSecKey(BaseModel):
-    secret_arn: Optional[str]
-    ckn: Optional[str]
+    secret_arn: str | None
+    ckn: str | None
     state: MacSecKeyStateType
     start_on: str
-    cak: Optional[str] = None
+    cak: str | None = None
 
     def to_dict(self) -> dict[str, str]:
         return {
@@ -51,17 +51,17 @@ class Connection(BaseModel):
     encryption_mode: EncryptionModeType
     has_logical_redundancy: bool
     jumbo_frame_capable: bool
-    lag_id: Optional[str]
+    lag_id: str | None
     loa_issue_time: str
     location: str
-    mac_sec_capable: Optional[bool]
+    mac_sec_capable: bool | None
     mac_sec_keys: list[MacSecKey]
     owner_account: str
     partner_name: str
     port_encryption_status: PortEncryptionStatusType
-    provider_name: Optional[str]
+    provider_name: str | None
     region: str
-    tags: Optional[list[dict[str, str]]]
+    tags: list[dict[str, str]] | None
     vlan: int
     connection_id: str = field(default="", init=False)
     backend: "DirectConnectBackend"
@@ -113,12 +113,12 @@ class LAG(BaseModel):
     has_logical_redundancy: bool
     jumbo_frame_capable: bool
     location: str
-    mac_sec_capable: Optional[bool]
+    mac_sec_capable: bool | None
     mac_sec_keys: list[MacSecKey]
     owner_account: str
-    provider_name: Optional[str]
+    provider_name: str | None
     region: str
-    tags: Optional[list[dict[str, str]]]
+    tags: list[dict[str, str]] | None
     lag_id: str = field(default="", init=False)
     backend: "DirectConnectBackend"
 
@@ -161,7 +161,7 @@ class DirectConnectBackend(BaseBackend):
         self.lags: dict[str, LAG] = {}
         self.tagger = TaggingService(key_name="key", value_name="value")
 
-    def describe_connections(self, connection_id: Optional[str]) -> list[Connection]:
+    def describe_connections(self, connection_id: str | None) -> list[Connection]:
         if connection_id and connection_id not in self.connections:
             raise ConnectionNotFound(connection_id, self.region_name)
         if connection_id:
@@ -174,10 +174,10 @@ class DirectConnectBackend(BaseBackend):
         location: str,
         bandwidth: str,
         connection_name: str,
-        lag_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        provider_name: Optional[str],
-        request_mac_sec: Optional[bool],
+        lag_id: str | None,
+        tags: list[dict[str, str]] | None,
+        provider_name: str | None,
+        request_mac_sec: bool | None,
     ) -> Connection:
         encryption_mode = EncryptionModeType.NO
         mac_sec_keys = []
@@ -261,8 +261,8 @@ class DirectConnectBackend(BaseBackend):
     def update_connection(
         self,
         connection_id: str,
-        new_connection_name: Optional[str],
-        new_encryption_mode: Optional[EncryptionModeType],
+        new_connection_name: str | None,
+        new_encryption_mode: EncryptionModeType | None,
     ) -> Connection:
         if not connection_id:
             raise ConnectionIdMissing()
@@ -278,9 +278,9 @@ class DirectConnectBackend(BaseBackend):
     def associate_mac_sec_key(
         self,
         connection_id: str,
-        secret_arn: Optional[str],
-        ckn: Optional[str],
-        cak: Optional[str],
+        secret_arn: str | None,
+        ckn: str | None,
+        cak: str | None,
     ) -> tuple[str, list[MacSecKey]]:
         mac_sec_key = MacSecKey(
             secret_arn=secret_arn or "mock_secret_arn",
@@ -328,11 +328,11 @@ class DirectConnectBackend(BaseBackend):
         location: str,
         connections_bandwidth: str,
         lag_name: str,
-        connection_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        child_connection_tags: Optional[list[dict[str, str]]],
-        provider_name: Optional[str],
-        request_mac_sec: Optional[bool],
+        connection_id: str | None,
+        tags: list[dict[str, str]] | None,
+        child_connection_tags: list[dict[str, str]] | None,
+        provider_name: str | None,
+        request_mac_sec: bool | None,
     ) -> LAG:
         if connection_id:
             raise NotImplementedError(
@@ -393,7 +393,7 @@ class DirectConnectBackend(BaseBackend):
         self.lags[lag.lag_id] = lag
         return lag
 
-    def describe_lags(self, lag_id: Optional[str]) -> list[LAG]:
+    def describe_lags(self, lag_id: str | None) -> list[LAG]:
         if lag_id and lag_id not in self.lags:
             raise LAGNotFound(lag_id, self.region_name)
         if lag_id:

--- a/moto/dms/models.py
+++ b/moto/dms/models.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -37,7 +37,7 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         migration_type: str,
         table_mappings: str,
         replication_task_settings: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> "FakeReplicationTask":
         """
         The following parameters are not yet implemented:
@@ -114,21 +114,21 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         self,
         replication_instance_identifier: str,
         replication_instance_class: str,
-        allocated_storage: Optional[int] = None,
-        vpc_security_group_ids: Optional[list[str]] = None,
-        availability_zone: Optional[str] = None,
-        replication_subnet_group_identifier: Optional[str] = None,
-        preferred_maintenance_window: Optional[str] = None,
-        multi_az: Optional[bool] = False,
-        engine_version: Optional[str] = None,
-        auto_minor_version_upgrade: Optional[bool] = True,
-        tags: Optional[list[dict[str, str]]] = None,
-        kms_key_id: Optional[str] = None,
-        publicly_accessible: Optional[bool] = True,
-        dns_name_servers: Optional[str] = None,
-        resource_identifier: Optional[str] = None,
-        network_type: Optional[str] = None,
-        kerberos_authentication_settings: Optional[dict[str, str]] = None,
+        allocated_storage: int | None = None,
+        vpc_security_group_ids: list[str] | None = None,
+        availability_zone: str | None = None,
+        replication_subnet_group_identifier: str | None = None,
+        preferred_maintenance_window: str | None = None,
+        multi_az: bool | None = False,
+        engine_version: str | None = None,
+        auto_minor_version_upgrade: bool | None = True,
+        tags: list[dict[str, str]] | None = None,
+        kms_key_id: str | None = None,
+        publicly_accessible: bool | None = True,
+        dns_name_servers: str | None = None,
+        resource_identifier: str | None = None,
+        network_type: str | None = None,
+        kerberos_authentication_settings: dict[str, str] | None = None,
     ) -> "FakeReplicationInstance":
         replication_instance = FakeReplicationInstance(
             replication_instance_identifier=replication_instance_identifier,
@@ -165,9 +165,9 @@ class DatabaseMigrationServiceBackend(BaseBackend):
 
     def describe_replication_instances(
         self,
-        filters: Optional[list[dict[str, Any]]] = None,
-        max_records: Optional[int] = None,
-        marker: Optional[str] = None,
+        filters: list[dict[str, Any]] | None = None,
+        max_records: int | None = None,
+        marker: str | None = None,
     ) -> list["FakeReplicationInstance"]:
         """Get information about replication instances with optional filtering"""
         ### TODO: Implement pagination
@@ -240,31 +240,31 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         database_name: str,
         extra_connection_attributes: str,
         kms_key_id: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
         certificate_arn: str,
         ssl_mode: str,
         service_access_role_arn: str,
         external_table_definition: str,
-        dynamo_db_settings: Optional[dict[str, Any]],
-        s3_settings: Optional[dict[str, Any]],
-        dms_transfer_settings: Optional[dict[str, Any]],
-        mongo_db_settings: Optional[dict[str, Any]],
-        kinesis_settings: Optional[dict[str, Any]],
-        kafka_settings: Optional[dict[str, Any]],
-        elasticsearch_settings: Optional[dict[str, Any]],
-        neptune_settings: Optional[dict[str, Any]],
-        redshift_settings: Optional[dict[str, Any]],
-        postgre_sql_settings: Optional[dict[str, Any]],
-        my_sql_settings: Optional[dict[str, Any]],
-        oracle_settings: Optional[dict[str, Any]],
-        sybase_settings: Optional[dict[str, Any]],
-        microsoft_sql_server_settings: Optional[dict[str, Any]],
-        ibm_db2_settings: Optional[dict[str, Any]],
-        resource_identifier: Optional[str],
-        doc_db_settings: Optional[dict[str, Any]],
-        redis_settings: Optional[dict[str, Any]],
-        gcp_my_sql_settings: Optional[dict[str, Any]],
-        timestream_settings: Optional[dict[str, Any]],
+        dynamo_db_settings: dict[str, Any] | None,
+        s3_settings: dict[str, Any] | None,
+        dms_transfer_settings: dict[str, Any] | None,
+        mongo_db_settings: dict[str, Any] | None,
+        kinesis_settings: dict[str, Any] | None,
+        kafka_settings: dict[str, Any] | None,
+        elasticsearch_settings: dict[str, Any] | None,
+        neptune_settings: dict[str, Any] | None,
+        redshift_settings: dict[str, Any] | None,
+        postgre_sql_settings: dict[str, Any] | None,
+        my_sql_settings: dict[str, Any] | None,
+        oracle_settings: dict[str, Any] | None,
+        sybase_settings: dict[str, Any] | None,
+        microsoft_sql_server_settings: dict[str, Any] | None,
+        ibm_db2_settings: dict[str, Any] | None,
+        resource_identifier: str | None,
+        doc_db_settings: dict[str, Any] | None,
+        redis_settings: dict[str, Any] | None,
+        gcp_my_sql_settings: dict[str, Any] | None,
+        timestream_settings: dict[str, Any] | None,
     ) -> "Endpoint":
         if endpoint_type not in ["source", "target"]:
             raise ValidationError("Invalid endpoint type")
@@ -321,8 +321,8 @@ class DatabaseMigrationServiceBackend(BaseBackend):
     def describe_endpoints(
         self,
         filters: list[dict[str, Any]],
-        max_records: Optional[int],
-        marker: Optional[str],
+        max_records: int | None,
+        marker: str | None,
     ) -> list["Endpoint"]:
         endpoints = list(self.endpoints.values())
         filter_map = {
@@ -384,7 +384,7 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         replication_subnet_group_identifier: str,
         replication_subnet_group_description: str,
         subnet_ids: list[str],
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> "FakeReplicationSubnetGroup":
         replication_subnet_group = FakeReplicationSubnetGroup(
             replication_subnet_group_identifier=replication_subnet_group_identifier,
@@ -408,8 +408,8 @@ class DatabaseMigrationServiceBackend(BaseBackend):
     def describe_replication_subnet_groups(
         self,
         filters: list[dict[str, Any]],
-        max_records: Optional[int],
-        marker: Optional[str],
+        max_records: int | None,
+        marker: str | None,
     ) -> list["FakeReplicationSubnetGroup"]:
         subnet_groups = list(self.replication_subnet_groups.values())
         filter_map = {
@@ -483,8 +483,8 @@ class DatabaseMigrationServiceBackend(BaseBackend):
     def describe_connections(
         self,
         filters: list[dict[str, Any]],
-        max_records: Optional[int],
-        marker: Optional[str],
+        max_records: int | None,
+        marker: str | None,
     ) -> list["FakeConnection"]:
         filter_map = {
             "endpoint-arn": "endpoint_arn",
@@ -523,31 +523,31 @@ class Endpoint(BaseModel):
         extra_connection_attributes: str,
         status: str,
         kms_key_id: str,
-        certificate_arn: Optional[str],
-        ssl_mode: Optional[str],
-        service_access_role_arn: Optional[str],
-        external_table_definition: Optional[str],
-        external_id: Optional[str],
-        dynamo_db_settings: Optional[dict[str, Any]],
-        s3_settings: Optional[dict[str, Any]],
-        dms_transfer_settings: Optional[dict[str, Any]],
-        mongo_db_settings: Optional[dict[str, Any]],
-        kinesis_settings: Optional[dict[str, Any]],
-        kafka_settings: Optional[dict[str, Any]],
-        elasticsearch_settings: Optional[dict[str, Any]],
-        neptune_settings: Optional[dict[str, Any]],
-        redshift_settings: Optional[dict[str, Any]],
-        postgre_sql_settings: Optional[dict[str, Any]],
-        my_sql_settings: Optional[dict[str, Any]],
-        oracle_settings: Optional[dict[str, Any]],
-        sybase_settings: Optional[dict[str, Any]],
-        microsoft_sql_server_settings: Optional[dict[str, Any]],
-        ibm_db2_settings: Optional[dict[str, Any]],
-        resource_identifier: Optional[str],
-        doc_db_settings: Optional[dict[str, Any]],
-        redis_settings: Optional[dict[str, Any]],
-        gcp_my_sql_settings: Optional[dict[str, Any]],
-        timestream_settings: Optional[dict[str, Any]],
+        certificate_arn: str | None,
+        ssl_mode: str | None,
+        service_access_role_arn: str | None,
+        external_table_definition: str | None,
+        external_id: str | None,
+        dynamo_db_settings: dict[str, Any] | None,
+        s3_settings: dict[str, Any] | None,
+        dms_transfer_settings: dict[str, Any] | None,
+        mongo_db_settings: dict[str, Any] | None,
+        kinesis_settings: dict[str, Any] | None,
+        kafka_settings: dict[str, Any] | None,
+        elasticsearch_settings: dict[str, Any] | None,
+        neptune_settings: dict[str, Any] | None,
+        redshift_settings: dict[str, Any] | None,
+        postgre_sql_settings: dict[str, Any] | None,
+        my_sql_settings: dict[str, Any] | None,
+        oracle_settings: dict[str, Any] | None,
+        sybase_settings: dict[str, Any] | None,
+        microsoft_sql_server_settings: dict[str, Any] | None,
+        ibm_db2_settings: dict[str, Any] | None,
+        resource_identifier: str | None,
+        doc_db_settings: dict[str, Any] | None,
+        redis_settings: dict[str, Any] | None,
+        gcp_my_sql_settings: dict[str, Any] | None,
+        timestream_settings: dict[str, Any] | None,
         account_id: str,
         region_name: str,
     ):
@@ -666,8 +666,8 @@ class FakeReplicationTask(BaseModel):
         self.status = "creating"
 
         self.creation_date = utcnow()
-        self.start_date: Optional[datetime] = None
-        self.stop_date: Optional[datetime] = None
+        self.start_date: datetime | None = None
+        self.stop_date: datetime | None = None
 
     def to_dict(self) -> dict[str, Any]:
         start_date = self.start_date.isoformat() if self.start_date else None
@@ -734,21 +734,21 @@ class FakeReplicationInstance(ManagedState):
         replication_instance_class: str,
         account_id: str,
         region_name: str,
-        allocated_storage: Optional[int] = None,
-        vpc_security_group_ids: Optional[list[str]] = None,
-        availability_zone: Optional[str] = None,
-        replication_subnet_group_identifier: Optional[str] = None,
-        preferred_maintenance_window: Optional[str] = None,
-        multi_az: Optional[bool] = False,
-        engine_version: Optional[str] = None,
-        auto_minor_version_upgrade: Optional[bool] = True,
-        tags: Optional[list[dict[str, str]]] = None,
-        kms_key_id: Optional[str] = None,
-        publicly_accessible: Optional[bool] = True,
-        dns_name_servers: Optional[str] = None,
-        resource_identifier: Optional[str] = None,
-        network_type: Optional[str] = None,
-        kerberos_authentication_settings: Optional[dict[str, str]] = None,
+        allocated_storage: int | None = None,
+        vpc_security_group_ids: list[str] | None = None,
+        availability_zone: str | None = None,
+        replication_subnet_group_identifier: str | None = None,
+        preferred_maintenance_window: str | None = None,
+        multi_az: bool | None = False,
+        engine_version: str | None = None,
+        auto_minor_version_upgrade: bool | None = True,
+        tags: list[dict[str, str]] | None = None,
+        kms_key_id: str | None = None,
+        publicly_accessible: bool | None = True,
+        dns_name_servers: str | None = None,
+        resource_identifier: str | None = None,
+        network_type: str | None = None,
+        kerberos_authentication_settings: dict[str, str] | None = None,
     ):
         ManagedState.__init__(
             self,
@@ -864,8 +864,8 @@ class FakeReplicationSubnetGroup(BaseModel):
         self,
         replication_subnet_group_identifier: str,
         replication_subnet_group_description: str,
-        subnetIds: Optional[list[str]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        subnetIds: list[str] | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.replication_subnet_group_identifier = replication_subnet_group_identifier
         self.description = replication_subnet_group_description

--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -1,7 +1,7 @@
 """DirectoryServiceBackend class with methods for supported APIs."""
 
 import copy
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -60,9 +60,9 @@ class Trust(BaseModel):
         remote_domain_name: str,
         trust_password: str,
         trust_direction: str,
-        trust_type: Optional[str],
-        conditional_forwarder_ip_addrs: Optional[list[str]],
-        selective_auth: Optional[str],
+        trust_type: str | None,
+        conditional_forwarder_ip_addrs: list[str] | None,
+        selective_auth: str | None,
     ) -> None:
         self.trust_id = f"t-{mock_random.get_random_hex(10)}"
         self.created_date_time = unix_time()
@@ -125,12 +125,12 @@ class Directory(BaseModel):
         name: str,
         password: str,
         directory_type: str,
-        size: Optional[str] = None,
-        vpc_settings: Optional[dict[str, Any]] = None,
-        connect_settings: Optional[dict[str, Any]] = None,
-        short_name: Optional[str] = None,
-        description: Optional[str] = None,
-        edition: Optional[str] = None,
+        size: str | None = None,
+        vpc_settings: dict[str, Any] | None = None,
+        connect_settings: dict[str, Any] | None = None,
+        short_name: str | None = None,
+        description: str | None = None,
+        edition: str | None = None,
     ):
         self.account_id = account_id
         self.region = region
@@ -538,8 +538,8 @@ class DirectoryServiceBackend(BaseBackend):
     def disable_sso(
         self,
         directory_id: str,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
+        username: str | None = None,
+        password: str | None = None,
     ) -> None:
         """Disable single-sign on for a directory."""
         self._validate_directory_id(directory_id)
@@ -550,8 +550,8 @@ class DirectoryServiceBackend(BaseBackend):
     def enable_sso(
         self,
         directory_id: str,
-        username: Optional[str] = None,
-        password: Optional[str] = None,
+        username: str | None = None,
+        password: str | None = None,
     ) -> None:
         """Enable single-sign on for a directory."""
         self._validate_directory_id(directory_id)
@@ -568,7 +568,7 @@ class DirectoryServiceBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_directories(
-        self, directory_ids: Optional[list[str]] = None
+        self, directory_ids: list[str] | None = None
     ) -> list[Directory]:
         """Return info on all directories or directories with matching IDs."""
         for directory_id in directory_ids or self.directories:
@@ -634,9 +634,9 @@ class DirectoryServiceBackend(BaseBackend):
         remote_domain_name: str,
         trust_password: str,
         trust_direction: str,
-        trust_type: Optional[str],
-        conditional_forwarder_ip_addrs: Optional[list[str]],
-        selective_auth: Optional[str],
+        trust_type: str | None,
+        conditional_forwarder_ip_addrs: list[str] | None,
+        selective_auth: str | None,
     ) -> str:
         self._validate_directory_id(directory_id)
         validate_args(
@@ -661,7 +661,7 @@ class DirectoryServiceBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_trusts(
-        self, directory_id: Optional[str], trust_ids: Optional[list[str]]
+        self, directory_id: str | None, trust_ids: list[str] | None
     ) -> list[Trust]:
         if directory_id:
             self._validate_directory_id(directory_id)
@@ -680,7 +680,7 @@ class DirectoryServiceBackend(BaseBackend):
         return queried_trusts
 
     def delete_trust(
-        self, trust_id: str, delete_associated_conditional_forwarder: Optional[bool]
+        self, trust_id: str, delete_associated_conditional_forwarder: bool | None
     ) -> str:
         # TODO: Implement handle for delete_associated_conditional_forwarder once conditional forwarder is implemented
         delete_associated_conditional_forwarder = (
@@ -721,7 +721,7 @@ class DirectoryServiceBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_settings(
-        self, directory_id: str, status: Optional[str]
+        self, directory_id: str, status: str | None
     ) -> list[dict[str, str]]:
         """Describe settings for a Directory"""
         self._validate_directory_id(directory_id)

--- a/moto/dsql/models.py
+++ b/moto/dsql/models.py
@@ -1,7 +1,6 @@
 """AuroraDSQLBackend class with methods for supported APIs."""
 
 from collections import OrderedDict
-from typing import Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -20,9 +19,9 @@ class Cluster(BaseModel, ManagedState):
         self,
         region_name: str,
         account_id: str,
-        deletion_protection_enabled: Optional[bool],
-        tags: Optional[dict[str, str]],
-        client_token: Optional[str],
+        deletion_protection_enabled: bool | None,
+        tags: dict[str, str] | None,
+        client_token: str | None,
     ):
         ManagedState.__init__(
             self, "dsql::cluster", transitions=[("CREATING", "ACTIVE")]
@@ -56,8 +55,8 @@ class AuroraDSQLBackend(BaseBackend):
     def create_cluster(
         self,
         deletion_protection_enabled: bool,
-        tags: Optional[dict[str, str]],
-        client_token: Optional[str],
+        tags: dict[str, str] | None,
+        client_token: str | None,
     ) -> Cluster:
         cluster = Cluster(
             self.region_name,

--- a/moto/dynamodb/comparisons.py
+++ b/moto/dynamodb/comparisons.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import re
 from collections import deque, namedtuple
 from collections.abc import Iterable
 from decimal import Decimal
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.dynamodb.exceptions import (
     ConditionAttributeIsReservedKeyword,
@@ -13,18 +15,18 @@ from moto.dynamodb.parsing.reserved_keywords import ReservedKeywords
 
 
 def create_condition_expression_parser(
-    expr: Optional[str],
-    names: Optional[dict[str, str]],
-    values: Optional[dict[str, dict[str, str]]],
-) -> "ConditionExpressionParser":
+    expr: str | None,
+    names: dict[str, str] | None,
+    values: dict[str, dict[str, str]] | None,
+) -> ConditionExpressionParser:
     return ConditionExpressionParser(expr, names, values)
 
 
 def get_filter_expression(
-    expr: Optional[str],
-    names: Optional[dict[str, str]],
-    values: Optional[dict[str, dict[str, str]]],
-) -> Union["Op", "Func"]:
+    expr: str | None,
+    names: dict[str, str] | None,
+    values: dict[str, dict[str, str]] | None,
+) -> Op | Func:
     """
     Parse a filter expression into an Op.
 
@@ -36,7 +38,7 @@ def get_filter_expression(
     return parser.parse()
 
 
-def get_expected(expected: dict[str, Any]) -> Union["Op", "Func"]:
+def get_expected(expected: dict[str, Any]) -> Op | Func:
     """
     Parse a filter expression into an Op.
 
@@ -61,7 +63,7 @@ def get_expected(expected: dict[str, Any]) -> Union["Op", "Func"]:
     }
 
     # NOTE: Always uses ConditionalOperator=AND
-    conditions: list[Union[Op, Func]] = []
+    conditions: list[Op | Func] = []
     for key, cond in expected.items():
         path = AttributePath([key])
         if "Exists" in cond:
@@ -96,13 +98,11 @@ class Op:
 
     OP = ""
 
-    def __init__(
-        self, lhs: Union["Func", "Op", "Operand"], rhs: Union["Func", "Op", "Operand"]
-    ):
+    def __init__(self, lhs: Func | Op | Operand, rhs: Func | Op | Operand):
         self.lhs = lhs
         self.rhs = rhs
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         raise NotImplementedError(f"Expr not defined for {type(self)}")
 
     def __repr__(self) -> str:
@@ -156,9 +156,9 @@ class RecursionStopIteration(StopIteration):
 class ConditionExpressionParser:
     def __init__(
         self,
-        condition_expression: Optional[str],
-        expression_attribute_names: Optional[dict[str, str]],
-        expression_attribute_values: Optional[dict[str, dict[str, str]]],
+        condition_expression: str | None,
+        expression_attribute_names: dict[str, str] | None,
+        expression_attribute_values: dict[str, dict[str, str]] | None,
     ):
         self.condition_expression = condition_expression
         self.expression_attribute_names = expression_attribute_names
@@ -167,7 +167,7 @@ class ConditionExpressionParser:
         self.expr_attr_names_found: list[str] = []
         self.expr_attr_values_found: list[str] = []
 
-    def parse(self) -> Union[Op, "Func"]:
+    def parse(self) -> Op | Func:
         """Returns a syntax tree for the expression.
 
         The tree, and all of the nodes in the tree are a tuple of
@@ -840,7 +840,7 @@ class ConditionExpressionParser:
 
         return output
 
-    def _make_operand(self, node: Node) -> "Operand":
+    def _make_operand(self, node: Node) -> Operand:
         if node.kind == self.Kind.PATH:
             return AttributePath([child.value for child in node.children])
         elif node.kind == self.Kind.EXPRESSION_ATTRIBUTE_VALUE:
@@ -855,7 +855,7 @@ class ConditionExpressionParser:
         else:  # pragma: no cover
             raise ValueError(f"Unknown operand: {node}")
 
-    def _make_op_condition(self, node: Node) -> Union["Func", Op]:
+    def _make_op_condition(self, node: Node) -> Func | Op:
         if node.kind == self.Kind.OR:
             lhs, rhs = node.children
             return OpOr(self._make_op_condition(lhs), self._make_op_condition(rhs))
@@ -896,7 +896,7 @@ class ConditionExpressionParser:
             raise ValueError(f"Unknown expression node kind {node.kind}")
 
     def _assert_no_redundant_parentheses(
-        self, node: Node, parent_kind: Optional[str] = None
+        self, node: Node, parent_kind: str | None = None
     ) -> None:
         if node.kind == self.Kind.PARENTHESES:
             (child,) = node.children
@@ -911,7 +911,7 @@ class ConditionExpressionParser:
             self._assert_no_redundant_parentheses(child, node.kind)
 
     def _is_redundant_parenthesized_child(
-        self, parent_kind: Optional[str], child_kind: str
+        self, parent_kind: str | None, child_kind: str
     ) -> bool:
         return child_kind == self.Kind.PARENTHESES
 
@@ -921,10 +921,10 @@ class ConditionExpressionParser:
 
 
 class Operand:
-    def expr(self, item: Optional[Item]) -> Any:
+    def expr(self, item: Item | None) -> Any:
         raise NotImplementedError
 
-    def get_type(self, item: Optional[Item]) -> Optional[str]:
+    def get_type(self, item: Item | None) -> str | None:
         raise NotImplementedError
 
 
@@ -940,7 +940,7 @@ class AttributePath(Operand):
         assert len(path) >= 1
         self.path = path
 
-    def _get_attr(self, item: Optional[Item]) -> Any:
+    def _get_attr(self, item: Item | None) -> Any:
         if item is None:
             return None
 
@@ -956,14 +956,14 @@ class AttributePath(Operand):
 
         return attr
 
-    def expr(self, item: Optional[Item]) -> Any:
+    def expr(self, item: Item | None) -> Any:
         attr = self._get_attr(item)
         if attr is None:
             return None
         else:
             return attr.cast_value
 
-    def get_type(self, item: Optional[Item]) -> Optional[str]:
+    def get_type(self, item: Item | None) -> str | None:
         attr = self._get_attr(item)
         if attr is None:
             return None
@@ -987,7 +987,7 @@ class AttributeValue(Operand):
         self.type = list(value.keys())[0]
         self.value = value[self.type]
 
-    def expr(self, item: Optional[Item]) -> Any:
+    def expr(self, item: Item | None) -> Any:
         if self.type == "N":
             return Decimal(self.value)
         elif self.type in ["SS", "NS", "BS"]:
@@ -1003,7 +1003,7 @@ class AttributeValue(Operand):
             return self.value
         return self.value
 
-    def get_type(self, item: Optional[Item]) -> str:
+    def get_type(self, item: Item | None) -> str:
         return self.type
 
     def __repr__(self) -> str:
@@ -1013,7 +1013,7 @@ class AttributeValue(Operand):
 class OpDefault(Op):
     OP = "NONE"
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         """If no condition is specified, always True."""
         return True
 
@@ -1021,10 +1021,10 @@ class OpDefault(Op):
 class OpNot(Op):
     OP = "NOT"
 
-    def __init__(self, lhs: Union["Func", Op]):
+    def __init__(self, lhs: Func | Op):
         super().__init__(lhs, None)  # type: ignore[arg-type]
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         return not lhs
 
@@ -1035,7 +1035,7 @@ class OpNot(Op):
 class OpAnd(Op):
     OP = "AND"
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         return lhs and self.rhs.expr(item)
 
@@ -1043,7 +1043,7 @@ class OpAnd(Op):
 class OpLessThan(Op):
     OP = "<"
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
@@ -1056,7 +1056,7 @@ class OpLessThan(Op):
 class OpGreaterThan(Op):
     OP = ">"
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
@@ -1069,7 +1069,7 @@ class OpGreaterThan(Op):
 class OpEqual(Op):
     OP = "="
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         return lhs == rhs
@@ -1078,7 +1078,7 @@ class OpEqual(Op):
 class OpNotEqual(Op):
     OP = "<>"
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         return lhs != rhs
@@ -1087,7 +1087,7 @@ class OpNotEqual(Op):
 class OpLessThanOrEqual(Op):
     OP = "<="
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
@@ -1100,7 +1100,7 @@ class OpLessThanOrEqual(Op):
 class OpGreaterThanOrEqual(Op):
     OP = ">="
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         rhs = self.rhs.expr(item)
         # In python3 None is not a valid comparator when using < or > so must be handled specially
@@ -1113,7 +1113,7 @@ class OpGreaterThanOrEqual(Op):
 class OpOr(Op):
     OP = "OR"
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         lhs = self.lhs.expr(item)
         return lhs or self.rhs.expr(item)
 
@@ -1128,7 +1128,7 @@ class Func:
     def __init__(self, *arguments: Any):
         self.arguments = arguments
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         raise NotImplementedError
 
     def __repr__(self) -> str:
@@ -1142,7 +1142,7 @@ class FuncAttrExists(Func):
         self.attr = attribute
         super().__init__(attribute)
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         return self.attr.get_type(item) is not None
 
 
@@ -1158,7 +1158,7 @@ class FuncAttrType(Func):
         self.type = _type
         super().__init__(attribute, _type)
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         return self.attr.get_type(item) == self.type.expr(item)  # type: ignore[comparison-overlap]
 
 
@@ -1170,7 +1170,7 @@ class FuncBeginsWith(Func):
         self.substr = substr
         super().__init__(attribute, substr)
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         if self.attr.get_type(item) != "S":
             return False
         if self.substr.get_type(item) != "S":
@@ -1186,7 +1186,7 @@ class FuncContains(Func):
         self.operand = operand
         super().__init__(attribute, operand)
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         if self.attr.get_type(item) in ("S", "SS", "NS", "BS", "L"):
             try:
                 return self.operand.expr(item) in self.attr.expr(item)
@@ -1206,7 +1206,7 @@ class FuncSize(Func):
         self.attr = attribute
         super().__init__(attribute)
 
-    def expr(self, item: Optional[Item]) -> int:  # type: ignore[override]
+    def expr(self, item: Item | None) -> int:  # type: ignore[override]
         if self.attr.get_type(item) is None:
             raise ValueError(f"Invalid attribute name {self.attr}")
 
@@ -1224,7 +1224,7 @@ class FuncBetween(Func):
         self.end = end
         super().__init__(attribute, start, end)
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         # In python3 None is not a valid comparator when using < or > so must be handled specially
         start = self.start.expr(item)
         attr = self.attr.expr(item)
@@ -1252,7 +1252,7 @@ class FuncIn(Func):
         self.possible_values = possible_values
         super().__init__(attribute, *possible_values)
 
-    def expr(self, item: Optional[Item]) -> bool:
+    def expr(self, item: Item | None) -> bool:
         for possible_value in self.possible_values:
             if self.attr.expr(item) == possible_value.expr(item):
                 return True

--- a/moto/dynamodb/exceptions.py
+++ b/moto/dynamodb/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.exceptions import JsonRESTError
 from moto.dynamodb.limits import HASH_KEY_MAX_LENGTH, RANGE_KEY_MAX_LENGTH
@@ -207,9 +207,7 @@ class IncorrectDataType(MockValidationException):
 class ConditionalCheckFailed(DynamodbException):
     error_type = ERROR_TYPE_PREFIX + "ConditionalCheckFailedException"
 
-    def __init__(
-        self, msg: Optional[str] = None, item: Optional[dict[str, Any]] = None
-    ):
+    def __init__(self, msg: str | None = None, item: dict[str, Any] | None = None):
         _msg = msg or "The conditional request failed"
         super().__init__(ConditionalCheckFailed.error_type, _msg)
         if item:
@@ -297,9 +295,7 @@ class UpdateHashRangeKeyException(MockValidationException):
 class InvalidAttributeTypeError(MockValidationException):
     msg = "One or more parameter values were invalid: Type mismatch for key {} expected: {} actual: {}"
 
-    def __init__(
-        self, name: Optional[str], expected_type: Optional[str], actual_type: str
-    ):
+    def __init__(self, name: str | None, expected_type: str | None, actual_type: str):
         super().__init__(self.msg.format(name, expected_type, actual_type))
 
 
@@ -325,7 +321,7 @@ class TooManyClauses(InvalidUpdateExpression):
 
 
 class ResourceNotFoundException(JsonRESTError):
-    def __init__(self, msg: Optional[str] = None, table_name: Optional[str] = None):
+    def __init__(self, msg: str | None = None, table_name: str | None = None):
         err = ERROR_TYPE_PREFIX + "ResourceNotFoundException"
         default_msg = "Requested resource not found"
         if table_name is not None:
@@ -366,7 +362,7 @@ class TableAlreadyExistsException(JsonRESTError):
 
 
 class ResourceInUseException(JsonRESTError):
-    def __init__(self, msg: Optional[str] = None) -> None:
+    def __init__(self, msg: str | None = None) -> None:
         er = ERROR_TYPE_PREFIX + "ResourceInUseException"
         super().__init__(er, msg or "Resource in use")
 

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -1,7 +1,7 @@
 import copy
 import re
 from collections import OrderedDict
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.exceptions import JsonRESTError
@@ -76,16 +76,16 @@ class DynamoDBBackend(BaseBackend):
         self,
         name: str,
         schema: list[dict[str, str]],
-        throughput: Optional[dict[str, int]],
+        throughput: dict[str, int] | None,
         attr: list[dict[str, str]],
-        global_indexes: Optional[list[dict[str, Any]]],
-        indexes: Optional[list[dict[str, Any]]],
-        streams: Optional[dict[str, Any]],
+        global_indexes: list[dict[str, Any]] | None,
+        indexes: list[dict[str, Any]] | None,
+        streams: dict[str, Any] | None,
         billing_mode: str,
-        sse_specification: Optional[dict[str, Any]],
+        sse_specification: dict[str, Any] | None,
         tags: list[dict[str, str]],
-        deletion_protection_enabled: Optional[bool],
-        warm_throughput: Optional[dict[str, Any]],
+        deletion_protection_enabled: bool | None,
+        warm_throughput: dict[str, Any] | None,
     ) -> Table:
         if name in self.tables:
             raise ResourceInUseException(f"Table already exists: {name}")
@@ -115,7 +115,7 @@ class DynamoDBBackend(BaseBackend):
                 raise DeletionProtectedException(name)
         return self.tables.pop(table_for_deletion.name)
 
-    def describe_endpoints(self) -> list[dict[str, Union[int, str]]]:
+    def describe_endpoints(self) -> list[dict[str, int | str]]:
         return [
             {
                 "Address": f"dynamodb.{self.region_name}.amazonaws.com",
@@ -143,7 +143,7 @@ class DynamoDBBackend(BaseBackend):
 
     def list_tables(
         self, limit: int, exclusive_start_table_name: str
-    ) -> tuple[list[str], Optional[str]]:
+    ) -> tuple[list[str], str | None]:
         all_tables: list[str] = list(self.tables.keys())
 
         if exclusive_start_table_name:
@@ -181,8 +181,8 @@ class DynamoDBBackend(BaseBackend):
         throughput: dict[str, Any],
         billing_mode: str,
         stream_spec: dict[str, Any],
-        deletion_protection_enabled: Optional[bool],
-        warm_throughput: Optional[dict[str, Any]],
+        deletion_protection_enabled: bool | None,
+        warm_throughput: dict[str, Any] | None,
     ) -> Table:
         table = self.get_table(name)
         if attr_definitions:
@@ -258,12 +258,12 @@ class DynamoDBBackend(BaseBackend):
         self,
         table_name: str,
         item_attrs: dict[str, Any],
-        expected: Optional[dict[str, Any]] = None,
-        condition_expression: Optional[str] = None,
-        expression_attribute_names: Optional[dict[str, Any]] = None,
-        expression_attribute_values: Optional[dict[str, Any]] = None,
+        expected: dict[str, Any] | None = None,
+        condition_expression: str | None = None,
+        expression_attribute_names: dict[str, Any] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
         overwrite: bool = False,
-        return_values_on_condition_check_failure: Optional[str] = None,
+        return_values_on_condition_check_failure: str | None = None,
     ) -> Item:
         table = self.get_table(table_name)
         return table.put_item(
@@ -278,7 +278,7 @@ class DynamoDBBackend(BaseBackend):
 
     def get_table_keys_name(
         self, table_name: str, keys: dict[str, Any]
-    ) -> tuple[Optional[str], Optional[str]]:
+    ) -> tuple[str | None, str | None]:
         """
         Given a set of keys, extracts the key and range key
         """
@@ -301,7 +301,7 @@ class DynamoDBBackend(BaseBackend):
 
     def get_keys_value(
         self, table: Table, keys: dict[str, Any]
-    ) -> tuple[DynamoType, Optional[DynamoType]]:
+    ) -> tuple[DynamoType, DynamoType | None]:
         if table.hash_key_attr not in keys or (
             table.has_range_key and table.range_key_attr not in keys
         ):
@@ -314,7 +314,7 @@ class DynamoDBBackend(BaseBackend):
         return hash_key, range_key
 
     def get_schema(
-        self, table_name: str, index_name: Optional[str]
+        self, table_name: str, index_name: str | None
     ) -> list[dict[str, Any]]:
         table = self.get_table(table_name)
         if index_name:
@@ -346,8 +346,8 @@ class DynamoDBBackend(BaseBackend):
         self,
         table_name: str,
         keys: dict[str, Any],
-        projection_expressions: Optional[list[list[str]]] = None,
-    ) -> Optional[Item]:
+        projection_expressions: list[list[str]] | None = None,
+    ) -> Item | None:
         table = self.get_table(table_name)
         hash_key, range_key = self.get_keys_value(table, keys)
         return table.get_item(hash_key, range_key, projection_expressions)
@@ -355,24 +355,24 @@ class DynamoDBBackend(BaseBackend):
     def query(
         self,
         table_name: str,
-        hash_key_dict: Optional[dict[str, Any]],
-        range_comparison: Optional[str],
+        hash_key_dict: dict[str, Any] | None,
+        range_comparison: str | None,
         range_value_dicts: list[dict[str, Any]],
         limit: int,
         exclusive_start_key: dict[str, Any],
         scan_index_forward: bool,
-        projection_expressions: Optional[list[list[str]]],
-        index_name: Optional[str] = None,
+        projection_expressions: list[list[str]] | None,
+        index_name: str | None = None,
         consistent_read: bool = False,
-        expr_names: Optional[dict[str, str]] = None,
-        expr_values: Optional[dict[str, dict[str, str]]] = None,
-        filter_expression: Optional[str] = None,
-        hash_key_conditions: Optional[list[tuple[str, dict[str, Any]]]] = None,
+        expr_names: dict[str, str] | None = None,
+        expr_values: dict[str, dict[str, str]] | None = None,
+        filter_expression: str | None = None,
+        hash_key_conditions: list[tuple[str, dict[str, Any]]] | None = None,
         range_key_conditions: Optional[
             list[tuple[str, str, list[dict[str, Any]]]]
         ] = None,
         **filter_kwargs: Any,
-    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
+    ) -> tuple[list[Item], int, dict[str, Any] | None]:
         table = self.get_table(table_name)
 
         hash_key = DynamoType(hash_key_dict) if hash_key_dict else None
@@ -413,14 +413,14 @@ class DynamoDBBackend(BaseBackend):
         filters: dict[str, Any],
         limit: int,
         exclusive_start_key: dict[str, Any],
-        filter_expression: Optional[str],
+        filter_expression: str | None,
         expr_names: dict[str, Any],
         expr_values: dict[str, Any],
         index_name: str,
         consistent_read: bool,
-        projection_expression: Optional[list[list[str]]],
-        segments: Union[tuple[None, None], tuple[int, int]],
-    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
+        projection_expression: list[list[str]] | None,
+        segments: tuple[None, None] | tuple[int, int],
+    ) -> tuple[list[Item], int, dict[str, Any] | None]:
         table = self.get_table(table_name)
 
         scan_filters: dict[str, Any] = {}
@@ -450,10 +450,10 @@ class DynamoDBBackend(BaseBackend):
         update_expression: str,
         expression_attribute_names: dict[str, Any],
         expression_attribute_values: dict[str, Any],
-        attribute_updates: Optional[dict[str, Any]] = None,
-        expected: Optional[dict[str, Any]] = None,
-        condition_expression: Optional[str] = None,
-        return_values_on_condition_check_failure: Optional[str] = None,
+        attribute_updates: dict[str, Any] | None = None,
+        expected: dict[str, Any] | None = None,
+        condition_expression: str | None = None,
+        return_values_on_condition_check_failure: str | None = None,
     ) -> Item:
         table = self.get_table(table_name)
 
@@ -557,11 +557,11 @@ class DynamoDBBackend(BaseBackend):
         self,
         table_name: str,
         key: dict[str, Any],
-        expression_attribute_names: Optional[dict[str, Any]] = None,
-        expression_attribute_values: Optional[dict[str, Any]] = None,
-        condition_expression: Optional[str] = None,
-        return_values_on_condition_check_failure: Optional[str] = None,
-    ) -> Optional[Item]:
+        expression_attribute_names: dict[str, Any] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
+        condition_expression: str | None = None,
+        return_values_on_condition_check_failure: str | None = None,
+    ) -> Item | None:
         table = self.get_table(table_name)
 
         hash_value, range_value = self.get_keys_value(table, key)
@@ -631,10 +631,10 @@ class DynamoDBBackend(BaseBackend):
             target_items.add(item)
 
         errors: list[
-            Union[tuple[str, str, dict[str, Any]], tuple[None, None, None]]
+            tuple[str, str, dict[str, Any]] | tuple[None, None, None]
         ] = []  # [(Code, Message, Item), ..]
         for item in transact_items:
-            original_item: Optional[dict[str, Any]] = None
+            original_item: dict[str, Any] | None = None
             # Check transact writes are not performing multiple operations on the same item
             if len(list(item.keys())) > 1:
                 raise TransactWriteSingleOpException
@@ -975,13 +975,13 @@ class DynamoDBBackend(BaseBackend):
     def import_table(
         self,
         s3_source: dict[str, str],
-        input_format: Optional[str],
-        compression_type: Optional[str],
+        input_format: str | None,
+        compression_type: str | None,
         table_name: str,
         billing_mode: str,
-        throughput: Optional[dict[str, int]],
+        throughput: dict[str, int] | None,
         key_schema: list[dict[str, str]],
-        global_indexes: Optional[list[dict[str, Any]]],
+        global_indexes: list[dict[str, Any]] | None,
         attrs: list[dict[str, str]],
     ) -> TableImport:
         """
@@ -1057,7 +1057,7 @@ class DynamoDBBackend(BaseBackend):
         return exports
 
     def put_resource_policy(
-        self, resource_arn: str, policy_doc: str, expected_revision_id: Optional[str]
+        self, resource_arn: str, policy_doc: str, expected_revision_id: str | None
     ) -> ResourcePolicy:
         table_name = resource_arn.split("/")[-1]
         if table_name not in self.tables:
@@ -1094,7 +1094,7 @@ class DynamoDBBackend(BaseBackend):
         return self.resource_policies[resource_arn]
 
     def delete_resource_policy(
-        self, resource_arn: str, expected_revision_id: Optional[str]
+        self, resource_arn: str, expected_revision_id: str | None
     ) -> None:
         table_name = resource_arn.split("/")[-1]
         if table_name not in self.tables or not (

--- a/moto/dynamodb/models/dynamo_type.py
+++ b/moto/dynamodb/models/dynamo_type.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import base64
 import copy
 from decimal import Decimal
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from botocore.utils import merge_dicts
@@ -61,7 +63,7 @@ class DynamoType:
     http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModelDataTypes
     """
 
-    def __init__(self, type_as_dict: Union["DynamoType", dict[str, Any]]):
+    def __init__(self, type_as_dict: DynamoType | dict[str, Any]):
         if type(type_as_dict) is DynamoType:
             self.type: str = type_as_dict.type
             self.value: Any = type_as_dict.value
@@ -76,28 +78,28 @@ class DynamoType:
     def __hash__(self) -> int:
         return hash((self.type, self.cast_value))
 
-    def __eq__(self, other: "DynamoType") -> bool:  # type: ignore[override]
+    def __eq__(self, other: DynamoType) -> bool:  # type: ignore[override]
         return self.type == other.type and self.cast_value == other.cast_value
 
-    def __ne__(self, other: "DynamoType") -> bool:  # type: ignore[override]
+    def __ne__(self, other: DynamoType) -> bool:  # type: ignore[override]
         return self.type != other.type or self.cast_value != other.cast_value
 
-    def __lt__(self, other: "DynamoType") -> bool:
+    def __lt__(self, other: DynamoType) -> bool:
         return self.cast_value < other.cast_value
 
-    def __le__(self, other: "DynamoType") -> bool:
+    def __le__(self, other: DynamoType) -> bool:
         return self.cast_value <= other.cast_value
 
-    def __gt__(self, other: "DynamoType") -> bool:
+    def __gt__(self, other: DynamoType) -> bool:
         return self.cast_value > other.cast_value
 
-    def __ge__(self, other: "DynamoType") -> bool:
+    def __ge__(self, other: DynamoType) -> bool:
         return self.cast_value >= other.cast_value
 
     def __repr__(self) -> str:
         return f"DynamoType: {self.to_json()}"
 
-    def __deepcopy__(self, memo: dict[int, Any]) -> "DynamoType":
+    def __deepcopy__(self, memo: dict[int, Any]) -> DynamoType:
         """Custom deepcopy that bypasses the expensive default pickle-based
         __reduce_ex__ protocol. Safe for DynamoDB AttributeValue trees,
         which are acyclic."""
@@ -116,14 +118,14 @@ class DynamoType:
             result.value = self.value
         return result
 
-    def __add__(self, other: "DynamoType") -> "DynamoType":
+    def __add__(self, other: DynamoType) -> DynamoType:
         if self.type != other.type:
             raise TypeError("Different types of operandi is not allowed.")
         if self.is_number():
-            self_value: Union[Decimal, int] = (
+            self_value: Decimal | int = (
                 Decimal(self.value) if "." in self.value else int(self.value)
             )
-            other_value: Union[Decimal, int] = (
+            other_value: Decimal | int = (
                 Decimal(other.value) if "." in other.value else int(other.value)
             )
             total = self_value + other_value
@@ -131,7 +133,7 @@ class DynamoType:
         else:
             raise IncorrectDataType()
 
-    def __sub__(self, other: "DynamoType") -> "DynamoType":
+    def __sub__(self, other: DynamoType) -> DynamoType:
         if self.type != other.type:
             raise TypeError("Different types of operandi is not allowed.")
         if self.type == DDBType.NUMBER:
@@ -141,7 +143,7 @@ class DynamoType:
         else:
             raise TypeError("Sum only supported for Numbers.")
 
-    def __getitem__(self, item: "DynamoType") -> "DynamoType":
+    def __getitem__(self, item: DynamoType) -> DynamoType:
         if isinstance(item, str):
             # If our DynamoType is a map it should be subscriptable with a key
             if self.type == DDBType.MAP:
@@ -168,7 +170,7 @@ class DynamoType:
         else:
             raise NotImplementedError(f"No set_item for {type(key)}")
 
-    def __delitem__(self, item: str) -> "DynamoType":
+    def __delitem__(self, item: str) -> DynamoType:
         if isinstance(item, str) and self.type == DDBType.MAP:
             del self.value[item]
         return self
@@ -189,7 +191,7 @@ class DynamoType:
         else:
             return self.value
 
-    def child_attr(self, key: Union[int, str, None]) -> Optional["DynamoType"]:
+    def child_attr(self, key: int | str | None) -> DynamoType | None:
         """
         Get Map or List children by key. str for Map, int for List.
 
@@ -279,7 +281,7 @@ class DynamoType:
     def is_null(self) -> bool:
         return self.type == DDBType.NULL
 
-    def same_type(self, other: "DynamoType") -> bool:
+    def same_type(self, other: DynamoType) -> bool:
         return self.type == other.type
 
     def pop(self, key: str, *args: Any, **kwargs: Any) -> None:
@@ -317,7 +319,7 @@ class Item(BaseModel):
     def __init__(
         self,
         hash_key: DynamoType,
-        range_key: Optional[DynamoType],
+        range_key: DynamoType | None,
         attrs: dict[str, Any],
     ):
         self.hash_key = hash_key
@@ -327,7 +329,7 @@ class Item(BaseModel):
         for key, value in attrs.items():
             self.attrs[key] = DynamoType(value)
 
-    def __eq__(self, other: "Item") -> bool:  # type: ignore[override]
+    def __eq__(self, other: Item) -> bool:  # type: ignore[override]
         return all(
             [
                 self.hash_key == other.hash_key,
@@ -339,7 +341,7 @@ class Item(BaseModel):
     def __repr__(self) -> str:
         return f"Item: {self.to_json()}"
 
-    def __deepcopy__(self, memo: dict[int, Any]) -> "Item":
+    def __deepcopy__(self, memo: dict[int, Any]) -> Item:
         """Custom deepcopy that bypasses the expensive default pickle-based
         __reduce_ex__ protocol, and skips LimitedSizeDict size validation
         during copy (the source item already passed validation on write)."""
@@ -389,7 +391,7 @@ class Item(BaseModel):
         return attributes
 
     def describe_attrs(
-        self, attributes: Optional[dict[str, Any]] = None
+        self, attributes: dict[str, Any] | None = None
     ) -> dict[str, dict[str, Any]]:
         if attributes:
             included = {}
@@ -484,7 +486,7 @@ class Item(BaseModel):
                     f"{action} action not support for update_with_attribute_updates"
                 )
 
-    def project(self, projection_expressions: list[list[str]]) -> "Item":
+    def project(self, projection_expressions: list[list[str]]) -> Item:
         # Returns a new Item with only the dictionary-keys that match the provided projection_expression
         # Will return an empty Item if the expression does not match anything
         result: dict[str, Any] = {}
@@ -500,9 +502,7 @@ class Item(BaseModel):
             attrs=serializer.serialize(result)["M"],
         )
 
-    def is_within_segment(
-        self, segments: Union[tuple[None, None], tuple[int, int]]
-    ) -> bool:
+    def is_within_segment(self, segments: tuple[None, None] | tuple[int, int]) -> bool:
         """
         Segments can be either (x, y) or (None, None)
         None, None => the user requested the entire table, so the item always falls within that

--- a/moto/dynamodb/models/table.py
+++ b/moto/dynamodb/models/table.py
@@ -2,7 +2,7 @@ import copy
 import math
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import unix_time_millis, utcnow
@@ -101,8 +101,8 @@ class GlobalSecondaryIndex(SecondaryIndex):
         projection: dict[str, Any],
         table_key_attrs: list[str],
         status: str = "ACTIVE",
-        throughput: Optional[dict[str, Any]] = None,
-        warm_throughput: Optional[dict[str, Any]] = None,
+        throughput: dict[str, Any] | None = None,
+        warm_throughput: dict[str, Any] | None = None,
     ):
         super().__init__(index_name, schema, projection, table_key_attrs)
         self.status = status
@@ -161,8 +161,8 @@ class StreamRecord(BaseModel):
         table: "Table",
         stream_type: str,
         event_name: str,
-        old: Optional[Item],
-        new: Optional[Item],
+        old: Item | None,
+        new: Item | None,
         seq: int,
     ):
         old_a = old.to_json()["Attributes"] if old is not None else {}
@@ -219,7 +219,7 @@ class StreamShard(BaseModel):
             },
         }
 
-    def add(self, old: Optional[Item], new: Optional[Item]) -> None:
+    def add(self, old: Item | None, new: Item | None) -> None:
         t = self.table.stream_specification["StreamViewType"]  # type: ignore
         if old is None:
             event_name = "INSERT"
@@ -257,24 +257,24 @@ class Table(CloudFormationModel):
         region: str,
         schema: list[dict[str, Any]],
         attr: list[dict[str, str]],
-        throughput: Optional[dict[str, int]] = None,
-        billing_mode: Optional[str] = None,
-        indexes: Optional[list[dict[str, Any]]] = None,
-        global_indexes: Optional[list[dict[str, Any]]] = None,
-        streams: Optional[dict[str, Any]] = None,
-        sse_specification: Optional[dict[str, Any]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        deletion_protection_enabled: Optional[bool] = False,
-        warm_throughput: Optional[dict[str, Any]] = None,
+        throughput: dict[str, int] | None = None,
+        billing_mode: str | None = None,
+        indexes: list[dict[str, Any]] | None = None,
+        global_indexes: list[dict[str, Any]] | None = None,
+        streams: dict[str, Any] | None = None,
+        sse_specification: dict[str, Any] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        deletion_protection_enabled: bool | None = False,
+        warm_throughput: dict[str, Any] | None = None,
     ):
         self.name = table_name
         self.account_id = account_id
         self.region_name = region
         self.attr = attr
         self.schema = schema
-        self.range_key_attr: Optional[str] = None
+        self.range_key_attr: str | None = None
         self.hash_key_attr: str = ""
-        self.range_key_type: Optional[str] = None
+        self.range_key_type: str | None = None
         self.hash_key_type: str = ""
         for elem in schema:
             attr_type = [
@@ -325,9 +325,9 @@ class Table(CloudFormationModel):
             "TimeToLiveStatus": "DISABLED"  # One of 'ENABLING'|'DISABLING'|'ENABLED'|'DISABLED',
             # 'AttributeName': 'string'  # Can contain this
         }
-        self.stream_specification: Optional[dict[str, Any]] = {"StreamEnabled": False}
-        self.latest_stream_label: Optional[str] = None
-        self.stream_shard: Optional[StreamShard] = None
+        self.stream_specification: dict[str, Any] | None = {"StreamEnabled": False}
+        self.latest_stream_label: str | None = None
+        self.stream_shard: StreamShard | None = None
         self.set_stream_specification(streams)
         self.lambda_event_source_mappings: dict[str, Any] = {}
         self.continuous_backups: dict[str, Any] = {
@@ -458,7 +458,7 @@ class Table(CloudFormationModel):
     def _generate_arn(self, name: str) -> str:
         return f"arn:{get_partition(self.region_name)}:dynamodb:{self.region_name}:{self.account_id}:table/{name}"
 
-    def set_stream_specification(self, streams: Optional[dict[str, Any]]) -> None:
+    def set_stream_specification(self, streams: dict[str, Any] | None) -> None:
         self.stream_specification = streams
         if (
             self.stream_specification
@@ -543,7 +543,7 @@ class Table(CloudFormationModel):
                     raise RangeKeyTooLong
 
     def _validate_item_types(
-        self, item_attrs: dict[str, Any], attr: Optional[str] = None
+        self, item_attrs: dict[str, Any], attr: str | None = None
     ) -> None:
         for key, value in item_attrs.items():
             if isinstance(value, dict):
@@ -617,12 +617,12 @@ class Table(CloudFormationModel):
     def put_item(
         self,
         item_attrs: dict[str, Any],
-        expected: Optional[dict[str, Any]] = None,
-        condition_expression: Optional[str] = None,
-        expression_attribute_names: Optional[dict[str, str]] = None,
-        expression_attribute_values: Optional[dict[str, Any]] = None,
+        expected: dict[str, Any] | None = None,
+        condition_expression: str | None = None,
+        expression_attribute_names: dict[str, str] | None = None,
+        expression_attribute_values: dict[str, Any] | None = None,
         overwrite: bool = False,
-        return_values_on_condition_check_failure: Optional[str] = None,
+        return_values_on_condition_check_failure: str | None = None,
     ) -> Item:
         if self.hash_key_attr not in item_attrs.keys():
             raise MockValidationException(
@@ -708,9 +708,9 @@ class Table(CloudFormationModel):
     def get_item(
         self,
         hash_key: DynamoType,
-        range_key: Optional[DynamoType] = None,
-        projection_expression: Optional[list[list[str]]] = None,
-    ) -> Optional[Item]:
+        range_key: DynamoType | None = None,
+        projection_expression: list[list[str]] | None = None,
+    ) -> Item | None:
         if self.has_range_key and not range_key:
             raise MockValidationException(
                 "Table has a range key, but no range key was passed into get_item"
@@ -731,8 +731,8 @@ class Table(CloudFormationModel):
             return None
 
     def delete_item(
-        self, hash_key: DynamoType, range_key: Optional[DynamoType]
-    ) -> Optional[Item]:
+        self, hash_key: DynamoType, range_key: DynamoType | None
+    ) -> Item | None:
         try:
             if range_key:
                 item = self.items[hash_key].pop(range_key)
@@ -748,24 +748,24 @@ class Table(CloudFormationModel):
 
     def query(
         self,
-        hash_key: Optional[DynamoType],
-        range_comparison: Optional[str],
+        hash_key: DynamoType | None,
+        range_comparison: str | None,
         range_objs: list[DynamoType],
         limit: int,
         exclusive_start_key: dict[str, Any],
         scan_index_forward: bool,
-        projection_expressions: Optional[list[list[str]]],
-        index_name: Optional[str] = None,
+        projection_expressions: list[list[str]] | None,
+        index_name: str | None = None,
         consistent_read: bool = False,
         filter_expression: Any = None,
-        hash_key_conditions: Optional[list[tuple[str, DynamoType]]] = None,
-        range_key_conditions: Optional[list[tuple[str, str, list[DynamoType]]]] = None,
+        hash_key_conditions: list[tuple[str, DynamoType]] | None = None,
+        range_key_conditions: list[tuple[str, str, list[DynamoType]]] | None = None,
         **filter_kwargs: Any,
-    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
+    ) -> tuple[list[Item], int, dict[str, Any] | None]:
         # FIND POSSIBLE RESULTS
         # Initialize variables for range key handling
-        index_range_key: Optional[dict[str, str]] = None
-        last_range_key_name: Optional[str] = None
+        index_range_key: dict[str, str] | None = None
+        last_range_key_name: str | None = None
 
         # Extract last_range_key_name from range_key_conditions if present
         if range_key_conditions:
@@ -822,7 +822,7 @@ class Table(CloudFormationModel):
             # Note: For backward compatibility with _generate_attr_to_sort_by, we always
             # include table range key (even if None) when there's only one GSI range key
             if index_range_keys:
-                range_attrs: list[Optional[str]] = [
+                range_attrs: list[str | None] = [
                     k["AttributeName"] for k in index_range_keys
                 ]
                 # Always append table range key for backward compatibility with sorting
@@ -942,7 +942,7 @@ class Table(CloudFormationModel):
 
             if range_comparison:
                 # Determine which attribute to apply the range comparison to
-                range_attr_for_comparison: Optional[str] = None
+                range_attr_for_comparison: str | None = None
                 if last_range_key_name:
                     # Multi-attribute key: use the specific range key from the query
                     range_attr_for_comparison = last_range_key_name
@@ -1038,11 +1038,11 @@ class Table(CloudFormationModel):
         limit: int,
         exclusive_start_key: dict[str, Any],
         filter_expression: Any = None,
-        index_name: Optional[str] = None,
+        index_name: str | None = None,
         consistent_read: bool = False,
-        projection_expression: Optional[list[list[str]]] = None,
-        segments: Union[tuple[None, None], tuple[int, int]] = (None, None),
-    ) -> tuple[list[Item], int, Optional[dict[str, Any]]]:
+        projection_expression: list[list[str]] | None = None,
+        segments: tuple[None, None] | tuple[int, int] = (None, None),
+    ) -> tuple[list[Item], int, dict[str, Any] | None]:
         results: list[Item] = []
         result_size = 0
         scanned_count = 0
@@ -1159,7 +1159,7 @@ class Table(CloudFormationModel):
         item: Item,
         dct: dict[str, Any],
         hash_key_attrs: list[str],
-        range_key_attrs: list[Optional[str]],
+        range_key_attrs: list[str | None],
         scan_index_forward: bool,
     ) -> bool:
         """
@@ -1190,7 +1190,7 @@ class Table(CloudFormationModel):
     def sorted_items(
         self,
         hash_key_attrs: list[str],
-        range_key_attrs: list[Optional[str]],
+        range_key_attrs: list[str | None],
         items: list[Item],
     ) -> list[Item]:
         attrs_to_sort_by = self._generate_attr_to_sort_by(
@@ -1202,7 +1202,7 @@ class Table(CloudFormationModel):
         return items
 
     def _generate_attr_to_sort_by(
-        self, hash_key_attrs: list[str], range_key_attrs: list[Optional[str]]
+        self, hash_key_attrs: list[str], range_key_attrs: list[str | None]
     ) -> list[str]:
         # For GSI queries, hash_key_attrs = [gsi_hash_keys..., table_hash_key]
         # and range_key_attrs = [gsi_range_keys..., table_range_key]
@@ -1224,7 +1224,7 @@ class Table(CloudFormationModel):
             table_range_key = range_key_attrs[0] if range_key_attrs else None
 
         # Sort order: GSI hash keys, GSI range keys, table hash key, table range key
-        attrs_to_sort_by: list[Optional[str]] = []
+        attrs_to_sort_by: list[str | None] = []
         attrs_to_sort_by.extend(gsi_hash_keys)
         attrs_to_sort_by.extend(gsi_range_keys)
         attrs_to_sort_by.append(table_hash_key)
@@ -1234,7 +1234,7 @@ class Table(CloudFormationModel):
         ]
 
     def _get_last_evaluated_key(
-        self, last_result: Item, index_name: Optional[str]
+        self, last_result: Item, index_name: str | None
     ) -> dict[str, Any]:
         last_evaluated_key = {self.hash_key_attr: last_result.hash_key}
         if self.range_key_attr is not None and last_result.range_key is not None:
@@ -1259,8 +1259,8 @@ class Backup:
         region_name: str,
         name: str,
         table: Table,
-        status: Optional[str] = None,
-        type_: Optional[str] = None,
+        status: str | None = None,
+        type_: str | None = None,
     ):
         self.region_name = region_name
         self.account_id = account_id

--- a/moto/dynamodb/models/table_export.py
+++ b/moto/dynamodb/models/table_export.py
@@ -1,5 +1,5 @@
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from moto.core.utils import gzip_compress
@@ -34,8 +34,8 @@ class TableExport(Thread):
         self.account_id = account_id
         self.region_name = region_name
 
-        self.failure_code: Optional[str] = None
-        self.failure_message: Optional[str] = None
+        self.failure_code: str | None = None
+        self.failure_message: str | None = None
         self.item_count = 0
         self.processed_bytes = 0
         self.error_count = 0

--- a/moto/dynamodb/models/table_import.py
+++ b/moto/dynamodb/models/table_import.py
@@ -1,5 +1,5 @@
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from moto.core.utils import gzip_decompress
@@ -19,11 +19,11 @@ class TableImport(Thread):
         region_name: str,
         table_name: str,
         billing_mode: str,
-        throughput: Optional[dict[str, int]],
+        throughput: dict[str, int] | None,
         key_schema: list[dict[str, str]],
-        global_indexes: Optional[list[dict[str, Any]]],
+        global_indexes: list[dict[str, Any]] | None,
         attrs: list[dict[str, str]],
-        compression_type: Optional[str],
+        compression_type: str | None,
     ):
         super().__init__()
         self.partition = get_partition(region_name)
@@ -41,9 +41,9 @@ class TableImport(Thread):
         self.attrs = attrs
         self.compression_type = compression_type
 
-        self.failure_code: Optional[str] = None
-        self.failure_message: Optional[str] = None
-        self.table: Optional[Table] = None
+        self.failure_code: str | None = None
+        self.failure_message: str | None = None
+        self.table: Table | None = None
         self.table_arn = f"arn:{get_partition(self.region_name)}:dynamodb:{self.region_name}:{self.account_id}:table/{table_name}"
 
         self.processed_count = 0

--- a/moto/dynamodb/models/utilities.py
+++ b/moto/dynamodb/models/utilities.py
@@ -2,7 +2,7 @@ import base64
 import json
 import re
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 
 class DynamoJsonEncoder(json.JSONEncoder):
@@ -71,8 +71,8 @@ def bytesize(val: str) -> int:
 def find_nested_key(
     keys: list[str],
     dct: dict[str, Any],
-    processed_keys: Optional[list[str]] = None,
-    result: Optional[dict[str, Any]] = None,
+    processed_keys: list[str] | None = None,
+    result: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     keys   : A list of keys that may be present in the provided dictionary

--- a/moto/dynamodb/parsing/executors.py
+++ b/moto/dynamodb/parsing/executors.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.dynamodb.exceptions import (
     IncorrectDataType,
@@ -39,7 +39,7 @@ class NodeExecutor:
 
     def get_item_part_for_path_nodes(
         self, item: Item, path_nodes: list[Node]
-    ) -> Union[DynamoType, dict[str, Any]]:
+    ) -> DynamoType | dict[str, Any]:
         """
         For a list of path nodes travers the item by following the path_nodes
         Args:
@@ -56,9 +56,7 @@ class NodeExecutor:
                 self.expression_attribute_names
             ).resolve_expression_path_nodes_to_dynamo_type(item, path_nodes)
 
-    def get_item_before_end_of_path(
-        self, item: Item
-    ) -> Union[DynamoType, dict[str, Any]]:
+    def get_item_before_end_of_path(self, item: Item) -> DynamoType | dict[str, Any]:
         """
         Get the part ot the item where the item will perform the action. For most actions this should be the parent. As
         that element will need to be modified by the action.
@@ -72,7 +70,7 @@ class NodeExecutor:
             item, self.get_path_expression_nodes()[:-1]
         )
 
-    def get_item_at_end_of_path(self, item: Item) -> Union[DynamoType, dict[str, Any]]:
+    def get_item_at_end_of_path(self, item: Item) -> DynamoType | dict[str, Any]:
         """
         For a DELETE the path points at the stringset so we need to evaluate the full path.
         Args:
@@ -122,7 +120,7 @@ class SetExecutor(NodeExecutor):
     @classmethod
     def set(  # type: ignore[misc]
         cls,
-        item_part_to_modify_with_set: Union[DynamoType, dict[str, Any]],
+        item_part_to_modify_with_set: DynamoType | dict[str, Any],
         element_to_set: Any,
         value_to_set: Any,
         expression_attribute_names: dict[str, str],
@@ -287,7 +285,7 @@ class UpdateExpressionExecutor:
         self.item = item
         self.expression_attribute_names = expression_attribute_names
 
-    def execute(self, node: Optional[Node] = None) -> None:
+    def execute(self, node: Node | None = None) -> None:
         """
         As explained in moto.dynamodb.parsing.expressions.NestableExpressionParserMixin._create_node the order of nodes
         in the AST can be translated of the order of statements in the expression. As such we can start at the root node
@@ -312,7 +310,7 @@ class UpdateExpressionExecutor:
         else:
             node_executor(node, self.expression_attribute_names).execute(self.item)
 
-    def get_specific_execution(self, node: Node) -> Optional[type[NodeExecutor]]:
+    def get_specific_execution(self, node: Node) -> type[NodeExecutor] | None:
         for node_class in self.execution_map:
             if isinstance(node, node_class):
                 return self.execution_map[node_class]

--- a/moto/dynamodb/parsing/key_condition_expression.py
+++ b/moto/dynamodb/parsing/key_condition_expression.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.dynamodb.exceptions import KeyIsEmptyStringException, MockValidationException
 from moto.utilities.tokenizer import GenericTokenizer
@@ -42,10 +42,10 @@ def parse_expression(
         - expression_attribute_names_used: List of expression attribute names used
     """
 
-    current_stage: Optional[EXPRESSION_STAGES] = None
+    current_stage: EXPRESSION_STAGES | None = None
     current_phrase = ""
     key_name = comparison = ""
-    key_values: list[Union[dict[str, str], str]] = []
+    key_values: list[dict[str, str] | str] = []
     expression_attribute_names_used: list[str] = []
     results: list[tuple[str, str, Any]] = []
     tokenizer = GenericTokenizer(key_condition_expression)

--- a/moto/dynamodb/parsing/partiql.py
+++ b/moto/dynamodb/parsing/partiql.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.dynamodb.exceptions import MockValidationException, ResourceNotFoundException
 
@@ -10,7 +10,7 @@ def query(
     statement: str, source_data: dict[str, list[Any]], parameters: list[dict[str, Any]]
 ) -> tuple[
     list[dict[str, Any]],
-    dict[str, list[tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]]],
+    dict[str, list[tuple[dict[str, Any] | None, dict[str, Any] | None]]],
 ]:
     from py_partiql_parser import DynamoDBStatementParser
     from py_partiql_parser.exceptions import DocumentNotFoundException

--- a/moto/dynamodb/parsing/reserved_keywords.py
+++ b/moto/dynamodb/parsing/reserved_keywords.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.utilities.utils import load_resource_as_str
 
 
@@ -10,7 +8,7 @@ class ReservedKeywords:
         'Invalid UpdateExpression: Syntax error; token: "1", near: "VALUE 1"'
     """
 
-    KEYWORDS: Optional[list[str]] = None
+    KEYWORDS: list[str] | None = None
 
     @classmethod
     def get_reserved_keywords(cls) -> list[str]:

--- a/moto/dynamodb/parsing/tokens.py
+++ b/moto/dynamodb/parsing/tokens.py
@@ -1,5 +1,4 @@
 import re
-from typing import Union
 
 from moto.dynamodb.exceptions import (
     InvalidExpressionAttributeNameKey,
@@ -54,7 +53,7 @@ class Token:
         NUMBER: "Number",
     }
 
-    def __init__(self, token_type: Union[int, str], value: str):
+    def __init__(self, token_type: int | str, value: str):
         assert (
             token_type in self.SPECIAL_CHARACTERS
             or token_type in self.PLACEHOLDER_NAMES
@@ -153,7 +152,7 @@ class ExpressionTokenizer:
 
         return ExpressionTokenizer(input_expression_str)._make_list()
 
-    def add_token(self, token_type: Union[int, str], token_value: str) -> None:
+    def add_token(self, token_type: int | str, token_value: str) -> None:
         self.token_list.append(Token(token_type, token_value))
 
     def add_token_from_stage(self, token_type: int) -> None:

--- a/moto/dynamodb/parsing/validators.py
+++ b/moto/dynamodb/parsing/validators.py
@@ -5,7 +5,7 @@ See docstring class Validator below for more details on validation
 from abc import abstractmethod
 from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, Union
+from typing import Any
 
 from moto.dynamodb.exceptions import (
     AttributeDoesNotExist,
@@ -92,13 +92,13 @@ class ExpressionPathResolver:
 
     def resolve_expression_path(
         self, item: Item, update_expression_path: UpdateExpressionPath
-    ) -> Union[NoneExistingPath, DDBTypedValue]:
+    ) -> NoneExistingPath | DDBTypedValue:
         assert isinstance(update_expression_path, UpdateExpressionPath)
         return self.resolve_expression_path_nodes(item, update_expression_path.children)
 
     def resolve_expression_path_nodes(
         self, item: Item, update_expression_path_nodes: list[Node]
-    ) -> Union[NoneExistingPath, DDBTypedValue]:
+    ) -> NoneExistingPath | DDBTypedValue:
         target = item.attrs
 
         for child in update_expression_path_nodes:
@@ -167,12 +167,10 @@ class ExpressionAttributeResolvingProcessor(DepthFirstTraverser):  # type: ignor
 
     def pre_processing_of_child(
         self,
-        parent_node: Union[
-            UpdateExpressionSetAction,
-            UpdateExpressionRemoveAction,
-            UpdateExpressionDeleteAction,
-            UpdateExpressionAddAction,
-        ],
+        parent_node: UpdateExpressionSetAction
+        | UpdateExpressionRemoveAction
+        | UpdateExpressionDeleteAction
+        | UpdateExpressionAddAction,
         child_id: int,
     ) -> None:
         """
@@ -214,7 +212,7 @@ class ExpressionAttributeResolvingProcessor(DepthFirstTraverser):  # type: ignor
 
     def resolve_expression_path(
         self, node: DDBTypedValue
-    ) -> Union[NoneExistingPath, DDBTypedValue]:
+    ) -> NoneExistingPath | DDBTypedValue:
         return ExpressionPathResolver(
             self.expression_attribute_names
         ).resolve_expression_path(self.item, node)

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -3,7 +3,7 @@ import itertools
 import json
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
@@ -86,7 +86,7 @@ def include_consumed_capacity(
 
 
 def validate_put_has_empty_keys(
-    field_updates: dict[str, Any], table: Table, custom_error_msg: Optional[str] = None
+    field_updates: dict[str, Any], table: Table, custom_error_msg: str | None = None
 ) -> None:
     """
     Error if any keys have an empty value. Checks Global index attributes as well
@@ -157,7 +157,7 @@ def validate_put_has_gsi_keys_set_to_none(item: dict[str, Any], table: Table) ->
 
 
 def validate_attributes_used(
-    attribute_names: Optional[dict[str, Any]],
+    attribute_names: dict[str, Any] | None,
     names_used: list[str],
     provided_attr: str = "Names",
 ) -> None:
@@ -186,8 +186,8 @@ def check_projection_expression(expression: str) -> None:
 class ProjectionExpressionParser:
     def __init__(
         self,
-        projection_expression: Optional[str],
-        expression_attribute_names: Optional[dict[str, str]],
+        projection_expression: str | None,
+        expression_attribute_names: dict[str, str] | None,
     ):
         self.projection_expression = projection_expression
         self.expression_attribute_names = (
@@ -235,7 +235,7 @@ class DynamoHandler(BaseResponse):
         super().__init__(service_name="dynamodb")
         self.automated_parameter_parsing = True
 
-    def get_endpoint_name(self, headers: Any) -> Optional[str]:
+    def get_endpoint_name(self, headers: Any) -> str | None:
         """Parses request headers and extracts part od the X-Amz-Target
         that corresponds to a method of DynamoHandler
 
@@ -326,12 +326,12 @@ class DynamoHandler(BaseResponse):
     def _validate_table_creation(
         self,
         billing_mode: str,
-        throughput: Optional[dict[str, Any]],
+        throughput: dict[str, Any] | None,
         key_schema: list[dict[str, str]],
-        global_indexes: Optional[list[dict[str, Any]]],
-        local_secondary_indexes: Optional[list[dict[str, Any]]],
+        global_indexes: list[dict[str, Any]] | None,
+        local_secondary_indexes: list[dict[str, Any]] | None,
         attr: list[dict[str, str]],
-        warm_throughput: Optional[dict[str, Any]],
+        warm_throughput: dict[str, Any] | None,
     ) -> None:
         # Validate Throughput
         if billing_mode == "PAY_PER_REQUEST" and throughput:
@@ -522,7 +522,7 @@ class DynamoHandler(BaseResponse):
                     + dump_list(actual_attrs)
                 )
 
-    def _get_filter_expression(self) -> Optional[str]:
+    def _get_filter_expression(self) -> str | None:
         filter_expression = self.body.get("FilterExpression")
         if filter_expression == "":
             raise MockValidationException(
@@ -530,7 +530,7 @@ class DynamoHandler(BaseResponse):
             )
         return filter_expression
 
-    def _get_projection_expression(self) -> Optional[str]:
+    def _get_projection_expression(self) -> str | None:
         expression = self.body.get("ProjectionExpression")
         if expression == "":
             raise MockValidationException(

--- a/moto/dynamodb_v20111205/models.py
+++ b/moto/dynamodb_v20111205/models.py
@@ -1,7 +1,7 @@
 import json
 from collections import OrderedDict, defaultdict
 from collections.abc import Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -12,7 +12,7 @@ from .comparisons import get_comparison_func
 
 
 class DynamoJsonEncoder(json.JSONEncoder):
-    def default(self, o: Any) -> Optional[str]:  # type: ignore[return]
+    def default(self, o: Any) -> str | None:  # type: ignore[return]
         if hasattr(o, "to_json"):
             return o.to_json()
 
@@ -62,8 +62,8 @@ class Item(BaseModel):
         self,
         hash_key: DynamoType,
         hash_key_type: str,
-        range_key: Optional[DynamoType],
-        range_key_type: Optional[str],
+        range_key: DynamoType | None,
+        range_key_type: str | None,
         attrs: dict[str, Any],
     ):
         self.hash_key = hash_key
@@ -103,10 +103,10 @@ class Table(BaseModel):
         name: str,
         hash_key_attr: str,
         hash_key_type: str,
-        range_key_attr: Optional[str] = None,
-        range_key_type: Optional[str] = None,
-        read_capacity: Optional[str] = None,
-        write_capacity: Optional[str] = None,
+        range_key_attr: str | None = None,
+        range_key_type: str | None = None,
+        read_capacity: str | None = None,
+        write_capacity: str | None = None,
     ):
         self.account_id = account_id
         self.name = name
@@ -117,9 +117,7 @@ class Table(BaseModel):
         self.read_capacity = read_capacity
         self.write_capacity = write_capacity
         self.created_at = utcnow()
-        self.items: dict[DynamoType, Union[Item, dict[DynamoType, Item]]] = defaultdict(
-            dict
-        )
+        self.items: dict[DynamoType, Item | dict[DynamoType, Item]] = defaultdict(dict)
 
     @property
     def has_range_key(self) -> bool:
@@ -167,7 +165,7 @@ class Table(BaseModel):
     def put_item(self, item_attrs: dict[str, Any]) -> Item:
         hash_value = DynamoType(item_attrs.get(self.hash_key_attr))  # type: ignore[arg-type]
         if self.has_range_key:
-            range_value: Optional[DynamoType] = DynamoType(
+            range_value: DynamoType | None = DynamoType(
                 item_attrs.get(self.range_key_attr)  # type: ignore[arg-type]
             )
         else:
@@ -184,8 +182,8 @@ class Table(BaseModel):
         return item
 
     def get_item(
-        self, hash_key: DynamoType, range_key: Optional[DynamoType]
-    ) -> Optional[Item]:
+        self, hash_key: DynamoType, range_key: DynamoType | None
+    ) -> Item | None:
         if self.has_range_key and not range_key:
             raise ValueError(
                 "Table has a range key, but no range key was passed into get_item"
@@ -259,8 +257,8 @@ class Table(BaseModel):
         return results, scanned_count, last_page
 
     def delete_item(
-        self, hash_key: DynamoType, range_key: Optional[DynamoType]
-    ) -> Optional[Item]:
+        self, hash_key: DynamoType, range_key: DynamoType | None
+    ) -> Item | None:
         try:
             if range_key:
                 return self.items[hash_key].pop(range_key)  # type: ignore
@@ -272,9 +270,9 @@ class Table(BaseModel):
     def update_item(
         self,
         hash_key: DynamoType,
-        range_key: Optional[DynamoType],
+        range_key: DynamoType | None,
         attr_updates: dict[str, Any],
-    ) -> Optional[Item]:
+    ) -> Item | None:
         item = self.get_item(hash_key, range_key)
         if not item:
             return None
@@ -299,7 +297,7 @@ class DynamoDBBackend(BaseBackend):
         self.tables[name] = table
         return table
 
-    def delete_table(self, name: str) -> Optional[Table]:
+    def delete_table(self, name: str) -> Table | None:
         return self.tables.pop(name, None)
 
     def update_table_throughput(
@@ -310,7 +308,7 @@ class DynamoDBBackend(BaseBackend):
         table.write_capacity = new_write_units
         return table
 
-    def put_item(self, table_name: str, item_attrs: dict[str, Any]) -> Optional[Item]:
+    def put_item(self, table_name: str, item_attrs: dict[str, Any]) -> Item | None:
         table = self.tables.get(table_name)
         if not table:
             return None
@@ -321,8 +319,8 @@ class DynamoDBBackend(BaseBackend):
         self,
         table_name: str,
         hash_key_dict: dict[str, Any],
-        range_key_dict: Optional[dict[str, Any]],
-    ) -> Optional[Item]:
+        range_key_dict: dict[str, Any] | None,
+    ) -> Item | None:
         table = self.tables.get(table_name)
         if not table:
             return None
@@ -338,7 +336,7 @@ class DynamoDBBackend(BaseBackend):
         hash_key_dict: dict[str, Any],
         range_comparison: str,
         range_value_dicts: list[dict[str, Any]],
-    ) -> tuple[Optional[Iterable[Item]], Optional[bool]]:
+    ) -> tuple[Iterable[Item] | None, bool | None]:
         table = self.tables.get(table_name)
         if not table:
             return None, None
@@ -350,7 +348,7 @@ class DynamoDBBackend(BaseBackend):
 
     def scan(
         self, table_name: str, filters: dict[str, Any]
-    ) -> tuple[Optional[list[Item]], Optional[int], Optional[bool]]:
+    ) -> tuple[list[Item] | None, int | None, bool | None]:
         table = self.tables.get(table_name)
         if not table:
             return None, None, None
@@ -366,8 +364,8 @@ class DynamoDBBackend(BaseBackend):
         self,
         table_name: str,
         hash_key_dict: dict[str, Any],
-        range_key_dict: Optional[dict[str, Any]],
-    ) -> Optional[Item]:
+        range_key_dict: dict[str, Any] | None,
+    ) -> Item | None:
         table = self.tables.get(table_name)
         if not table:
             return None
@@ -381,9 +379,9 @@ class DynamoDBBackend(BaseBackend):
         self,
         table_name: str,
         hash_key_dict: dict[str, Any],
-        range_key_dict: Optional[dict[str, Any]],
+        range_key_dict: dict[str, Any] | None,
         attr_updates: dict[str, Any],
-    ) -> Optional[Item]:
+    ) -> Item | None:
         table = self.tables.get(table_name)
         if not table:
             return None

--- a/moto/dynamodb_v20111205/responses.py
+++ b/moto/dynamodb_v20111205/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import BaseResponse
@@ -12,7 +12,7 @@ class DynamoHandler(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="dynamodb")
 
-    def get_endpoint_name(self, headers: dict[str, str]) -> Optional[str]:  # type: ignore[return]
+    def get_endpoint_name(self, headers: dict[str, str]) -> str | None:  # type: ignore[return]
         """Parses request headers and extracts part od the X-Amz-Target
         that corresponds to a method of DynamoHandler
 
@@ -92,7 +92,7 @@ class DynamoHandler(BaseResponse):
         )
         return dynamo_json_dump(table.describe)
 
-    def delete_table(self) -> Union[str, TYPE_RESPONSE]:
+    def delete_table(self) -> str | TYPE_RESPONSE:
         name = self.body["TableName"]
         table = self.backend.delete_table(name)
         if table:
@@ -111,7 +111,7 @@ class DynamoHandler(BaseResponse):
         )
         return dynamo_json_dump(table.describe)
 
-    def describe_table(self) -> Union[TYPE_RESPONSE, str]:
+    def describe_table(self) -> TYPE_RESPONSE | str:
         name = self.body["TableName"]
         try:
             table = self.backend.tables[name]
@@ -120,7 +120,7 @@ class DynamoHandler(BaseResponse):
             return self.error(er)
         return dynamo_json_dump(table.describe)
 
-    def put_item(self) -> Union[TYPE_RESPONSE, str]:
+    def put_item(self) -> TYPE_RESPONSE | str:
         name = self.body["TableName"]
         item = self.body["Item"]
         result = self.backend.put_item(name, item)
@@ -159,7 +159,7 @@ class DynamoHandler(BaseResponse):
 
         return dynamo_json_dump(response)
 
-    def get_item(self) -> Union[TYPE_RESPONSE, str]:
+    def get_item(self) -> TYPE_RESPONSE | str:
         name = self.body["TableName"]
         key = self.body["Key"]
         hash_key = key["HashKeyElement"]
@@ -201,7 +201,7 @@ class DynamoHandler(BaseResponse):
             }
         return dynamo_json_dump(results)
 
-    def query(self) -> Union[TYPE_RESPONSE, str]:
+    def query(self) -> TYPE_RESPONSE | str:
         name = self.body["TableName"]
         hash_key = self.body["HashKeyValue"]
         range_condition = self.body.get("RangeKeyCondition")
@@ -232,7 +232,7 @@ class DynamoHandler(BaseResponse):
         #     }
         return dynamo_json_dump(result)
 
-    def scan(self) -> Union[TYPE_RESPONSE, str]:
+    def scan(self) -> TYPE_RESPONSE | str:
         name = self.body["TableName"]
 
         filters = {}
@@ -265,7 +265,7 @@ class DynamoHandler(BaseResponse):
         #     }
         return dynamo_json_dump(result)
 
-    def delete_item(self) -> Union[TYPE_RESPONSE, str]:
+    def delete_item(self) -> TYPE_RESPONSE | str:
         name = self.body["TableName"]
         key = self.body["Key"]
         hash_key = key["HashKeyElement"]
@@ -283,7 +283,7 @@ class DynamoHandler(BaseResponse):
             er = "com.amazonaws.dynamodb.v20111205#ResourceNotFoundException"
             return self.error(er)
 
-    def update_item(self) -> Union[TYPE_RESPONSE, str]:
+    def update_item(self) -> TYPE_RESPONSE | str:
         name = self.body["TableName"]
         key = self.body["Key"]
         hash_key = key["HashKeyElement"]

--- a/moto/dynamodbstreams/models.py
+++ b/moto/dynamodbstreams/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import base64
 import os
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -16,7 +16,7 @@ class ShardIterator(BaseModel):
         streams_backend: DynamoDBStreamsBackend,
         stream_shard: StreamShard,
         shard_iterator_type: str,
-        sequence_number: Optional[int] = None,
+        sequence_number: int | None = None,
     ):
         self.id = base64.b64encode(os.urandom(472)).decode("utf-8")
         self.streams_backend = streams_backend
@@ -89,7 +89,7 @@ class DynamoDBStreamsBackend(BaseBackend):
         }
         return stream
 
-    def list_streams(self, table_name: Optional[str] = None) -> list[dict[str, Any]]:
+    def list_streams(self, table_name: str | None = None) -> list[dict[str, Any]]:
         streams = []
         for table in self.dynamodb.tables.values():
             if table_name is not None and table.name != table_name:
@@ -110,7 +110,7 @@ class DynamoDBStreamsBackend(BaseBackend):
         arn: str,
         shard_id: str,
         shard_iterator_type: str,
-        sequence_number: Optional[str] = None,
+        sequence_number: str | None = None,
     ) -> ShardIterator:
         table = self._get_table_from_arn(arn)
         assert table.stream_shard.id == shard_id  # type: ignore[union-attr]

--- a/moto/ebs/models.py
+++ b/moto/ebs/models.py
@@ -1,6 +1,6 @@
 """EBSBackend class with methods for supported APIs."""
 
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -72,7 +72,7 @@ class EBSBackend(BaseBackend):
         return ec2_backends[self.account_id][self.region_name]
 
     def start_snapshot(
-        self, volume_size: int, tags: Optional[list[dict[str, str]]], description: str
+        self, volume_size: int, tags: list[dict[str, str]] | None, description: str
     ) -> EBSSnapshot:
         """
         The following parameters are not yet implemented: ParentSnapshotId, ClientToken, Encrypted, KmsKeyArn, Timeout
@@ -123,14 +123,14 @@ class EBSBackend(BaseBackend):
 
     def list_changed_blocks(
         self, first_snapshot_id: str, second_snapshot_id: str
-    ) -> tuple[dict[str, tuple[str, Optional[str]]], EBSSnapshot]:
+    ) -> tuple[dict[str, tuple[str, str | None]], EBSSnapshot]:
         """
         The following parameters are not yet implemented: NextToken, MaxResults, StartingBlockIndex
         """
         snapshot1 = self.snapshots[first_snapshot_id]
         snapshot2 = self.snapshots[second_snapshot_id]
         changed_blocks: dict[
-            str, tuple[str, Optional[str]]
+            str, tuple[str, str | None]
         ] = {}  # {idx: (token1, token2), ..}
         for idx in snapshot1.blocks:
             block1 = snapshot1.blocks[idx]

--- a/moto/ec2/exceptions.py
+++ b/moto/ec2/exceptions.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.exceptions import ServiceException
 
@@ -79,7 +79,7 @@ class InvalidParameterCombination(EC2ClientError):
 
 
 class MalformedDHCPOptionsIdError(EC2ClientError):
-    def __init__(self, dhcp_options_id: Optional[str]):
+    def __init__(self, dhcp_options_id: str | None):
         super().__init__(
             "InvalidDhcpOptionsId.Malformed",
             f'Invalid id: "{dhcp_options_id}" (expecting "dopt-...")',
@@ -303,7 +303,7 @@ class InvalidInstanceTypeError(EC2ClientError):
 
 
 class InvalidAMIIdError(EC2ClientError):
-    def __init__(self, ami_id: Union[list[str], str]):
+    def __init__(self, ami_id: list[str] | str):
         if isinstance(ami_id, str):
             message = f"The image id '[{ami_id}]' does not exist"
         elif len(ami_id) > 1:
@@ -327,7 +327,7 @@ class UnvailableAMIIdError(EC2ClientError):
 
 
 class InvalidAMIAttributeItemValueError(EC2ClientError):
-    def __init__(self, attribute: str, value: Union[str, Iterable[str], None]):
+    def __init__(self, attribute: str, value: str | Iterable[str] | None):
         super().__init__(
             "InvalidAMIAttributeItemValue",
             f'Invalid attribute item value "{value}" for {attribute} item type.',
@@ -603,7 +603,7 @@ class MotoNotImplementedError(NotImplementedError):
 
 
 class FilterNotImplementedError(MotoNotImplementedError):
-    def __init__(self, filter_name: str, method_name: Optional[str]):
+    def __init__(self, filter_name: str, method_name: str | None):
         super().__init__(f"The filter '{filter_name}' for {method_name}")
 
 
@@ -644,7 +644,7 @@ class LastEniDetachError(OperationNotPermitted):
 
 class InvalidAvailabilityZoneError(EC2ClientError):
     def __init__(
-        self, availability_zone_value: Optional[str], valid_availability_zones: str
+        self, availability_zone_value: str | None, valid_availability_zones: str
     ):
         super().__init__(
             "InvalidParameterValue",
@@ -781,7 +781,7 @@ class InvalidLaunchTemplateIdNotFound(EC2ClientError):
 
 
 class InvalidLaunchTemplateVersionNotFound(EC2ClientError):
-    def __init__(self, version: str, template_id: Optional[str] = None):
+    def __init__(self, version: str, template_id: str | None = None):
         if template_id:
             msg = f"Could not find the specified version {version} for the launch template with ID {template_id}."
         else:
@@ -878,7 +878,7 @@ class InvalidCarrierGatewayID(EC2ClientError):
 
 
 class InvalidTransitGatewayID(EC2ClientError):
-    def __init__(self, transit_gateway_id: str, msg: Optional[str] = None):
+    def __init__(self, transit_gateway_id: str, msg: str | None = None):
         super().__init__(
             "InvalidTransitGatewayID.NotFound",
             msg or f"The transitGateway ID '{transit_gateway_id}' does not exist",

--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import json
 import os
 import re
 from datetime import datetime
 from os import environ
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from moto import settings
 from moto.core.parse import default_timestamp_parser as parse_timestamp
@@ -36,29 +38,29 @@ class Ami(TaggedEC2Resource):
         self,
         ec2_backend: Any,
         ami_id: str,
-        instance: Optional[Instance] = None,
-        source_ami: Optional["Ami"] = None,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
-        owner_id: Optional[str] = None,
-        owner_alias: Optional[str] = None,
+        instance: Instance | None = None,
+        source_ami: Ami | None = None,
+        name: str | None = None,
+        description: str | None = None,
+        owner_id: str | None = None,
+        owner_alias: str | None = None,
         public: bool = False,
-        virtualization_type: Optional[str] = None,
-        architecture: Optional[str] = None,
+        virtualization_type: str | None = None,
+        architecture: str | None = None,
         state: str = "available",
-        creation_date: Optional[datetime] = None,
-        platform: Optional[str] = None,
+        creation_date: datetime | None = None,
+        platform: str | None = None,
         image_type: str = "machine",
-        image_location: Optional[str] = None,
-        hypervisor: Optional[str] = None,
+        image_location: str | None = None,
+        hypervisor: str | None = None,
         root_device_type: str = "standard",
         root_device_name: str = "/dev/sda1",
         sriov: str = "simple",
         region_name: str = "us-east-1a",
-        snapshot_description: Optional[str] = None,
-        product_codes: Optional[set[str]] = None,
+        snapshot_description: str | None = None,
+        product_codes: set[str] | None = None,
         boot_mode: str = "uefi",
-        tags: Optional[dict[str, Any]] = None,
+        tags: dict[str, Any] | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = ami_id
@@ -80,7 +82,7 @@ class Ami(TaggedEC2Resource):
         self.creation_date = creation_date or utcnow()
         self.product_codes = product_codes or set()
         self.boot_mode = boot_mode
-        self.instance_id: Optional[str] = None
+        self.instance_id: str | None = None
 
         if tags is not None:
             self.add_tags(tags)
@@ -142,12 +144,10 @@ class Ami(TaggedEC2Resource):
         ]
 
     @property
-    def source_instance_id(self) -> Optional[str]:
+    def source_instance_id(self) -> str | None:
         return self.instance_id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "virtualization-type":
             return self.virtualization_type
         elif filter_name == "kernel-id":
@@ -254,8 +254,8 @@ class AmiBackend:
         self,
         source_image_id: str,
         source_region: str,
-        name: Optional[str] = None,
-        description: Optional[str] = None,
+        name: str | None = None,
+        description: str | None = None,
     ) -> Ami:
         from ..models import ec2_backends
 
@@ -275,10 +275,10 @@ class AmiBackend:
 
     def describe_images(
         self,
-        ami_ids: Optional[list[str]] = None,
-        filters: Optional[dict[str, Any]] = None,
-        exec_users: Optional[list[str]] = None,
-        owners: Optional[list[str]] = None,
+        ami_ids: list[str] | None = None,
+        filters: dict[str, Any] | None = None,
+        exec_users: list[str] | None = None,
+        owners: list[str] | None = None,
     ) -> list[Ami]:
         images = list(self.amis.copy().values())
 
@@ -379,7 +379,7 @@ class AmiBackend:
                 pass
 
     def register_image(
-        self, name: Optional[str] = None, description: Optional[str] = None
+        self, name: str | None = None, description: str | None = None
     ) -> Ami:
         ami_id = random_ami_id()
         ami = Ami(

--- a/moto/ec2/models/availability_zones_and_regions.py
+++ b/moto/ec2/models/availability_zones_and_regions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from boto3 import Session
 
@@ -25,7 +25,7 @@ class Zone:
         self.zone_id = zone_id
         self.zone_type = zone_type
         self.state = "available"
-        self.messages: list[dict[str, Optional[str]]] = []
+        self.messages: list[dict[str, str | None]] = []
 
 
 class RegionsAndZonesBackend:
@@ -202,9 +202,7 @@ class RegionsAndZonesBackend:
                 Zone(region_name=name, name=f"{name}c", zone_id=f"{shorthand}-az3"),
             ]
 
-    def describe_regions(
-        self, region_names: Optional[list[str]] = None
-    ) -> list[Region]:
+    def describe_regions(self, region_names: list[str] | None = None) -> list[Region]:
         if not region_names:
             return self.regions
         ret = []
@@ -216,9 +214,9 @@ class RegionsAndZonesBackend:
 
     def describe_availability_zones(
         self,
-        filters: Optional[list[dict[str, Any]]] = None,
-        zone_names: Optional[list[str]] = None,
-        zone_ids: Optional[list[str]] = None,
+        filters: list[dict[str, Any]] | None = None,
+        zone_names: list[str] | None = None,
+        zone_ids: list[str] | None = None,
     ) -> list[Zone]:
         """
         The following parameters are supported: ZoneIds, ZoneNames, Filters
@@ -240,7 +238,7 @@ class RegionsAndZonesBackend:
         result = [r for r in result if not zone_names or r.name in zone_names]
         return result
 
-    def get_zone_by_name(self, name: str) -> Optional[Zone]:
+    def get_zone_by_name(self, name: str) -> Zone | None:
         for zone in self.describe_availability_zones():
             if zone.name == name:
                 return zone

--- a/moto/ec2/models/carrier_gateways.py
+++ b/moto/ec2/models/carrier_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.utilities.utils import filter_resources
 
@@ -9,7 +9,7 @@ from .core import TaggedEC2Resource
 
 class CarrierGateway(TaggedEC2Resource):
     def __init__(
-        self, ec2_backend: Any, vpc_id: str, tags: Optional[dict[str, str]] = None
+        self, ec2_backend: Any, vpc_id: str, tags: dict[str, str] | None = None
     ):
         self.id = random_carrier_gateway_id()
         self.ec2_backend = ec2_backend
@@ -31,7 +31,7 @@ class CarrierGatewayBackend:
         self.carrier_gateways: dict[str, CarrierGateway] = {}
 
     def create_carrier_gateway(
-        self, vpc_id: str, tags: Optional[dict[str, str]] = None
+        self, vpc_id: str, tags: dict[str, str] | None = None
     ) -> CarrierGateway:
         vpc = self.get_vpc(vpc_id)  # type: ignore[attr-defined]
         if not vpc:
@@ -48,7 +48,7 @@ class CarrierGatewayBackend:
         return carrier_gateway
 
     def describe_carrier_gateways(
-        self, ids: Optional[list[str]] = None, filters: Any = None
+        self, ids: list[str] | None = None, filters: Any = None
     ) -> list[CarrierGateway]:
         carrier_gateways = list(self.carrier_gateways.values())
 

--- a/moto/ec2/models/core.py
+++ b/moto/ec2/models/core.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import BaseModel
 
@@ -27,9 +27,7 @@ class TaggedEC2Resource(BaseModel):
         for key, value in tag_map.items():
             self.ec2_backend.create_tags([self.id], {key: value})  # type: ignore[attr-defined]
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         tags = self.get_tags()
 
         if filter_name.startswith("tag:"):

--- a/moto/ec2/models/customer_gateways.py
+++ b/moto/ec2/models/customer_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from ..exceptions import InvalidCustomerGatewayIdError
 from ..utils import random_customer_gateway_id
@@ -14,7 +14,7 @@ class CustomerGateway(TaggedEC2Resource):
         ip_address: str,
         bgp_asn: str,
         state: str = "available",
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = gateway_id
@@ -25,9 +25,7 @@ class CustomerGateway(TaggedEC2Resource):
         self.add_tags(tags or {})
         super().__init__()
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         return super().get_filter_value(filter_name, "DescribeCustomerGateways")
 
 
@@ -40,7 +38,7 @@ class CustomerGatewayBackend:
         gateway_type: str,
         ip_address: str,
         bgp_asn: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> CustomerGateway:
         customer_gateway_id = random_customer_gateway_id()
         customer_gateway = CustomerGateway(
@@ -50,7 +48,7 @@ class CustomerGatewayBackend:
         return customer_gateway
 
     def describe_customer_gateways(
-        self, filters: Any = None, customer_gateway_ids: Optional[list[str]] = None
+        self, filters: Any = None, customer_gateway_ids: list[str] | None = None
     ) -> list[CustomerGateway]:
         customer_gateways = list(self.customer_gateways.copy().values())
         if customer_gateway_ids:

--- a/moto/ec2/models/dhcp_options.py
+++ b/moto/ec2/models/dhcp_options.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, Optional
+from typing import Any
 
 from ..exceptions import (
     DependencyViolationError,
@@ -15,11 +15,11 @@ class DHCPOptionsSet(TaggedEC2Resource):
     def __init__(
         self,
         ec2_backend: Any,
-        domain_name_servers: Optional[list[str]] = None,
-        domain_name: Optional[str] = None,
-        ntp_servers: Optional[list[str]] = None,
-        netbios_name_servers: Optional[list[str]] = None,
-        netbios_node_type: Optional[str] = None,
+        domain_name_servers: list[str] | None = None,
+        domain_name: str | None = None,
+        ntp_servers: list[str] | None = None,
+        netbios_name_servers: list[str] | None = None,
+        netbios_node_type: str | None = None,
     ):
         self.ec2_backend = ec2_backend
         self._options = {
@@ -32,9 +32,7 @@ class DHCPOptionsSet(TaggedEC2Resource):
         self.id = random_dhcp_option_id()
         self.vpc = None
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         """
         API Version 2015-10-01 defines the following filters for DescribeDhcpOptions:
 
@@ -81,11 +79,11 @@ class DHCPOptionsSetBackend:
 
     def create_dhcp_options(
         self,
-        domain_name_servers: Optional[list[str]] = None,
-        domain_name: Optional[str] = None,
-        ntp_servers: Optional[list[str]] = None,
-        netbios_name_servers: Optional[list[str]] = None,
-        netbios_node_type: Optional[str] = None,
+        domain_name_servers: list[str] | None = None,
+        domain_name: str | None = None,
+        ntp_servers: list[str] | None = None,
+        netbios_name_servers: list[str] | None = None,
+        netbios_node_type: str | None = None,
     ) -> DHCPOptionsSet:
         NETBIOS_NODE_TYPES = [1, 2, 4, 8]
 
@@ -107,7 +105,7 @@ class DHCPOptionsSetBackend:
         self.dhcp_options_sets[options.id] = options
         return options
 
-    def delete_dhcp_options_set(self, options_id: Optional[str]) -> None:
+    def delete_dhcp_options_set(self, options_id: str | None) -> None:
         if not (options_id and options_id.startswith("dopt-")):
             raise MalformedDHCPOptionsIdError(options_id)
 
@@ -119,7 +117,7 @@ class DHCPOptionsSetBackend:
             raise InvalidDHCPOptionsIdError(options_id)
 
     def describe_dhcp_options(
-        self, dhcp_options_ids: Optional[list[str]] = None, filters: Any = None
+        self, dhcp_options_ids: list[str] | None = None, filters: Any = None
     ) -> list[DHCPOptionsSet]:
         dhcp_options_sets = list(self.dhcp_options_sets.copy().values())
 

--- a/moto/ec2/models/elastic_block_store.py
+++ b/moto/ec2/models/elastic_block_store.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.core.utils import utcnow
@@ -31,25 +31,25 @@ GP3_DEFAULT_IOPS = 3000
 
 
 class VolumeModification:
-    original_size: Optional[int] = None
-    target_size: Optional[int] = None
-    original_volume_type: Optional[str] = None
-    target_volume_type: Optional[str] = None
-    original_iops: Optional[int] = None
-    target_iops: Optional[int] = None
-    original_throughput: Optional[int] = None
-    target_throughput: Optional[int] = None
-    original_multi_attach_enabled: Optional[bool] = None
-    target_multi_attach_enabled: Optional[bool] = None
+    original_size: int | None = None
+    target_size: int | None = None
+    original_volume_type: str | None = None
+    target_volume_type: str | None = None
+    original_iops: int | None = None
+    target_iops: int | None = None
+    original_throughput: int | None = None
+    target_throughput: int | None = None
+    original_multi_attach_enabled: bool | None = None
+    target_multi_attach_enabled: bool | None = None
 
     def __init__(
         self,
         volume: "Volume",
-        target_size: Optional[int] = None,
-        target_volume_type: Optional[str] = None,
-        target_iops: Optional[int] = None,
-        target_throughput: Optional[int] = None,
-        target_multi_attach_enabled: Optional[bool] = None,
+        target_size: int | None = None,
+        target_volume_type: str | None = None,
+        target_iops: int | None = None,
+        target_throughput: int | None = None,
+        target_multi_attach_enabled: bool | None = None,
     ):
         if not any(
             [
@@ -172,20 +172,20 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
         volume_id: str,
         size: int,
         zone: Any,
-        snapshot_id: Optional[str] = None,
+        snapshot_id: str | None = None,
         encrypted: bool = False,
-        kms_key_id: Optional[str] = None,
-        volume_type: Optional[str] = None,
-        iops: Optional[int] = None,
-        throughput: Optional[int] = None,
-        multi_attach_enabled: Optional[bool] = None,
+        kms_key_id: str | None = None,
+        volume_type: str | None = None,
+        iops: int | None = None,
+        throughput: int | None = None,
+        multi_attach_enabled: bool | None = None,
     ):
         self.id = volume_id
         self.volume_type = volume_type or "gp2"
         self.size = size
         self.zone = zone
         self.create_time = utcnow()
-        self.attachment: Optional[VolumeAttachment] = None
+        self.attachment: VolumeAttachment | None = None
         self.snapshot_id = snapshot_id
         self.ec2_backend = ec2_backend
         self.encrypted = encrypted
@@ -197,11 +197,11 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
 
     def modify(
         self,
-        target_size: Optional[int] = None,
-        target_volume_type: Optional[str] = None,
-        target_iops: Optional[int] = None,
-        target_throughput: Optional[int] = None,
-        target_multi_attach_enabled: Optional[bool] = None,
+        target_size: int | None = None,
+        target_volume_type: str | None = None,
+        target_iops: int | None = None,
+        target_throughput: int | None = None,
+        target_multi_attach_enabled: bool | None = None,
     ) -> None:
         modification = VolumeModification(
             volume=self,
@@ -261,7 +261,7 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
         return self.id
 
     @property
-    def availability_zone(self) -> Optional[str]:
+    def availability_zone(self) -> str | None:
         return self.zone.name if self.zone else None
 
     @property
@@ -277,9 +277,7 @@ class Volume(TaggedEC2Resource, CloudFormationModel):
         else:
             return "available"
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name.startswith("attachment") and not self.attachment:
             return None
         elif filter_name == "attachment.attach-time":
@@ -316,9 +314,9 @@ class Snapshot(TaggedEC2Resource):
         volume: Any,
         description: str,
         encrypted: bool = False,
-        kms_key_id: Optional[str] = None,
-        owner_id: Optional[str] = None,
-        from_ami: Optional[str] = None,
+        kms_key_id: str | None = None,
+        owner_id: str | None = None,
+        from_ami: str | None = None,
     ):
         self.id = snapshot_id
         self.volume = volume
@@ -349,9 +347,7 @@ class Snapshot(TaggedEC2Resource):
     def progress(self) -> str:
         return "100%"
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "description":
             return self.description
         elif filter_name == "snapshot-id":
@@ -385,13 +381,13 @@ class EBSBackend:
         self,
         size: int,
         zone_name: str,
-        snapshot_id: Optional[str] = None,
+        snapshot_id: str | None = None,
         encrypted: bool = False,
-        kms_key_id: Optional[str] = None,
-        volume_type: Optional[str] = None,
-        iops: Optional[int] = None,
-        throughput: Optional[int] = None,
-        multi_attach_enabled: Optional[bool] = None,
+        kms_key_id: str | None = None,
+        volume_type: str | None = None,
+        iops: int | None = None,
+        throughput: int | None = None,
+        multi_attach_enabled: bool | None = None,
     ) -> Volume:
         if kms_key_id and not encrypted:
             raise InvalidParameterDependency("KmsKeyId", "Encrypted")
@@ -439,7 +435,7 @@ class EBSBackend:
         return volume
 
     def describe_volumes(
-        self, volume_ids: Optional[list[str]] = None, filters: Any = None
+        self, volume_ids: list[str] | None = None, filters: Any = None
     ) -> list[Volume]:
         matches = list(self.volumes.values())
         if volume_ids:
@@ -454,11 +450,11 @@ class EBSBackend:
     def modify_volume(
         self,
         volume_id: str,
-        target_size: Optional[int] = None,
-        target_volume_type: Optional[str] = None,
-        target_iops: Optional[int] = None,
-        target_throughput: Optional[int] = None,
-        target_multi_attach_enabled: Optional[bool] = None,
+        target_size: int | None = None,
+        target_volume_type: str | None = None,
+        target_iops: int | None = None,
+        target_throughput: int | None = None,
+        target_multi_attach_enabled: bool | None = None,
     ) -> Volume:
         volume = self.get_volume(volume_id)
         volume.modify(
@@ -471,7 +467,7 @@ class EBSBackend:
         return volume
 
     def describe_volumes_modifications(
-        self, volume_ids: Optional[list[str]] = None, filters: Any = None
+        self, volume_ids: list[str] | None = None, filters: Any = None
     ) -> list[VolumeModification]:
         volumes = self.describe_volumes(volume_ids)
         modifications = []
@@ -501,7 +497,7 @@ class EBSBackend:
         instance_id: str,
         device_path: str,
         delete_on_termination: bool = False,
-    ) -> Optional[VolumeAttachment]:
+    ) -> VolumeAttachment | None:
         volume = self.get_volume(volume_id)
         instance = self.get_instance(instance_id)  # type: ignore[attr-defined]
 
@@ -545,8 +541,8 @@ class EBSBackend:
         self,
         volume_id: str,
         description: str,
-        owner_id: Optional[str] = None,
-        from_ami: Optional[str] = None,
+        owner_id: str | None = None,
+        from_ami: str | None = None,
     ) -> Snapshot:
         snapshot_id = random_snapshot_id()
         volume = self.get_volume(volume_id)
@@ -591,7 +587,7 @@ class EBSBackend:
         return snapshots
 
     def describe_snapshots(
-        self, snapshot_ids: Optional[list[str]] = None, filters: Any = None
+        self, snapshot_ids: list[str] | None = None, filters: Any = None
     ) -> list[Snapshot]:
         matches = list(self.snapshots.values())
         if snapshot_ids:
@@ -607,7 +603,7 @@ class EBSBackend:
         source_snapshot_id: str,
         source_region: str,
         description: str,
-        kms_key_id: Optional[str],
+        kms_key_id: str | None,
     ) -> Snapshot:
         from ..models import ec2_backends
 
@@ -664,8 +660,8 @@ class EBSBackend:
     def remove_create_volume_permission(
         self,
         snapshot_id: str,
-        user_ids: Optional[list[str]] = None,
-        groups: Optional[Iterable[str]] = None,
+        user_ids: list[str] | None = None,
+        groups: Iterable[str] | None = None,
     ) -> None:
         snapshot = self.get_snapshot(snapshot_id)
         if user_ids:

--- a/moto/ec2/models/elastic_ip_addresses.py
+++ b/moto/ec2/models/elastic_ip_addresses.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 
@@ -23,8 +23,8 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
         self,
         ec2_backend: Any,
         domain: str,
-        address: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        address: str | None = None,
+        tags: dict[str, str] | None = None,
     ):
         self.ec2_backend = ec2_backend
         if address:
@@ -36,7 +36,7 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
         self.domain = domain
         self.instance = None
         self.eni = None
-        self.association_id: Optional[str] = None
+        self.association_id: str | None = None
         self.add_tags(tags or {})
 
     @property
@@ -48,11 +48,11 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
         return self.eni.id if self.eni else ""
 
     @property
-    def network_interface_owner_id(self) -> Optional[str]:
+    def network_interface_owner_id(self) -> str | None:
         return self.eni.owner_id if self.eni else None
 
     @property
-    def private_ip_address(self) -> Optional[str]:
+    def private_ip_address(self) -> str | None:
         return self.eni.private_ip_address if self.eni else None
 
     @staticmethod
@@ -108,9 +108,7 @@ class ElasticAddress(TaggedEC2Resource, CloudFormationModel):
             return self.allocation_id
         raise UnformattedGetAttTemplateException()
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "allocation-id":
             return self.allocation_id
         elif filter_name == "association-id":
@@ -145,8 +143,8 @@ class ElasticAddressBackend:
     def allocate_address(
         self,
         domain: str,
-        address: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        address: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> ElasticAddress:
         if domain not in ["standard", "vpc"]:
             domain = "vpc"
@@ -202,8 +200,8 @@ class ElasticAddressBackend:
         self,
         instance: Any = None,
         eni: Any = None,
-        address: Optional[str] = None,
-        allocation_id: Optional[str] = None,
+        address: str | None = None,
+        allocation_id: str | None = None,
         reassociate: bool = False,
     ) -> ElasticAddress:
         eips = []
@@ -235,8 +233,8 @@ class ElasticAddressBackend:
 
     def describe_addresses(
         self,
-        allocation_ids: Optional[list[str]] = None,
-        public_ips: Optional[list[str]] = None,
+        allocation_ids: list[str] | None = None,
+        public_ips: list[str] | None = None,
         filters: Any = None,
     ) -> list[ElasticAddress]:
         matches = self.addresses.copy()
@@ -256,12 +254,12 @@ class ElasticAddressBackend:
         return matches
 
     def describe_addresses_attribute(
-        self, allocation_ids: Optional[list[str]] = None
+        self, allocation_ids: list[str] | None = None
     ) -> list[ElasticAddress]:
         return self.describe_addresses(allocation_ids)
 
     def disassociate_address(
-        self, address: Optional[str] = None, association_id: Optional[str] = None
+        self, address: str | None = None, association_id: str | None = None
     ) -> None:
         eips = []
         if address:
@@ -280,7 +278,7 @@ class ElasticAddressBackend:
         eip.association_id = None
 
     def release_address(
-        self, address: Optional[str] = None, allocation_id: Optional[str] = None
+        self, address: str | None = None, allocation_id: str | None = None
     ) -> None:
         eips = []
         if address:

--- a/moto/ec2/models/elastic_network_interfaces.py
+++ b/moto/ec2/models/elastic_network_interfaces.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from moto.core.common_models import CloudFormationModel
 
@@ -44,36 +44,36 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         self,
         ec2_backend: Any,
         subnet: Any,
-        private_ip_address: Union[list[str], str],
-        private_ip_addresses: Optional[list[dict[str, Any]]] = None,
+        private_ip_address: list[str] | str,
+        private_ip_addresses: list[dict[str, Any]] | None = None,
         device_index: int = 0,
         public_ip_auto_assign: bool = False,
-        group_ids: Optional[list[str]] = None,
-        description: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        delete_on_termination: Optional[bool] = False,
+        group_ids: list[str] | None = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
+        delete_on_termination: bool | None = False,
         **kwargs: Any,
     ):
         self.ec2_backend = ec2_backend
         self.id = random_eni_id()
-        self.device_index: Optional[int] = device_index
+        self.device_index: int | None = device_index
         if isinstance(private_ip_address, list) and private_ip_address:
             private_ip_address = private_ip_address[0]
-        self.private_ip_address: Optional[str] = private_ip_address or None  # type: ignore
+        self.private_ip_address: str | None = private_ip_address or None  # type: ignore
         self.private_ip_addresses: list[dict[str, Any]] = private_ip_addresses or []
         self.ipv6_addresses = kwargs.get("ipv6_addresses") or []
 
         self.subnet = subnet
         if isinstance(subnet, str):
             self.subnet = self.ec2_backend.get_subnet(subnet)
-        self.instance: Optional[Instance] = None
-        self.attachment_id: Optional[str] = None
-        self.attach_time: Optional[datetime] = None
+        self.instance: Instance | None = None
+        self.attachment_id: str | None = None
+        self.attach_time: datetime | None = None
         self.delete_on_termination = delete_on_termination
         self.description = description or ""
         self.source_dest_check = True
 
-        self.public_ip: Optional[str] = None
+        self.public_ip: str | None = None
         self.public_ip_auto_assign = public_ip_auto_assign
         self.start()
         self.add_tags(tags or {})
@@ -167,7 +167,7 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
         return self.ec2_backend.account_id
 
     @property
-    def attachment(self) -> Optional[Attachment]:
+    def attachment(self) -> Attachment | None:
         if self.attachment_id:
             return Attachment(self)
         return None
@@ -327,9 +327,7 @@ class NetworkInterface(TaggedEC2Resource, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "network-interface-id":
             return self.id
         elif filter_name in ("addresses.private-ip-address", "private-ip-address"):
@@ -361,12 +359,12 @@ class NetworkInterfaceBackend:
     def create_network_interface(
         self,
         subnet: Any,
-        private_ip_address: Union[str, list[str]],
-        private_ip_addresses: Optional[list[dict[str, Any]]] = None,
-        group_ids: Optional[list[str]] = None,
-        description: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        delete_on_termination: Optional[bool] = False,
+        private_ip_address: str | list[str],
+        private_ip_addresses: list[dict[str, Any]] | None = None,
+        group_ids: list[str] | None = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
+        delete_on_termination: bool | None = False,
         **kwargs: Any,
     ) -> NetworkInterface:
         eni = NetworkInterface(
@@ -437,8 +435,8 @@ class NetworkInterfaceBackend:
         self,
         eni_id: str,
         group_ids: list[str],
-        source_dest_check: Optional[bool] = None,
-        description: Optional[str] = None,
+        source_dest_check: bool | None = None,
+        description: str | None = None,
     ) -> None:
         eni = self.get_network_interface(eni_id)
         groups = [self.get_security_group_from_id(group_id) for group_id in group_ids]  # type: ignore[attr-defined]
@@ -451,7 +449,7 @@ class NetworkInterfaceBackend:
             eni.description = description
 
     def get_all_network_interfaces(
-        self, eni_ids: Optional[list[str]] = None, filters: Any = None
+        self, eni_ids: list[str] | None = None, filters: Any = None
     ) -> list[NetworkInterface]:
         enis = list(self.enis.values())
 
@@ -464,7 +462,7 @@ class NetworkInterfaceBackend:
         return generic_filter(filters, enis)
 
     def unassign_private_ip_addresses(
-        self, eni_id: str, private_ip_address: Optional[list[str]] = None
+        self, eni_id: str, private_ip_address: list[str] | None = None
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
         if private_ip_address:
@@ -476,8 +474,8 @@ class NetworkInterfaceBackend:
     def assign_private_ip_addresses(
         self,
         eni_id: str,
-        private_ip_addresses: Optional[list[str]] = None,
-        secondary_ips_count: Optional[int] = None,
+        private_ip_addresses: list[str] | None = None,
+        secondary_ips_count: int | None = None,
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
         eni_assigned_ips = [
@@ -502,8 +500,8 @@ class NetworkInterfaceBackend:
     def assign_ipv6_addresses(
         self,
         eni_id: str,
-        ipv6_addresses: Optional[list[str]] = None,
-        ipv6_count: Optional[int] = None,
+        ipv6_addresses: list[str] | None = None,
+        ipv6_count: int | None = None,
     ) -> NetworkInterface:
         eni = self.get_network_interface(eni_id)
         if ipv6_addresses:
@@ -521,7 +519,7 @@ class NetworkInterfaceBackend:
         return eni
 
     def unassign_ipv6_addresses(
-        self, eni_id: str, ips: Optional[list[str]] = None
+        self, eni_id: str, ips: list[str] | None = None
     ) -> list[str]:
         unassigned_addresses = []
         eni = self.get_network_interface(eni_id)

--- a/moto/ec2/models/fleets.py
+++ b/moto/ec2/models/fleets.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.ec2.models.spot_requests import SpotFleetLaunchSpec, SpotInstanceRequest
 
@@ -25,8 +25,8 @@ class Fleet(TaggedEC2Resource):
         replace_unhealthy_instances: bool,
         terminate_instances_with_expiration: bool,
         fleet_type: str,
-        valid_from: Optional[datetime],
-        valid_until: Optional[datetime],
+        valid_from: datetime | None,
+        valid_until: datetime | None,
         tag_specifications: list[dict[str, Any]],
     ):
         self.ec2_backend = ec2_backend
@@ -156,7 +156,7 @@ class Fleet(TaggedEC2Resource):
         return f"{x.year}-{x.month:02d}-{x.day:02d}T{x.hour:02d}:{x.minute:02d}:{x.second:02d}.000Z"
 
     @property
-    def valid_until_as_string(self) -> Optional[str]:
+    def valid_until_as_string(self) -> str | None:
         if self.valid_until is None:
             return self.valid_until
         x = self.valid_until
@@ -167,7 +167,7 @@ class Fleet(TaggedEC2Resource):
         return self.id
 
     @property
-    def instances(self) -> Optional[list[dict[str, Any]]]:
+    def instances(self) -> list[dict[str, Any]] | None:
         """
         Return instances for instant fleets, None for other fleet types.
         This is part of the CreateFleet response for instant fleets only.
@@ -199,7 +199,7 @@ class Fleet(TaggedEC2Resource):
 
     @staticmethod
     def _build_instance_data(
-        instance: Any, lifecycle: str, launch_spec: Optional[SpotFleetLaunchSpec]
+        instance: Any, lifecycle: str, launch_spec: SpotFleetLaunchSpec | None
     ) -> dict[str, Any]:
         instance_data = {
             "Lifecycle": lifecycle,
@@ -358,8 +358,8 @@ class FleetsBackend:
         replace_unhealthy_instances: bool,
         terminate_instances_with_expiration: bool,
         fleet_type: str,
-        valid_from: Optional[datetime],
-        valid_until: Optional[datetime],
+        valid_from: datetime | None,
+        valid_until: datetime | None,
         tag_specifications: list[dict[str, Any]],
     ) -> Fleet:
         fleet_id = random_fleet_id()
@@ -381,7 +381,7 @@ class FleetsBackend:
         self.fleets[fleet_id] = fleet
         return fleet
 
-    def get_fleet(self, fleet_id: str) -> Optional[Fleet]:
+    def get_fleet(self, fleet_id: str) -> Fleet | None:
         return self.fleets.get(fleet_id)
 
     def describe_fleet_instances(self, fleet_id: str) -> list[Any]:
@@ -391,7 +391,7 @@ class FleetsBackend:
         # TODO: These are incompatible types (list[object] + list[dict]) and should be normalized.
         return fleet.spot_requests + fleet.on_demand_instances
 
-    def describe_fleets(self, fleet_ids: Optional[list[str]]) -> list[Fleet]:
+    def describe_fleets(self, fleet_ids: list[str] | None) -> list[Fleet]:
         fleets = list(self.fleets.values())
 
         if fleet_ids:

--- a/moto/ec2/models/flow_logs.py
+++ b/moto/ec2/models/flow_logs.py
@@ -1,5 +1,5 @@
 import itertools
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.core.utils import utcnow
@@ -32,7 +32,7 @@ class FlowLogs(TaggedEC2Resource, CloudFormationModel):
         log_destination_type: str,
         log_format: str,
         deliver_logs_status: str = "SUCCESS",
-        deliver_logs_error_message: Optional[str] = None,
+        deliver_logs_error_message: str | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = flow_log_id
@@ -104,9 +104,7 @@ class FlowLogs(TaggedEC2Resource, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         """
         API Version 2016-11-15 defines the following filters for DescribeFlowLogs:
 
@@ -280,7 +278,7 @@ class FlowLogsBackend:
         return flow_logs_set, unsuccessful
 
     def describe_flow_logs(
-        self, flow_log_ids: Optional[list[str]] = None, filters: Any = None
+        self, flow_log_ids: list[str] | None = None, filters: Any = None
     ) -> list[FlowLogs]:
         matches = list(itertools.chain(list(self.flow_logs.values())))
         if flow_log_ids:

--- a/moto/ec2/models/hosts.py
+++ b/moto/ec2/models/hosts.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.utils import unix_time
 
@@ -20,8 +20,8 @@ class Host(TaggedEC2Resource):
         self.state = "available"
         self.host_recovery = host_recovery or "off"
         self.zone = zone
-        self.instance_type: Optional[str] = instance_type
-        self.instance_family: Optional[str] = instance_family
+        self.instance_type: str | None = instance_type
+        self.instance_family: str | None = instance_family
         self.auto_placement = auto_placement or "on"
         self.ec2_backend = backend
         self.allocation_time = unix_time()
@@ -46,9 +46,7 @@ class Host(TaggedEC2Resource):
     def release(self) -> None:
         self.state = "released"
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "availability-zone":
             return self.zone
         if filter_name == "state":

--- a/moto/ec2/models/iam_instance_profile.py
+++ b/moto/ec2/models/iam_instance_profile.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.ec2.models.instances import Instance
@@ -45,8 +45,8 @@ class IamInstanceProfileAssociationBackend:
     def associate_iam_instance_profile(
         self,
         instance_id: str,
-        iam_instance_profile_name: Optional[str] = None,
-        iam_instance_profile_arn: Optional[str] = None,
+        iam_instance_profile_name: str | None = None,
+        iam_instance_profile_arn: str | None = None,
     ) -> IamInstanceProfileAssociation:
         iam_association_id = random_iam_instance_profile_association_id()
 
@@ -77,8 +77,8 @@ class IamInstanceProfileAssociationBackend:
         association_ids: list[str],
         filters: Any = None,
         max_results: int = 100,
-        next_token: Optional[str] = None,
-    ) -> tuple[list[IamInstanceProfileAssociation], Optional[str]]:
+        next_token: str | None = None,
+    ) -> tuple[list[IamInstanceProfileAssociation], str | None]:
         associations_list: list[IamInstanceProfileAssociation] = []
         if association_ids:
             for association in self.iam_instance_profile_associations.values():
@@ -130,8 +130,8 @@ class IamInstanceProfileAssociationBackend:
     def replace_iam_instance_profile_association(
         self,
         association_id: str,
-        iam_instance_profile_name: Optional[str] = None,
-        iam_instance_profile_arn: Optional[str] = None,
+        iam_instance_profile_name: str | None = None,
+        iam_instance_profile_arn: str | None = None,
     ) -> IamInstanceProfileAssociation:
         instance_profile = filter_iam_instance_profiles(
             self.account_id,  # type: ignore[attr-defined]

--- a/moto/ec2/models/instance_types.py
+++ b/moto/ec2/models/instance_types.py
@@ -1,6 +1,6 @@
 import pathlib
 from os import listdir
-from typing import Any, Optional
+from typing import Any
 
 from moto.utilities.utils import load_resource
 
@@ -149,7 +149,7 @@ class InstanceTypeBackend:
     instance_types = list(map(InstanceType, INSTANCE_TYPES.keys()))
 
     def describe_instance_types(
-        self, instance_types: Optional[list[str]] = None, filters: Any = None
+        self, instance_types: list[str] | None = None, filters: Any = None
     ) -> list[InstanceType]:
         matches = self.instance_types
         if instance_types:
@@ -169,8 +169,8 @@ class InstanceTypeBackend:
 class InstanceTypeOfferingBackend:
     def describe_instance_type_offerings(
         self,
-        location_type: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        location_type: str | None = None,
+        filters: dict[str, Any] | None = None,
     ) -> list[Any]:
         location_type = location_type or "region"
         matches = INSTANCE_TYPE_OFFERINGS[location_type]

--- a/moto/ec2/models/instances.py
+++ b/moto/ec2/models/instances.py
@@ -4,7 +4,7 @@ import contextlib
 import copy
 from collections import OrderedDict
 from collections.abc import ItemsView
-from typing import Any, Optional
+from typing import Any
 
 from moto import settings
 from moto.core.common_models import CloudFormationModel
@@ -61,7 +61,7 @@ class StateReason:
 
 
 class MetadataOptions:
-    def __init__(self, options: Optional[dict[str, Any]] = None):
+    def __init__(self, options: dict[str, Any] | None = None):
         options = options or {}
         self.state = options.get("State", "applied")
         self.http_tokens = options.get("HttpTokens", "optional")
@@ -96,7 +96,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         self,
         ec2_backend: Any,
         image_id: str,
-        user_data: Optional[Base64EncodedString],
+        user_data: Base64EncodedString | None,
         security_groups: list[SecurityGroup],
         **kwargs: Any,
     ):
@@ -105,7 +105,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         self.id = random_instance_id()
         self.owner_id = ec2_backend.account_id
         self.client_token = kwargs.get("client_token")
-        self.lifecycle: Optional[str] = kwargs.get("lifecycle")
+        self.lifecycle: str | None = kwargs.get("lifecycle")
 
         nics = copy.deepcopy(kwargs.get("nics", []))
 
@@ -207,7 +207,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         return self._state
 
     @property
-    def state_transition_reason(self) -> Optional[str]:
+    def state_transition_reason(self) -> str | None:
         return self._reason
 
     @property
@@ -251,7 +251,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         return {"State": self.monitoring_state}
 
     @property
-    def vpc_id(self) -> Optional[str]:
+    def vpc_id(self) -> str | None:
         if self.subnet_id:
             with contextlib.suppress(InvalidSubnetIdError):
                 subnet: Subnet = self.ec2_backend.get_subnet(self.subnet_id)
@@ -261,7 +261,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         return None
 
     @property
-    def subnet_id(self) -> Optional[str]:
+    def subnet_id(self) -> str | None:
         if self._subnet_id:
             return self._subnet_id
         if self.nics:
@@ -282,11 +282,11 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         self,
         size: int,
         device_path: str,
-        snapshot_id: Optional[str],
+        snapshot_id: str | None,
         encrypted: bool,
         delete_on_termination: bool,
-        kms_key_id: Optional[str],
-        volume_type: Optional[str],
+        kms_key_id: str | None,
+        volume_type: str | None,
     ) -> None:
         volume = self.ec2_backend.create_volume(
             size=size,
@@ -342,11 +342,11 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
         return list(self.nics.values())
 
     @property
-    def private_ip(self) -> Optional[str]:
+    def private_ip(self) -> str | None:
         return self.nics[0].private_ip_address
 
     @property
-    def private_ip_address(self) -> Optional[str]:
+    def private_ip_address(self) -> str | None:
         return self.nics[0].private_ip_address
 
     @property
@@ -358,15 +358,15 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
             return f"ip-{formatted_ip}.{self.region_name}.compute.internal"
 
     @property
-    def public_ip(self) -> Optional[str]:
+    def public_ip(self) -> str | None:
         return self.nics[0].public_ip
 
     @property
-    def public_ip_address(self) -> Optional[str]:
+    def public_ip_address(self) -> str | None:
         return self.nics[0].public_ip
 
     @property
-    def public_dns_name(self) -> Optional[str]:
+    def public_dns_name(self) -> str | None:
         if self.public_ip:
             formatted_ip = self.public_ip.replace(".", "-")
             if self.region_name == "us-east-1":
@@ -567,7 +567,7 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
     def dynamic_group_list(self) -> list[SecurityGroup]:
         return self.security_groups
 
-    def _get_private_ip_from_nic(self, nic: dict[str, Any]) -> Optional[str]:
+    def _get_private_ip_from_nic(self, nic: dict[str, Any]) -> str | None:
         private_ip = nic.get("PrivateIpAddress")
         if private_ip:
             return private_ip
@@ -579,10 +579,10 @@ class Instance(TaggedEC2Resource, BotoInstance, CloudFormationModel):
     def prep_nics(
         self,
         nic_spec: list[dict[str, Any]],
-        private_ip: Optional[str] = None,
-        associate_public_ip: Optional[bool] = None,
-        security_groups: Optional[list[SecurityGroup]] = None,
-        ipv6_address_count: Optional[int] = None,
+        private_ip: str | None = None,
+        associate_public_ip: bool | None = None,
+        security_groups: list[SecurityGroup] | None = None,
+        ipv6_address_count: int | None = None,
     ) -> None:
         self.nics: dict[int, NetworkInterface] = {}
         for nic in nic_spec:
@@ -758,7 +758,7 @@ class InstanceBackend:
         self,
         image_id: str,
         count: int,
-        user_data: Optional[Base64EncodedString],
+        user_data: Base64EncodedString | None,
         security_group_names: list[str],
         **kwargs: Any,
     ) -> Reservation:
@@ -956,12 +956,12 @@ class InstanceBackend:
     def modify_instance_metadata_options(
         self,
         instance_id: str,
-        http_tokens: Optional[str] = None,
-        hop_limit: Optional[int] = None,
-        http_endpoint: Optional[str] = None,
-        dry_run: Optional[bool] = False,
-        http_protocol: Optional[str] = None,
-        metadata_tags: Optional[str] = None,
+        http_tokens: str | None = None,
+        hop_limit: int | None = None,
+        http_endpoint: str | None = None,
+        dry_run: bool | None = False,
+        http_protocol: str | None = None,
+        metadata_tags: str | None = None,
     ) -> MetadataOptions:
         instance = self.get_instance(instance_id)
         metadata_dict = {
@@ -1048,7 +1048,7 @@ class InstanceBackend:
             raise InvalidInstanceIdError(not_found_instance_ids)
         return result
 
-    def get_instance_by_id(self, instance_id: str) -> Optional[Instance]:
+    def get_instance_by_id(self, instance_id: str) -> Instance | None:
         for reservation in self.all_reservations():
             for instance in reservation.instances:
                 if instance.id == instance_id:

--- a/moto/ec2/models/internet_gateways.py
+++ b/moto/ec2/models/internet_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 
@@ -21,7 +21,7 @@ from .vpn_gateway import VPCGatewayAttachment
 
 class EgressOnlyInternetGateway(TaggedEC2Resource):
     def __init__(
-        self, ec2_backend: Any, vpc_id: str, tags: Optional[dict[str, str]] = None
+        self, ec2_backend: Any, vpc_id: str, tags: dict[str, str] | None = None
     ):
         self.id = random_egress_only_internet_gateway_id()
         self.ec2_backend = ec2_backend
@@ -43,7 +43,7 @@ class EgressOnlyInternetGatewayBackend:
         self.egress_only_internet_gateways: dict[str, EgressOnlyInternetGateway] = {}
 
     def create_egress_only_internet_gateway(
-        self, vpc_id: str, tags: Optional[dict[str, str]] = None
+        self, vpc_id: str, tags: dict[str, str] | None = None
     ) -> EgressOnlyInternetGateway:
         vpc = self.get_vpc(vpc_id)  # type: ignore[attr-defined]
         if not vpc:
@@ -53,7 +53,7 @@ class EgressOnlyInternetGatewayBackend:
         return egress_only_igw
 
     def describe_egress_only_internet_gateways(
-        self, ids: Optional[list[str]] = None
+        self, ids: list[str] | None = None
     ) -> list[EgressOnlyInternetGateway]:
         """
         The Filters-argument is not yet supported
@@ -138,7 +138,7 @@ class InternetGatewayBackend:
         self.internet_gateways: dict[str, InternetGateway] = {}
 
     def create_internet_gateway(
-        self, tags: Optional[list[dict[str, str]]] = None
+        self, tags: list[dict[str, str]] | None = None
     ) -> InternetGateway:
         igw = InternetGateway(self)
         for tag in tags or []:
@@ -147,7 +147,7 @@ class InternetGatewayBackend:
         return igw
 
     def describe_internet_gateways(
-        self, internet_gateway_ids: Optional[list[str]] = None, filters: Any = None
+        self, internet_gateway_ids: list[str] | None = None, filters: Any = None
     ) -> list[InternetGateway]:
         igws = []
         if internet_gateway_ids is None:

--- a/moto/ec2/models/key_pairs.py
+++ b/moto/ec2/models/key_pairs.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
@@ -50,9 +50,7 @@ class KeyPair(TaggedEC2Resource):
     def public_key(self) -> str:
         return self.material_public.decode("utf-8")
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> str:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> str:
         if filter_name == "key-name":
             return self.key_name
         elif filter_name == "key-pair-id":
@@ -80,7 +78,7 @@ class KeyPairBackend:
         self.key_pairs[name] = keypair
         return keypair
 
-    def delete_key_pair(self, name: str) -> Optional[KeyPair]:
+    def delete_key_pair(self, name: str) -> KeyPair | None:
         return self.key_pairs.pop(name, None)
 
     def describe_key_pairs(

--- a/moto/ec2/models/launch_templates.py
+++ b/moto/ec2/models/launch_templates.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.core.types import Base64EncodedString
@@ -55,7 +55,7 @@ class LaunchTemplateVersion:
         return self.data.get("SecurityGroups", [])
 
     @property
-    def user_data(self) -> Optional[Base64EncodedString]:
+    def user_data(self) -> Base64EncodedString | None:
         user_data = self.data.get("UserData")
         # UserData can be specified via multiple services/api endpoints,
         # so we make an assertion here that it's in the format we expect.
@@ -119,9 +119,7 @@ class LaunchTemplate(TaggedEC2Resource, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "launch-template-name":
             return self.name
         else:
@@ -246,8 +244,8 @@ class LaunchTemplateBackend:
     def modify_launch_template(
         self,
         default_version: str,
-        template_name: Optional[str] = None,
-        template_id: Optional[str] = None,
+        template_name: str | None = None,
+        template_id: str | None = None,
     ) -> LaunchTemplate:
         if template_name:
             template_id = self.launch_template_name_to_ids.get(template_name)
@@ -273,7 +271,7 @@ class LaunchTemplateBackend:
             raise InvalidLaunchTemplateNameNotFoundWithNameError(name)
         return self.get_launch_template(self.launch_template_name_to_ids[name])
 
-    def delete_launch_template(self, name: str, tid: Optional[str]) -> LaunchTemplate:
+    def delete_launch_template(self, name: str, tid: str | None) -> LaunchTemplate:
         if name:
             tid = self.launch_template_name_to_ids.get(name)
         if tid is None:
@@ -286,8 +284,8 @@ class LaunchTemplateBackend:
 
     def describe_launch_templates(
         self,
-        template_names: Optional[list[str]] = None,
-        template_ids: Optional[list[str]] = None,
+        template_names: list[str] | None = None,
+        template_ids: list[str] | None = None,
         filters: Any = None,
     ) -> list[LaunchTemplate]:
         if template_names and not template_ids:

--- a/moto/ec2/models/managed_prefixes.py
+++ b/moto/ec2/models/managed_prefixes.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.utilities.utils import filter_resources, get_partition
 
@@ -11,12 +11,12 @@ class ManagedPrefixList(TaggedEC2Resource):
         self,
         backend: Any,
         region: str,
-        address_family: Optional[str] = None,
-        entry: Optional[list[dict[str, str]]] = None,
-        max_entries: Optional[str] = None,
-        prefix_list_name: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        owner_id: Optional[str] = None,
+        address_family: str | None = None,
+        entry: list[dict[str, str]] | None = None,
+        max_entries: str | None = None,
+        prefix_list_name: str | None = None,
+        tags: dict[str, str] | None = None,
+        owner_id: str | None = None,
     ):
         self.ec2_backend = backend
         self.address_family = address_family
@@ -26,7 +26,7 @@ class ManagedPrefixList(TaggedEC2Resource):
         self.state = "create-complete"
         self.state_message = None
         self.add_tags(tags or {})
-        self.version: Optional[int] = 1
+        self.version: int | None = 1
         self.entries = {self.version: entry} if entry else {}
         self.resource_owner_id = owner_id if owner_id else None
         self.prefix_list_arn = self.arn(region, self.owner_id)
@@ -53,12 +53,12 @@ class ManagedPrefixListBackend:
 
     def create_managed_prefix_list(
         self,
-        address_family: Optional[str] = None,
-        entry: Optional[list[dict[str, str]]] = None,
-        max_entries: Optional[str] = None,
-        prefix_list_name: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        owner_id: Optional[str] = None,
+        address_family: str | None = None,
+        entry: list[dict[str, str]] | None = None,
+        max_entries: str | None = None,
+        prefix_list_name: str | None = None,
+        tags: dict[str, str] | None = None,
+        owner_id: str | None = None,
     ) -> ManagedPrefixList:
         managed_prefix_list = ManagedPrefixList(
             self,
@@ -74,7 +74,7 @@ class ManagedPrefixListBackend:
         return managed_prefix_list
 
     def describe_managed_prefix_lists(
-        self, prefix_list_ids: Optional[list[str]] = None, filters: Any = None
+        self, prefix_list_ids: list[str] | None = None, filters: Any = None
     ) -> list[ManagedPrefixList]:
         managed_prefix_lists = list(self.managed_prefix_lists.values())
         attr_pairs = (
@@ -105,7 +105,7 @@ class ManagedPrefixListBackend:
 
     def get_managed_prefix_list_entries(
         self, prefix_list_id: str
-    ) -> Optional[ManagedPrefixList]:
+    ) -> ManagedPrefixList | None:
         return self.managed_prefix_lists.get(prefix_list_id)
 
     def delete_managed_prefix_list(self, prefix_list_id: str) -> ManagedPrefixList:
@@ -119,9 +119,9 @@ class ManagedPrefixListBackend:
         self,
         add_entry: list[dict[str, str]],
         remove_entry: list[dict[str, str]],
-        prefix_list_id: Optional[str] = None,
-        current_version: Optional[str] = None,
-        prefix_list_name: Optional[str] = None,
+        prefix_list_id: str | None = None,
+        current_version: str | None = None,
+        prefix_list_name: str | None = None,
     ) -> ManagedPrefixList:
         managed_pl: ManagedPrefixList = self.managed_prefix_lists.get(prefix_list_id)  # type: ignore
         managed_pl.prefix_list_name = prefix_list_name

--- a/moto/ec2/models/nat_gateways.py
+++ b/moto/ec2/models/nat_gateways.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
@@ -13,7 +13,7 @@ class NatGateway(CloudFormationModel, TaggedEC2Resource):
         backend: Any,
         subnet_id: str,
         allocation_id: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
         connectivity_type: str = "public",
     ):
         # public properties
@@ -85,7 +85,7 @@ class NatGatewayBackend:
         self.nat_gateways: dict[str, NatGateway] = {}
 
     def describe_nat_gateways(
-        self, filters: Any, nat_gateway_ids: Optional[list[str]]
+        self, filters: Any, nat_gateway_ids: list[str] | None
     ) -> list[NatGateway]:
         nat_gateways = list(self.nat_gateways.values())
 
@@ -124,7 +124,7 @@ class NatGatewayBackend:
         self,
         subnet_id: str,
         allocation_id: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
         connectivity_type: str = "public",
     ) -> NatGateway:
         nat_gateway = NatGateway(

--- a/moto/ec2/models/network_acls.py
+++ b/moto/ec2/models/network_acls.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, TypedDict
+from typing import Any, TypedDict
 
 from ..exceptions import (
     DependencyViolationError,
@@ -27,7 +27,7 @@ class NetworkAclBackend:
     def create_network_acl(
         self,
         vpc_id: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
         default: bool = False,
     ) -> "NetworkAcl":
         network_acl_id = random_network_acl_id()
@@ -89,11 +89,11 @@ class NetworkAclBackend:
         rule_action: str,
         egress: bool,
         cidr_block: str,
-        icmp_code: Optional[int],
-        icmp_type: Optional[int],
-        port_range_from: Optional[int],
-        port_range_to: Optional[int],
-        ipv6_cidr_block: Optional[str],
+        icmp_code: int | None,
+        icmp_type: int | None,
+        port_range_from: int | None,
+        port_range_to: int | None,
+        ipv6_cidr_block: str | None,
     ) -> "NetworkAclEntry":
         network_acl = self.get_network_acl(network_acl_id)
         if any(
@@ -144,7 +144,7 @@ class NetworkAclBackend:
         icmp_type: int,
         port_range_from: int,
         port_range_to: int,
-        ipv6_cidr_block: Optional[str],
+        ipv6_cidr_block: str | None,
     ) -> "NetworkAclEntry":
         self.delete_network_acl_entry(network_acl_id, rule_number, egress)
         network_acl_entry = self.create_network_acl_entry(
@@ -201,7 +201,7 @@ class NetworkAclBackend:
         )
 
     def describe_network_acls(
-        self, network_acl_ids: Optional[list[str]] = None, filters: Any = None
+        self, network_acl_ids: list[str] | None = None, filters: Any = None
     ) -> list["NetworkAcl"]:
         network_acls = list(self.network_acls.values())
 
@@ -227,7 +227,7 @@ class NetworkAclAssociation:
         self,
         ec2_backend: Any,
         new_association_id: str,
-        subnet_id: Optional[str],
+        subnet_id: str | None,
         network_acl_id: str,
     ):
         self.ec2_backend = ec2_backend
@@ -248,7 +248,7 @@ class NetworkAcl(TaggedEC2Resource):
         network_acl_id: str,
         vpc_id: str,
         default: bool = False,
-        owner_id: Optional[str] = None,
+        owner_id: str | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = network_acl_id
@@ -266,9 +266,7 @@ class NetworkAcl(TaggedEC2Resource):
     def associations(self) -> list["NetworkAclAssociation"]:
         return list(self._associations.values())
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "default":
             return str(self.default).lower()
         elif filter_name == "vpc-id":
@@ -305,11 +303,11 @@ class NetworkAclEntry(TaggedEC2Resource):
         rule_action: str,
         egress: bool,
         cidr_block: str,
-        icmp_code: Optional[int],
-        icmp_type: Optional[int],
-        port_range_from: Optional[int],
-        port_range_to: Optional[int],
-        ipv6_cidr_block: Optional[str],
+        icmp_code: int | None,
+        icmp_type: int | None,
+        port_range_from: int | None,
+        port_range_to: int | None,
+        ipv6_cidr_block: str | None,
     ):
         self.ec2_backend = ec2_backend
         self.network_acl_id = network_acl_id
@@ -325,7 +323,7 @@ class NetworkAclEntry(TaggedEC2Resource):
         self.port_range_to = port_range_to
 
     @property
-    def icmp_type_code(self) -> Optional[dict[str, Any]]:
+    def icmp_type_code(self) -> dict[str, Any] | None:
         if self.icmp_code is not None or self.icmp_type is not None:
             result: dict[str, Any] = {}
             if self.icmp_code is not None:
@@ -336,7 +334,7 @@ class NetworkAclEntry(TaggedEC2Resource):
         return None
 
     @property
-    def port_range(self) -> Optional[dict[str, Any]]:
+    def port_range(self) -> dict[str, Any] | None:
         if self.port_range_from is not None or self.port_range_to is not None:
             return {"From": self.port_range_from, "To": self.port_range_to}
         return None

--- a/moto/ec2/models/route_tables.py
+++ b/moto/ec2/models/route_tables.py
@@ -1,5 +1,5 @@
 import ipaddress
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.ec2.models.carrier_gateways import CarrierGateway
@@ -112,9 +112,7 @@ class RouteTable(TaggedEC2Resource, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "association.main":
             # Note: Boto only supports 'true'.
             # https://github.com/boto/boto/issues/1742
@@ -178,19 +176,19 @@ class Route(CloudFormationModel):
     def __init__(
         self,
         route_table: RouteTable,
-        destination_cidr_block: Optional[str],
-        destination_ipv6_cidr_block: Optional[str],
-        destination_prefix_list: Optional[ManagedPrefixList] = None,
+        destination_cidr_block: str | None,
+        destination_ipv6_cidr_block: str | None,
+        destination_prefix_list: ManagedPrefixList | None = None,
         local: bool = False,
-        gateway: Optional[VpnGateway] = None,
-        instance: Optional[Instance] = None,
-        nat_gateway: Optional[NatGateway] = None,
-        egress_only_igw: Optional[EgressOnlyInternetGateway] = None,
-        transit_gateway: Optional[TransitGateway] = None,
-        interface: Optional[NetworkInterface] = None,
-        vpc_pcx: Optional[VPCPeeringConnection] = None,
-        carrier_gateway: Optional[CarrierGateway] = None,
-        vpc_endpoint_id: Optional[str] = None,
+        gateway: VpnGateway | None = None,
+        instance: Instance | None = None,
+        nat_gateway: NatGateway | None = None,
+        egress_only_igw: EgressOnlyInternetGateway | None = None,
+        transit_gateway: TransitGateway | None = None,
+        interface: NetworkInterface | None = None,
+        vpc_pcx: VPCPeeringConnection | None = None,
+        carrier_gateway: CarrierGateway | None = None,
+        vpc_endpoint_id: str | None = None,
     ):
         self.id = generate_route_id(
             route_table.id,
@@ -214,7 +212,7 @@ class Route(CloudFormationModel):
         self.vpc_endpoint_id = vpc_endpoint_id
 
     @property
-    def gateway_id(self) -> Optional[str]:
+    def gateway_id(self) -> str | None:
         if self.local:
             return "local"
         if self.gateway:
@@ -224,35 +222,35 @@ class Route(CloudFormationModel):
         return None
 
     @property
-    def instance_id(self) -> Optional[str]:
+    def instance_id(self) -> str | None:
         return self.instance.id if self.instance else None
 
     @property
-    def nat_gateway_id(self) -> Optional[str]:
+    def nat_gateway_id(self) -> str | None:
         return self.nat_gateway.id if self.nat_gateway else None
 
     @property
-    def egress_only_internet_gateway_id(self) -> Optional[str]:
+    def egress_only_internet_gateway_id(self) -> str | None:
         return self.egress_only_igw.id if self.egress_only_igw else None
 
     @property
-    def transit_gateway_id(self) -> Optional[str]:
+    def transit_gateway_id(self) -> str | None:
         return self.transit_gateway.id if self.transit_gateway else None
 
     @property
-    def network_interface_id(self) -> Optional[str]:
+    def network_interface_id(self) -> str | None:
         return self.interface.id if self.interface else None
 
     @property
-    def vpc_peering_connection_id(self) -> Optional[str]:
+    def vpc_peering_connection_id(self) -> str | None:
         return self.vpc_pcx.id if self.vpc_pcx else None
 
     @property
-    def carrier_gateway_id(self) -> Optional[str]:
+    def carrier_gateway_id(self) -> str | None:
         return self.carrier_gateway.id if self.carrier_gateway else None
 
     @property
-    def destination_prefix_list_id(self) -> Optional[str]:
+    def destination_prefix_list_id(self) -> str | None:
         return self.destination_prefix_list.id if self.destination_prefix_list else None
 
     @property
@@ -320,7 +318,7 @@ class RouteBackend:
     def create_route_table(
         self,
         vpc_id: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
         main: bool = False,
     ) -> RouteTable:
         route_table_id = random_route_table_id()
@@ -354,7 +352,7 @@ class RouteBackend:
         return route_table
 
     def describe_route_tables(
-        self, route_table_ids: Optional[list[str]] = None, filters: Any = None
+        self, route_table_ids: list[str] | None = None, filters: Any = None
     ) -> list[RouteTable]:
         route_tables = list(self.route_tables.values())
 
@@ -385,8 +383,8 @@ class RouteBackend:
     def associate_route_table(
         self,
         route_table_id: str,
-        gateway_id: Optional[str] = None,
-        subnet_id: Optional[str] = None,
+        gateway_id: str | None = None,
+        subnet_id: str | None = None,
     ) -> str:
         # Idempotent if association already exists.
         route_tables_by_subnet = self.describe_route_tables(
@@ -411,7 +409,7 @@ class RouteBackend:
             route_table._associations[association_id] = gateway_id
             return association_id
 
-    def disassociate_route_table(self, association_id: str) -> Optional[str]:
+    def disassociate_route_table(self, association_id: str) -> str | None:
         for route_table in self.route_tables.values():
             if association_id in route_table._associations:
                 return route_table._associations.pop(association_id, None)
@@ -448,19 +446,19 @@ class RouteBackend:
     def create_route(
         self,
         route_table_id: str,
-        destination_cidr_block: Optional[str],
-        destination_ipv6_cidr_block: Optional[str] = None,
-        destination_prefix_list_id: Optional[str] = None,
+        destination_cidr_block: str | None,
+        destination_ipv6_cidr_block: str | None = None,
+        destination_prefix_list_id: str | None = None,
         local: bool = False,
-        gateway_id: Optional[str] = None,
-        instance_id: Optional[str] = None,
-        nat_gateway_id: Optional[str] = None,
-        egress_only_igw_id: Optional[str] = None,
-        transit_gateway_id: Optional[str] = None,
-        interface_id: Optional[str] = None,
-        vpc_peering_connection_id: Optional[str] = None,
-        carrier_gateway_id: Optional[str] = None,
-        vpc_endpoint_id: Optional[str] = None,
+        gateway_id: str | None = None,
+        instance_id: str | None = None,
+        nat_gateway_id: str | None = None,
+        egress_only_igw_id: str | None = None,
+        transit_gateway_id: str | None = None,
+        interface_id: str | None = None,
+        vpc_peering_connection_id: str | None = None,
+        carrier_gateway_id: str | None = None,
+        vpc_endpoint_id: str | None = None,
     ) -> Route:
         gateway = None
         nat_gateway = None
@@ -535,15 +533,15 @@ class RouteBackend:
         self,
         route_table_id: str,
         destination_cidr_block: str,
-        destination_ipv6_cidr_block: Optional[str] = None,
-        destination_prefix_list_id: Optional[str] = None,
-        nat_gateway_id: Optional[str] = None,
-        egress_only_igw_id: Optional[str] = None,
-        transit_gateway_id: Optional[str] = None,
-        gateway_id: Optional[str] = None,
-        instance_id: Optional[str] = None,
-        interface_id: Optional[str] = None,
-        vpc_peering_connection_id: Optional[str] = None,
+        destination_ipv6_cidr_block: str | None = None,
+        destination_prefix_list_id: str | None = None,
+        nat_gateway_id: str | None = None,
+        egress_only_igw_id: str | None = None,
+        transit_gateway_id: str | None = None,
+        gateway_id: str | None = None,
+        instance_id: str | None = None,
+        interface_id: str | None = None,
+        vpc_peering_connection_id: str | None = None,
     ) -> Route:
         cidr = destination_cidr_block
         if destination_ipv6_cidr_block:
@@ -598,8 +596,8 @@ class RouteBackend:
         self,
         route_table_id: str,
         destination_cidr_block: str,
-        destination_ipv6_cidr_block: Optional[str] = None,
-        destination_prefix_list_id: Optional[str] = None,
+        destination_ipv6_cidr_block: str | None = None,
+        destination_prefix_list_id: str | None = None,
     ) -> Route:
         cidr = destination_cidr_block
         route_table = self.get_route_table(route_table_id)

--- a/moto/ec2/models/security_groups.py
+++ b/moto/ec2/models/security_groups.py
@@ -3,7 +3,7 @@ import itertools
 import json
 from collections import defaultdict
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.utils import aws_api_matches
@@ -41,13 +41,13 @@ class SecurityGroupRule(TaggedEC2Resource):
         ec2_backend: Any,
         ip_protocol: str,
         group_id: str,
-        from_port: Optional[str],
-        to_port: Optional[str],
-        ip_range: Optional[dict[str, str]],
-        source_group: Optional[dict[str, str]] = None,
-        prefix_list_id: Optional[dict[str, str]] = None,
+        from_port: str | None,
+        to_port: str | None,
+        ip_range: dict[str, str] | None,
+        source_group: dict[str, str] | None = None,
+        prefix_list_id: dict[str, str] | None = None,
         is_egress: bool = True,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = random_security_group_rule_id()
@@ -92,19 +92,19 @@ class SecurityGroupRule(TaggedEC2Resource):
         }
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         return self.ip_range.get("Description")
 
     @property
-    def cidr_ipv4(self) -> Optional[str]:
+    def cidr_ipv4(self) -> str | None:
         return self.ip_range.get("CidrIp", None)
 
     @property
-    def cidr_ipv6(self) -> Optional[str]:
+    def cidr_ipv6(self) -> str | None:
         return self.ip_range.get("CidrIpv6", None)
 
     @property
-    def referenced_group_info(self) -> Optional[dict[str, str]]:
+    def referenced_group_info(self) -> dict[str, str] | None:
         return self.source_group if self.source_group else None
 
     @property
@@ -174,9 +174,9 @@ class SecurityGroupRule(TaggedEC2Resource):
 class GroupedSecurityRuleView:
     def __init__(
         self,
-        from_port: Optional[int],
-        to_port: Optional[int],
-        ip_protocol: Optional[str],
+        from_port: int | None,
+        to_port: int | None,
+        ip_protocol: str | None,
     ):
         self.from_port = from_port
         self.to_port = to_port
@@ -205,9 +205,9 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
         group_id: str,
         name: str,
         description: str,
-        vpc_id: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        is_default: Optional[bool] = None,
+        vpc_id: str | None = None,
+        tags: dict[str, str] | None = None,
+        is_default: bool | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = group_id
@@ -217,7 +217,7 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
         self.description = description
         self.ingress_rules: list[SecurityGroupRule] = []
         self.egress_rules: list[SecurityGroupRule] = []
-        self.vpc_id: Optional[str] = vpc_id
+        self.vpc_id: str | None = vpc_id
         self.owner_id = ec2_backend.account_id
         self.add_tags(tags or {})
         self.is_default = is_default or False
@@ -556,7 +556,7 @@ class SecurityGroup(TaggedEC2Resource, CloudFormationModel):
             return self.id
         raise UnformattedGetAttTemplateException()
 
-    def get_rule(self, rule_id: str) -> Optional[SecurityGroupRule]:
+    def get_rule(self, rule_id: str) -> SecurityGroupRule | None:
         """Retrieve a security group rule by its ID."""
         for rule in list(itertools.chain(self.egress_rules, self.ingress_rules)):
             if rule.id == rule_id:
@@ -630,10 +630,10 @@ class SecurityGroupBackend:
         self,
         name: str,
         description: str,
-        vpc_id: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        vpc_id: str | None = None,
+        tags: dict[str, str] | None = None,
         force: bool = False,
-        is_default: Optional[bool] = None,
+        is_default: bool | None = None,
     ) -> SecurityGroup:
         vpc_id = vpc_id or self.default_vpc.id  # type: ignore[attr-defined]
         if not description:
@@ -659,8 +659,8 @@ class SecurityGroupBackend:
 
     def describe_security_groups(
         self,
-        group_ids: Optional[list[str]] = None,
-        groupnames: Optional[list[str]] = None,
+        group_ids: list[str] | None = None,
+        groupnames: list[str] | None = None,
         filters: Any = None,
     ) -> list[SecurityGroup]:
         all_groups = self.groups.copy()
@@ -717,12 +717,12 @@ class SecurityGroupBackend:
             rules = [rule for rule in rules if rule.matches_filters(filters)]
         return rules
 
-    def _delete_security_group(self, vpc_id: Optional[str], group_id: str) -> None:
+    def _delete_security_group(self, vpc_id: str | None, group_id: str) -> None:
         vpc_id = vpc_id or self.default_vpc.id  # type: ignore[attr-defined]
         self.groups[vpc_id].pop(group_id)
 
     def delete_security_group(
-        self, name: Optional[str] = None, group_id: Optional[str] = None
+        self, name: str | None = None, group_id: str | None = None
     ) -> None:
         if group_id:
             # loop over all the SGs, find the right one
@@ -738,7 +738,7 @@ class SecurityGroupBackend:
                 return self._delete_security_group(None, group.id)
             raise InvalidSecurityGroupNotFoundError(name)
 
-    def get_security_group_from_id(self, group_id: str) -> Optional[SecurityGroup]:
+    def get_security_group_from_id(self, group_id: str) -> SecurityGroup | None:
         # 2 levels of chaining necessary since it's a complex structure
         all_groups = itertools.chain.from_iterable(
             [x.copy().values() for x in self.groups.copy().values()]
@@ -749,8 +749,8 @@ class SecurityGroupBackend:
         return None
 
     def get_security_group_from_name(
-        self, name: str, vpc_id: Optional[str] = None
-    ) -> Optional[SecurityGroup]:
+        self, name: str, vpc_id: str | None = None
+    ) -> SecurityGroup | None:
         if vpc_id:
             for group in self.groups[vpc_id].values():
                 if group.name == name:
@@ -763,8 +763,8 @@ class SecurityGroupBackend:
         return None
 
     def get_security_group_by_name_or_id(
-        self, group_name_or_id: str, vpc_id: Optional[str] = None
-    ) -> Optional[SecurityGroup]:
+        self, group_name_or_id: str, vpc_id: str | None = None
+    ) -> SecurityGroup | None:
         # try searching by id, fallbacks to name search
         group = self.get_security_group_from_id(group_name_or_id)
         if group is None:
@@ -772,8 +772,8 @@ class SecurityGroupBackend:
         return group
 
     def get_default_security_group(
-        self, vpc_id: Optional[str] = None
-    ) -> Optional[SecurityGroup]:
+        self, vpc_id: str | None = None
+    ) -> SecurityGroup | None:
         for group in self.groups[vpc_id or self.default_vpc.id].values():  # type: ignore[attr-defined]
             if group.is_default:
                 return group
@@ -789,7 +789,7 @@ class SecurityGroupBackend:
         source_groups: list[dict[str, Any]],
         prefix_list_ids: list[dict[str, str]],
         is_egress: bool = False,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> Iterator[SecurityGroupRule]:
         for ip_range in ip_ranges:
             yield SecurityGroupRule(
@@ -903,11 +903,11 @@ class SecurityGroupBackend:
         from_port: str,
         to_port: str,
         ip_ranges: list[Any],
-        sgrule_tags: Optional[dict[str, str]] = None,
-        source_groups: Optional[list[dict[str, str]]] = None,
-        prefix_list_ids: Optional[list[dict[str, str]]] = None,
-        security_rule_ids: Optional[list[str]] = None,
-        vpc_id: Optional[str] = None,
+        sgrule_tags: dict[str, str] | None = None,
+        source_groups: list[dict[str, str]] | None = None,
+        prefix_list_ids: list[dict[str, str]] | None = None,
+        security_rule_ids: list[str] | None = None,
+        vpc_id: str | None = None,
     ) -> tuple[list[SecurityGroupRule], SecurityGroup]:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
         if group is None:
@@ -966,10 +966,10 @@ class SecurityGroupBackend:
         from_port: str,
         to_port: str,
         ip_ranges: list[Any],
-        source_groups: Optional[list[dict[str, Any]]] = None,
-        prefix_list_ids: Optional[list[dict[str, str]]] = None,
-        security_rule_ids: Optional[list[str]] = None,
-        vpc_id: Optional[str] = None,
+        source_groups: list[dict[str, Any]] | None = None,
+        prefix_list_ids: list[dict[str, str]] | None = None,
+        security_rule_ids: list[str] | None = None,
+        vpc_id: str | None = None,
     ) -> None:
         group: SecurityGroup = self.get_security_group_by_name_or_id(
             group_name_or_id, vpc_id
@@ -1023,11 +1023,11 @@ class SecurityGroupBackend:
         from_port: str,
         to_port: str,
         ip_ranges: list[Any],
-        sgrule_tags: Optional[dict[str, str]] = None,
-        source_groups: Optional[list[dict[str, Any]]] = None,
-        prefix_list_ids: Optional[list[dict[str, str]]] = None,
-        security_rule_ids: Optional[list[str]] = None,
-        vpc_id: Optional[str] = None,
+        sgrule_tags: dict[str, str] | None = None,
+        source_groups: list[dict[str, Any]] | None = None,
+        prefix_list_ids: list[dict[str, str]] | None = None,
+        security_rule_ids: list[str] | None = None,
+        vpc_id: str | None = None,
     ) -> tuple[list[SecurityGroupRule], SecurityGroup]:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
         if group is None:
@@ -1089,10 +1089,10 @@ class SecurityGroupBackend:
         from_port: str,
         to_port: str,
         ip_ranges: list[Any],
-        source_groups: Optional[list[dict[str, Any]]] = None,
-        prefix_list_ids: Optional[list[dict[str, str]]] = None,
-        security_rule_ids: Optional[list[str]] = None,
-        vpc_id: Optional[str] = None,
+        source_groups: list[dict[str, Any]] | None = None,
+        prefix_list_ids: list[dict[str, str]] | None = None,
+        security_rule_ids: list[str] | None = None,
+        vpc_id: str | None = None,
     ) -> None:
         group: SecurityGroup = self.get_security_group_by_name_or_id(
             group_name_or_id, vpc_id
@@ -1160,10 +1160,10 @@ class SecurityGroupBackend:
         from_port: str,
         to_port: str,
         ip_ranges: list[str],
-        source_groups: Optional[list[dict[str, Any]]] = None,
-        prefix_list_ids: Optional[list[dict[str, str]]] = None,
-        security_rule_ids: Optional[list[str]] = None,
-        vpc_id: Optional[str] = None,
+        source_groups: list[dict[str, Any]] | None = None,
+        prefix_list_ids: list[dict[str, str]] | None = None,
+        security_rule_ids: list[str] | None = None,
+        vpc_id: str | None = None,
     ) -> SecurityGroup:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
         if group is None:
@@ -1215,10 +1215,10 @@ class SecurityGroupBackend:
         from_port: str,
         to_port: str,
         ip_ranges: list[str],
-        source_groups: Optional[list[dict[str, Any]]] = None,
-        prefix_list_ids: Optional[list[dict[str, str]]] = None,
-        security_rule_ids: Optional[list[str]] = None,
-        vpc_id: Optional[str] = None,
+        source_groups: list[dict[str, Any]] | None = None,
+        prefix_list_ids: list[dict[str, str]] | None = None,
+        security_rule_ids: list[str] | None = None,
+        vpc_id: str | None = None,
     ) -> SecurityGroup:
         group = self.get_security_group_by_name_or_id(group_name_or_id, vpc_id)
         if group is None:
@@ -1287,7 +1287,7 @@ class SecurityGroupBackend:
                 rule.source_group["Description"] = description
 
     def _add_source_group(
-        self, source_groups: Optional[list[dict[str, Any]]], vpc_id: Optional[str]
+        self, source_groups: list[dict[str, Any]] | None, vpc_id: str | None
     ) -> list[dict[str, Any]]:
         _source_groups = []
         for item in source_groups or []:
@@ -1317,7 +1317,7 @@ class SecurityGroupBackend:
         group: SecurityGroup,
         current_rule_nb: int,
         ip_ranges: list[str],
-        source_groups: Optional[list[dict[str, str]]] = None,
+        source_groups: list[dict[str, str]] | None = None,
         egress: bool = False,
     ) -> None:
         max_nb_rules = 60 if group.vpc_id else 100

--- a/moto/ec2/models/spot_requests.py
+++ b/moto/ec2/models/spot_requests.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.types import Base64EncodedString
@@ -22,12 +24,12 @@ from .instance_types import INSTANCE_TYPE_OFFERINGS
 class LaunchSpecification(BaseModel):
     def __init__(
         self,
-        kernel_id: Optional[str],
-        ramdisk_id: Optional[str],
-        image_id: Optional[str],
-        key_name: Optional[str],
+        kernel_id: str | None,
+        ramdisk_id: str | None,
+        image_id: str | None,
+        key_name: str | None,
         instance_type: str,
-        placement: Optional[str],
+        placement: str | None,
         monitored: bool,
         subnet_id: str,
     ):
@@ -43,13 +45,13 @@ class LaunchSpecification(BaseModel):
         self.ebs_optimized = False
 
     @property
-    def placement(self) -> Optional[dict[str, Optional[str]]]:
+    def placement(self) -> dict[str, str | None] | None:
         if self.availability_zone:
             return {"AvailabilityZone": self.availability_zone}
         return None
 
     @property
-    def security_groups(self) -> list["SecurityGroup"]:
+    def security_groups(self) -> list[SecurityGroup]:
         return self.groups
 
     @property
@@ -65,23 +67,23 @@ class SpotInstanceRequest(TaggedEC2Resource):
         price: str,
         image_id: str,
         spot_instance_type: str,
-        valid_from: Optional[datetime],
-        valid_until: Optional[datetime],
-        launch_group: Optional[str],
-        availability_zone_group: Optional[str],
+        valid_from: datetime | None,
+        valid_until: datetime | None,
+        launch_group: str | None,
+        availability_zone_group: str | None,
         key_name: str,
         security_groups: list[str],
-        user_data: Optional[Base64EncodedString],
+        user_data: Base64EncodedString | None,
         instance_type: str,
-        placement: Optional[str],
-        kernel_id: Optional[str],
-        ramdisk_id: Optional[str],
+        placement: str | None,
+        kernel_id: str | None,
+        ramdisk_id: str | None,
         monitoring_enabled: bool,
         subnet_id: str,
         tags: dict[str, dict[str, str]],
-        spot_fleet_id: Optional[str],
-        instance_interruption_behaviour: Optional[str],
-        launch_spec: Optional["SpotFleetLaunchSpec"] = None,
+        spot_fleet_id: str | None,
+        instance_interruption_behaviour: str | None,
+        launch_spec: SpotFleetLaunchSpec | None = None,
     ):
         super().__init__()
         self.ec2_backend = ec2_backend
@@ -165,22 +167,20 @@ class SpotInstanceRequest(TaggedEC2Resource):
         return self.instance_interruption_behaviour
 
     @property
-    def valid_from_as_string(self) -> Optional[str]:
+    def valid_from_as_string(self) -> str | None:
         if self.valid_from is None:
             return self.valid_from
         x = self.valid_from
         return f"{x.year}-{x.month:02d}-{x.day:02d}T{x.hour:02d}:{x.minute:02d}:{x.second:02d}.000Z"
 
     @property
-    def valid_until_as_string(self) -> Optional[str]:
+    def valid_until_as_string(self) -> str | None:
         if self.valid_until is None:
             return self.valid_until
         x = self.valid_until
         return f"{x.year}-{x.month:02d}-{x.day:02d}T{x.hour:02d}:{x.minute:02d}:{x.second:02d}.000Z"
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "state":
             return self.state
         elif filter_name == "spot-instance-request-id":
@@ -188,7 +188,7 @@ class SpotInstanceRequest(TaggedEC2Resource):
         else:
             return super().get_filter_value(filter_name, "DescribeSpotInstanceRequests")
 
-    def launch_instance(self) -> "Instance":
+    def launch_instance(self) -> Instance:
         reservation = self.ec2_backend.run_instances(
             image_id=self.launch_specification.image_id,
             count=1,
@@ -222,8 +222,8 @@ class SpotFleetLaunchSpec:
         tag_specifications: dict[str, dict[str, str]],
         user_data: Any,
         weighted_capacity: float,
-        launch_template_spec: Optional[dict[str, Any]] = None,
-        overrides: Optional[dict[str, Any]] = None,
+        launch_template_spec: dict[str, Any] | None = None,
+        overrides: dict[str, Any] | None = None,
     ):
         self.ebs_optimized = ebs_optimized
         self.group_set = group_set
@@ -241,7 +241,7 @@ class SpotFleetLaunchSpec:
         self.overrides = overrides
 
     @property
-    def iam_instance_profile(self) -> Optional[dict[str, Any]]:
+    def iam_instance_profile(self) -> dict[str, Any] | None:
         if self._iam_instance_profile_arn:
             return {"Arn": self._iam_instance_profile_arn}
         return None
@@ -265,16 +265,16 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self,
         ec2_backend: Any,
-        spot_backend: "SpotRequestBackend",
+        spot_backend: SpotRequestBackend,
         spot_fleet_request_id: str,
         spot_price: str,
         target_capacity: str,
         iam_fleet_role: str,
         allocation_strategy: str,
         launch_specs: list[dict[str, Any]],
-        launch_template_config: Optional[list[dict[str, Any]]],
-        instance_interruption_behaviour: Optional[str],
-        tag_specifications: Optional[list[dict[str, Any]]],
+        launch_template_config: list[dict[str, Any]] | None,
+        instance_interruption_behaviour: str | None,
+        tag_specifications: list[dict[str, Any]] | None,
     ):
         self.ec2_backend = ec2_backend
         self.spot_backend = spot_backend
@@ -391,7 +391,7 @@ class SpotFleetRequest(TaggedEC2Resource, CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "SpotFleetRequest":
+    ) -> SpotFleetRequest:
         from ..models import ec2_backends
 
         properties = cloudformation_json["Properties"]["SpotFleetRequestConfigData"]
@@ -506,23 +506,23 @@ class SpotRequestBackend:
         image_id: str,
         count: int,
         spot_instance_type: str,
-        valid_from: Optional[datetime],
-        valid_until: Optional[datetime],
-        launch_group: Optional[str],
-        availability_zone_group: Optional[str],
+        valid_from: datetime | None,
+        valid_until: datetime | None,
+        launch_group: str | None,
+        availability_zone_group: str | None,
         key_name: str,
         security_groups: list[str],
-        user_data: Optional[Base64EncodedString],
+        user_data: Base64EncodedString | None,
         instance_type: str,
-        placement: Optional[str],
-        kernel_id: Optional[str],
-        ramdisk_id: Optional[str],
+        placement: str | None,
+        kernel_id: str | None,
+        ramdisk_id: str | None,
         monitoring_enabled: bool,
         subnet_id: str,
-        tags: Optional[dict[str, dict[str, str]]] = None,
-        spot_fleet_id: Optional[str] = None,
-        instance_interruption_behaviour: Optional[str] = None,
-        launch_spec: Optional[SpotFleetLaunchSpec] = None,
+        tags: dict[str, dict[str, str]] | None = None,
+        spot_fleet_id: str | None = None,
+        instance_interruption_behaviour: str | None = None,
+        launch_spec: SpotFleetLaunchSpec | None = None,
     ) -> list[SpotInstanceRequest]:
         requests = []
         tags = tags or {}
@@ -557,7 +557,7 @@ class SpotRequestBackend:
         return requests
 
     def describe_spot_instance_requests(
-        self, filters: Any = None, spot_instance_ids: Optional[list[str]] = None
+        self, filters: Any = None, spot_instance_ids: list[str] | None = None
     ) -> list[SpotInstanceRequest]:
         requests = list(self.spot_instance_requests.values())
 
@@ -581,9 +581,9 @@ class SpotRequestBackend:
         iam_fleet_role: str,
         allocation_strategy: str,
         launch_specs: list[dict[str, Any]],
-        launch_template_config: Optional[list[dict[str, Any]]] = None,
-        instance_interruption_behaviour: Optional[str] = None,
-        tag_specifications: Optional[list[dict[str, Any]]] = None,
+        launch_template_config: list[dict[str, Any]] | None = None,
+        instance_interruption_behaviour: str | None = None,
+        tag_specifications: list[dict[str, Any]] | None = None,
     ) -> SpotFleetRequest:
         spot_fleet_request_id = random_spot_fleet_request_id()
         request = SpotFleetRequest(
@@ -604,7 +604,7 @@ class SpotRequestBackend:
 
     def get_spot_fleet_request(
         self, spot_fleet_request_id: str
-    ) -> Optional[SpotFleetRequest]:
+    ) -> SpotFleetRequest | None:
         return self.spot_fleet_requests.get(spot_fleet_request_id)
 
     def describe_spot_fleet_instances(
@@ -656,7 +656,7 @@ class SpotRequestBackend:
             spot_fleet_request.terminate_instances()
 
     def describe_spot_price_history(
-        self, instance_types: Optional[list[str]] = None, filters: Any = None
+        self, instance_types: list[str] | None = None, filters: Any = None
     ) -> list[dict[str, str]]:
         matches = INSTANCE_TYPE_OFFERINGS["availability-zone"]
         matches = matches.get(self.region_name, [])  # type: ignore[attr-defined]

--- a/moto/ec2/models/subnets.py
+++ b/moto/ec2/models/subnets.py
@@ -5,7 +5,7 @@ import itertools
 from collections import defaultdict
 from collections.abc import Iterator
 from functools import cache
-from typing import TYPE_CHECKING, Any, Literal, Optional, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from moto.core.common_models import CloudFormationModel
 
@@ -47,8 +47,8 @@ class SubnetCidrReservation(TaggedEC2Resource):
         cidr: ipaddress.IPv4Network | ipaddress.IPv6Network,
         reservation_type: Literal["explicit"] | Literal["prefix"],
         owner_id: str,
-        tag_specifications: Optional[list[dict[str, Any]]] = None,
-        subnet_cidr_reservation_id: Optional[str] = None,
+        tag_specifications: list[dict[str, Any]] | None = None,
+        subnet_cidr_reservation_id: str | None = None,
     ) -> None:
         self.ec2_backend = ec2_backend
         self.id = subnet_cidr_reservation_id or random_subnet_cidr_reservation_id()
@@ -58,9 +58,7 @@ class SubnetCidrReservation(TaggedEC2Resource):
         self.owner_id = owner_id
         self.tag_specifications = tag_specifications or []
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "reservationType":
             return self.reservation_type
         elif filter_name == "subnet-id":
@@ -76,7 +74,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         subnet_id: str,
         vpc_id: str,
         cidr_block: str,
-        ipv6_cidr_block: Optional[str],
+        ipv6_cidr_block: str | None,
         availability_zone: Zone,
         default_for_az: bool,
         map_public_ip_on_launch: bool,
@@ -219,9 +217,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         """
         API Version 2014-10-01 defines the following filters for DescribeSubnets:
 
@@ -329,7 +325,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
         self,
         reservation_type: Literal["explicit"] | Literal["prefix"],
         cidr_block: ipaddress.IPv4Network | ipaddress.IPv6Network,
-        tag_specifications: Optional[list[dict[str, Any]]] = None,
+        tag_specifications: list[dict[str, Any]] | None = None,
     ) -> SubnetCidrReservation:
         if not self._cidr_within_subnet_cidr_blocks(cidr_block):
             raise InvalidCidrReservationNotWithinSubnetCidr(str(self.cidr))
@@ -421,7 +417,7 @@ class Subnet(TaggedEC2Resource, CloudFormationModel):
     def delete_subnet_cidr_reservation(
         self,
         reservation_id: str,
-    ) -> Optional[SubnetCidrReservation]:
+    ) -> SubnetCidrReservation | None:
         for index, reservation in enumerate(self._cidr_reservations):
             if reservation.id == reservation_id:
                 self._cidr_reservations.pop(index)
@@ -522,11 +518,11 @@ class SubnetBackend:
         self,
         vpc_id: str,
         cidr_block: str,
-        ipv6_cidr_block: Optional[str] = None,
-        availability_zone: Optional[str] = None,
-        availability_zone_id: Optional[str] = None,
+        ipv6_cidr_block: str | None = None,
+        availability_zone: str | None = None,
+        availability_zone_id: str | None = None,
         ipv6_native: bool = False,
-        tags: Optional[dict[str, dict[str, str]]] = None,
+        tags: dict[str, dict[str, str]] | None = None,
     ) -> Subnet:
         subnet_id = random_subnet_id()
         # Validate VPC exists and the supplied CIDR block is a subnet of the VPC's
@@ -615,7 +611,7 @@ class SubnetBackend:
         return subnet
 
     def describe_subnets(
-        self, subnet_ids: Optional[list[str]] = None, filters: Optional[Any] = None
+        self, subnet_ids: list[str] | None = None, filters: Any | None = None
     ) -> list[Subnet]:
         # Extract a list of all subnets
         matches = list(
@@ -650,7 +646,7 @@ class SubnetBackend:
         else:
             raise InvalidParameterValueError(attr_name)
 
-    def get_subnet_from_ipv6_association(self, association_id: str) -> Optional[Subnet]:
+    def get_subnet_from_ipv6_association(self, association_id: str) -> Subnet | None:
         subnet = None
         for s in self.describe_subnets():
             if association_id in s.ipv6_cidr_block_associations:
@@ -687,7 +683,7 @@ class SubnetBackend:
         subnet_id: str,
         reservation_type: str,
         cidr: str,
-        tags: Optional[list[dict[str, Any]]] = None,
+        tags: list[dict[str, Any]] | None = None,
     ) -> SubnetCidrReservation:
         if reservation_type not in {"prefix", "explicit"}:
             raise InvalidPrefixReservationType(reservation_type)
@@ -712,7 +708,7 @@ class SubnetBackend:
     def get_subnet_cidr_reservations(
         self,
         subnet_id: str,
-        filters: Optional[Any] = None,
+        filters: Any | None = None,
     ) -> dict[str, list[SubnetCidrReservation]]:
         matches: list[SubnetCidrReservation] = self.get_subnet(
             subnet_id

--- a/moto/ec2/models/tags.py
+++ b/moto/ec2/models/tags.py
@@ -1,6 +1,5 @@
 import re
 from collections import defaultdict
-from typing import Optional
 
 from ..exceptions import (
     InvalidParameterValueErrorTagNull,
@@ -55,7 +54,7 @@ class TagBackend:
         return True
 
     def describe_tags(
-        self, filters: Optional[dict[str, list[str]]] = None
+        self, filters: dict[str, list[str]] | None = None
     ) -> list[dict[str, str]]:
         results = []
         key_filters = []

--- a/moto/ec2/models/traffic_mirrors.py
+++ b/moto/ec2/models/traffic_mirrors.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import filter_resources
@@ -16,9 +16,9 @@ class TrafficMirrorFilter(TaggedEC2Resource):
     def __init__(
         self,
         ec2_backend: Any,
-        description: Optional[str],
-        tag_specifications: Optional[list[dict[str, Any]]],
-        client_token: Optional[str],
+        description: str | None,
+        tag_specifications: list[dict[str, Any]] | None,
+        client_token: str | None,
     ):
         self.ec2_backend = ec2_backend
         self.id = random_traffic_mirror_filter_id()
@@ -57,12 +57,12 @@ class TrafficMirrorTarget(TaggedEC2Resource):
     def __init__(
         self,
         ec2_backend: Any,
-        network_interface_id: Optional[str],
-        network_load_balancer_arn: Optional[str],
-        description: Optional[str],
-        tag_specifications: Optional[list[dict[str, Any]]],
-        client_token: Optional[str],
-        gateway_load_balancer_endpoint_id: Optional[str],
+        network_interface_id: str | None,
+        network_load_balancer_arn: str | None,
+        description: str | None,
+        tag_specifications: list[dict[str, Any]] | None,
+        client_token: str | None,
+        gateway_load_balancer_endpoint_id: str | None,
     ):
         self.ec2_backend = ec2_backend
         self.id = random_traffic_mirror_target_id()
@@ -110,8 +110,8 @@ class TrafficMirrorTarget(TaggedEC2Resource):
 
     @staticmethod
     def _determine_traffic_mirror_target_type(
-        values: dict[str, Optional[str]],
-    ) -> Optional[str]:
+        values: dict[str, str | None],
+    ) -> str | None:
         target_fields = {
             "NetworkInterfaceId": "network-interface",
             "NetworkLoadBalancerArn": "network-load-balancer",
@@ -137,9 +137,9 @@ class TrafficMirrorsBackend:
 
     def create_traffic_mirror_filter(
         self,
-        description: Optional[str],
-        tag_specifications: Optional[list[dict[str, Any]]],
-        client_token: Optional[str],
+        description: str | None,
+        tag_specifications: list[dict[str, Any]] | None,
+        client_token: str | None,
     ) -> TrafficMirrorFilter:
         mirror_filter = TrafficMirrorFilter(
             self, description, tag_specifications, client_token
@@ -150,12 +150,12 @@ class TrafficMirrorsBackend:
 
     def create_traffic_mirror_target(
         self,
-        network_interface_id: Optional[str],
-        network_load_balancer_arn: Optional[str],
-        description: Optional[str],
-        tag_specifications: Optional[list[dict[str, Any]]],
-        client_token: Optional[str],
-        gateway_load_balancer_endpoint_id: Optional[str],
+        network_interface_id: str | None,
+        network_load_balancer_arn: str | None,
+        description: str | None,
+        tag_specifications: list[dict[str, Any]] | None,
+        client_token: str | None,
+        gateway_load_balancer_endpoint_id: str | None,
     ) -> TrafficMirrorTarget:
         mirror_target = TrafficMirrorTarget(
             self,
@@ -172,8 +172,8 @@ class TrafficMirrorsBackend:
 
     def describe_traffic_mirror_filters(
         self,
-        traffic_mirror_filter_ids: Optional[list[str]],
-        filters: Optional[list[Any]],
+        traffic_mirror_filter_ids: list[str] | None,
+        filters: list[Any] | None,
     ) -> list[TrafficMirrorFilter]:
         traffic_mirror_filters = list(self.traffic_mirror_filters.values())
 
@@ -197,8 +197,8 @@ class TrafficMirrorsBackend:
 
     def describe_traffic_mirror_targets(
         self,
-        traffic_mirror_target_ids: Optional[list[str]],
-        filters: Optional[list[Any]],
+        traffic_mirror_target_ids: list[str] | None,
+        filters: list[Any] | None,
     ) -> list[TrafficMirrorTarget]:
         traffic_mirror_targets = list(self.traffic_mirror_targets.values())
 

--- a/moto/ec2/models/transit_gateway.py
+++ b/moto/ec2/models/transit_gateway.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
@@ -28,8 +28,8 @@ class TransitGateway(TaggedEC2Resource, CloudFormationModel):
     def __init__(
         self,
         backend: Any,
-        description: Optional[str],
-        options: Optional[dict[str, str]] = None,
+        description: str | None,
+        options: dict[str, str] | None = None,
     ):
         self.ec2_backend = backend
         self.id = random_transit_gateway_id()
@@ -111,9 +111,9 @@ class TransitGatewayBackend:
 
     def create_transit_gateway(
         self,
-        description: Optional[str],
-        options: Optional[dict[str, str]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        description: str | None,
+        options: dict[str, str] | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> TransitGateway:
         transit_gateway = TransitGateway(self, description, options)
         for tag in tags or []:
@@ -123,7 +123,7 @@ class TransitGatewayBackend:
         return transit_gateway
 
     def describe_transit_gateways(
-        self, filters: Any, transit_gateway_ids: Optional[list[str]]
+        self, filters: Any, transit_gateway_ids: list[str] | None
     ) -> list[TransitGateway]:
         transit_gateways = list(self.transit_gateways.values())
 
@@ -151,8 +151,8 @@ class TransitGatewayBackend:
     def modify_transit_gateway(
         self,
         transit_gateway_id: str,
-        description: Optional[str] = None,
-        options: Optional[dict[str, str]] = None,
+        description: str | None = None,
+        options: dict[str, str] | None = None,
     ) -> TransitGateway:
         transit_gateway = self.transit_gateways[transit_gateway_id]
         if description:

--- a/moto/ec2/models/transit_gateway_attachments.py
+++ b/moto/ec2/models/transit_gateway_attachments.py
@@ -1,7 +1,7 @@
 import weakref
 from collections import defaultdict
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.utilities.utils import filter_resources, merge_multiple_dicts
@@ -27,7 +27,7 @@ class TransitGatewayAttachment(TaggedEC2Resource):
         resource_id: str,
         resource_type: str,
         transit_gateway: "TransitGateway",
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ):
         self.ec2_backend = backend
         self._association_data: dict[str, str] = {}
@@ -64,7 +64,7 @@ class TransitGatewayAttachment(TaggedEC2Resource):
         return self.resource_owner_id
 
     @property
-    def association(self) -> Optional[dict[str, str]]:
+    def association(self) -> dict[str, str] | None:
         if self.state == "available" and self.transit_gateway_route_table:
             return {
                 "State": "associated",
@@ -87,8 +87,8 @@ class TransitGatewayVpcAttachment(TransitGatewayAttachment):
         transit_gateway: "TransitGateway",
         vpc_id: str,
         subnet_ids: list[str],
-        tags: Optional[dict[str, str]] = None,
-        options: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
+        options: dict[str, str] | None = None,
     ):
         super().__init__(
             backend=backend,
@@ -166,7 +166,7 @@ class TransitGatewayAttachmentBackend:
         self,
         vpn_id: str,
         transit_gateway_id: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> TransitGatewayAttachment:
         transit_gateway = self.transit_gateways[transit_gateway_id]  # type: ignore[attr-defined]
         transit_gateway_vpn_attachment = TransitGatewayAttachment(
@@ -186,8 +186,8 @@ class TransitGatewayAttachmentBackend:
         transit_gateway_id: str,
         vpc_id: str,
         subnet_ids: list[str],
-        tags: Optional[dict[str, str]] = None,
-        options: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
+        options: dict[str, str] | None = None,
     ) -> TransitGatewayVpcAttachment:
         # Validate that the TransitGateway exists
         if not (transit_gateway := self.transit_gateways.get(transit_gateway_id)):  # type: ignore[attr-defined]
@@ -217,7 +217,7 @@ class TransitGatewayAttachmentBackend:
 
     def describe_transit_gateway_attachments(
         self,
-        transit_gateways_attachment_ids: Optional[list[str]] = None,
+        transit_gateways_attachment_ids: list[str] | None = None,
         filters: Any = None,
     ) -> list[TransitGatewayAttachment]:
         transit_gateway_attachments = list(self.transit_gateway_attachments.values())
@@ -245,7 +245,7 @@ class TransitGatewayAttachmentBackend:
 
     def describe_transit_gateway_vpc_attachments(
         self,
-        transit_gateways_attachment_ids: Optional[list[str]] = None,
+        transit_gateways_attachment_ids: list[str] | None = None,
         filters: Any = None,
     ) -> list[TransitGatewayAttachment]:
         transit_gateway_attachments = list(self.transit_gateway_attachments.values())
@@ -298,9 +298,9 @@ class TransitGatewayAttachmentBackend:
     def modify_transit_gateway_vpc_attachment(
         self,
         transit_gateway_attachment_id: str,
-        add_subnet_ids: Optional[list[str]] = None,
-        options: Optional[dict[str, str]] = None,
-        remove_subnet_ids: Optional[list[str]] = None,
+        add_subnet_ids: list[str] | None = None,
+        options: dict[str, str] | None = None,
+        remove_subnet_ids: list[str] | None = None,
     ) -> TransitGatewayAttachment:
         tgw_attachment = self.transit_gateway_attachments[transit_gateway_attachment_id]
         if remove_subnet_ids:
@@ -390,7 +390,7 @@ class TransitGatewayAttachmentBackend:
 
     def describe_transit_gateway_peering_attachments(
         self,
-        transit_gateways_attachment_ids: Optional[list[str]] = None,
+        transit_gateways_attachment_ids: list[str] | None = None,
         filters: Any = None,
     ) -> list[TransitGatewayAttachment]:
         transit_gateway_attachments = list(self.transit_gateway_attachments.values())

--- a/moto/ec2/models/transit_gateway_route_tables.py
+++ b/moto/ec2/models/transit_gateway_route_tables.py
@@ -1,6 +1,6 @@
 import itertools
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.utils import utcnow
 from moto.utilities.utils import filter_resources
@@ -32,7 +32,7 @@ class TransitGatewayRouteTable(TaggedEC2Resource):
         self,
         backend: Any,
         transit_gateway_id: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
         default_association_route_table: bool = False,
         default_propagation_route_table: bool = False,
     ):
@@ -45,7 +45,7 @@ class TransitGatewayRouteTable(TaggedEC2Resource):
         self.default_association_route_table = default_association_route_table
         self.default_propagation_route_table = default_propagation_route_table
         self.state = "available"
-        self.routes: dict[str, dict[str, Optional[str]]] = {}
+        self.routes: dict[str, dict[str, str | None]] = {}
         self.add_tags(tags or {})
         self.route_table_associations: dict[str, RouteTableAssociation] = {}
         self.route_table_propagation: list[RouteTablePropagation] = []
@@ -93,7 +93,7 @@ class TransitGatewayRouteTableBackend:
     def create_transit_gateway_route_table(
         self,
         transit_gateway_id: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
         default_association_route_table: bool = False,
         default_propagation_route_table: bool = False,
     ) -> TransitGatewayRouteTable:
@@ -110,7 +110,7 @@ class TransitGatewayRouteTableBackend:
         return transit_gateways_route_table
 
     def get_all_transit_gateway_route_tables(
-        self, transit_gateway_route_table_ids: Optional[str] = None, filters: Any = None
+        self, transit_gateway_route_table_ids: str | None = None, filters: Any = None
     ) -> list[TransitGatewayRouteTable]:
         transit_gateway_route_tables = list(self.transit_gateways_route_tables.values())
 
@@ -147,9 +147,9 @@ class TransitGatewayRouteTableBackend:
         self,
         transit_gateway_route_table_id: str,
         destination_cidr_block: str,
-        transit_gateway_attachment_id: Optional[str] = None,
+        transit_gateway_attachment_id: str | None = None,
         blackhole: bool = False,
-    ) -> dict[str, Optional[str]]:
+    ) -> dict[str, str | None]:
         transit_gateways_route_table = self.transit_gateways_route_tables[
             transit_gateway_route_table_id
         ]
@@ -178,7 +178,7 @@ class TransitGatewayRouteTableBackend:
 
     def delete_transit_gateway_route(
         self, transit_gateway_route_table_id: str, destination_cidr_block: str
-    ) -> dict[str, Optional[str]]:
+    ) -> dict[str, str | None]:
         transit_gateways_route_table = self.transit_gateways_route_tables[
             transit_gateway_route_table_id
         ]
@@ -189,8 +189,8 @@ class TransitGatewayRouteTableBackend:
         self,
         transit_gateway_route_table_id: str,
         filters: Any,
-        max_results: Optional[int] = None,
-    ) -> list[dict[str, Optional[str]]]:
+        max_results: int | None = None,
+    ) -> list[dict[str, str | None]]:
         """
         The following filters are currently supported: type, state, route-search.exact-match
         """

--- a/moto/ec2/models/vpc_peering_connections.py
+++ b/moto/ec2/models/vpc_peering_connections.py
@@ -1,7 +1,7 @@
 import weakref
 from collections import defaultdict
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 
@@ -59,7 +59,7 @@ class VPCPeeringConnection(TaggedEC2Resource, CloudFormationModel):
         vpc_pcx_id: str,
         vpc: VPC,
         peer_vpc: VPC,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ):
         self.id = vpc_pcx_id
         self.ec2_backend = backend
@@ -149,7 +149,7 @@ class VPCPeeringConnectionBackend:
                 yield inst
 
     def create_vpc_peering_connection(
-        self, vpc: VPC, peer_vpc: VPC, tags: Optional[dict[str, str]] = None
+        self, vpc: VPC, peer_vpc: VPC, tags: dict[str, str] | None = None
     ) -> VPCPeeringConnection:
         vpc_pcx_id = random_vpc_peering_connection_id()
         vpc_pcx = VPCPeeringConnection(self, vpc_pcx_id, vpc, peer_vpc, tags)
@@ -167,7 +167,7 @@ class VPCPeeringConnectionBackend:
         return vpc_pcx
 
     def describe_vpc_peering_connections(
-        self, vpc_peering_ids: Optional[list[str]] = None
+        self, vpc_peering_ids: list[str] | None = None
     ) -> list[VPCPeeringConnection]:
         all_pcxs = list(self.vpc_pcxs.values())
         if vpc_peering_ids:
@@ -227,8 +227,8 @@ class VPCPeeringConnectionBackend:
     def modify_vpc_peering_connection_options(
         self,
         vpc_pcx_id: str,
-        accepter_options: Optional[dict[str, Any]] = None,
-        requester_options: Optional[dict[str, Any]] = None,
+        accepter_options: dict[str, Any] | None = None,
+        requester_options: dict[str, Any] | None = None,
     ) -> VPCPeeringConnection:
         vpc_pcx = self.get_vpc_peering_connection(vpc_pcx_id)
         if not vpc_pcx:

--- a/moto/ec2/models/vpc_service_configuration.py
+++ b/moto/ec2/models/vpc_service_configuration.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 from moto.moto_api._internal import mock_random
@@ -99,7 +99,7 @@ class VPCServiceConfigurationBackend:
 
     def get_vpc_endpoint_service(
         self, resource_id: str
-    ) -> Optional[VPCServiceConfiguration]:
+    ) -> VPCServiceConfiguration | None:
         return self.configurations.get(resource_id)
 
     def create_vpc_endpoint_service_configuration(
@@ -126,7 +126,7 @@ class VPCServiceConfigurationBackend:
         return config
 
     def describe_vpc_endpoint_service_configurations(
-        self, service_ids: Optional[list[str]]
+        self, service_ids: list[str] | None
     ) -> list[VPCServiceConfiguration]:
         """
         The Filters, MaxResults, NextToken parameters are not yet implemented
@@ -167,8 +167,8 @@ class VPCServiceConfigurationBackend:
     def modify_vpc_endpoint_service_configuration(
         self,
         service_id: str,
-        acceptance_required: Optional[str],
-        private_dns_name: Optional[str],
+        acceptance_required: str | None,
+        private_dns_name: str | None,
         add_network_lbs: list[str],
         remove_network_lbs: list[str],
         add_gateway_lbs: list[str],

--- a/moto/ec2/models/vpcs.py
+++ b/moto/ec2/models/vpcs.py
@@ -5,7 +5,7 @@ import threading
 import weakref
 from collections import defaultdict
 from operator import itemgetter
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BaseBackend
 from moto.core.common_models import CloudFormationModel
@@ -339,17 +339,17 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
         endpoint_id: str,
         vpc_id: str,
         service_name: str,
-        endpoint_type: Optional[str],
-        policy_document: Optional[str],
+        endpoint_type: str | None,
+        policy_document: str | None,
         route_table_ids: list[str],
-        subnet_ids: Optional[list[str]] = None,
-        network_interface_ids: Optional[list[str]] = None,
-        dns_entries: Optional[list[dict[str, str]]] = None,
-        client_token: Optional[str] = None,
-        security_group_ids: Optional[list[str]] = None,
-        tags: Optional[dict[str, str]] = None,
-        private_dns_enabled: Optional[bool] = None,
-        destination_prefix_list_id: Optional[str] = None,
+        subnet_ids: list[str] | None = None,
+        network_interface_ids: list[str] | None = None,
+        dns_entries: list[dict[str, str]] | None = None,
+        client_token: str | None = None,
+        security_group_ids: list[str] | None = None,
+        tags: dict[str, str] | None = None,
+        private_dns_enabled: bool | None = None,
+        destination_prefix_list_id: str | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = endpoint_id
@@ -380,13 +380,13 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
 
     def modify(
         self,
-        policy_doc: Optional[str],
-        add_subnets: Optional[list[str]],
-        remove_subnets: Optional[list[str]],
-        add_route_tables: Optional[list[str]],
-        remove_route_tables: Optional[list[str]],
-        add_security_groups: Optional[list[str]],
-        remove_security_groups: Optional[list[str]],
+        policy_doc: str | None,
+        add_subnets: list[str] | None,
+        remove_subnets: list[str] | None,
+        add_route_tables: list[str] | None,
+        remove_route_tables: list[str] | None,
+        add_security_groups: list[str] | None,
+        remove_security_groups: list[str] | None,
     ) -> None:
         if policy_doc:
             self.policy_document = policy_doc
@@ -420,9 +420,7 @@ class VPCEndPoint(TaggedEC2Resource, CloudFormationModel):
                 if rt_id not in remove_route_tables
             ]
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name in ("vpc-endpoint-type", "vpc_endpoint_type"):
             return self.vpc_endpoint_type
         if filter_name in ("vpc-endpoint-state", "vpc_endpoint_state"):
@@ -491,7 +489,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
         is_default: bool,
         instance_tenancy: str = "default",
         amazon_provided_ipv6_cidr_block: bool = False,
-        ipv6_cidr_block_network_border_group: Optional[str] = None,
+        ipv6_cidr_block_network_border_group: str | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = vpc_id
@@ -615,9 +613,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name in ("vpc-id", "vpcId"):
             return self.id
         elif filter_name in ("cidr", "cidr-block", "cidrBlock"):
@@ -665,7 +661,7 @@ class VPC(TaggedEC2Resource, CloudFormationModel):
         self,
         cidr_block: str,
         amazon_provided_ipv6_cidr_block: bool = False,
-        ipv6_cidr_block_network_border_group: Optional[str] = None,
+        ipv6_cidr_block_network_border_group: str | None = None,
     ) -> dict[str, Any]:
         max_associations = 5 if not amazon_provided_ipv6_cidr_block else 1
 
@@ -770,7 +766,7 @@ class VPCBackend:
             self.create_default_subnet(zone.name)  # type: ignore[attr-defined]
         return vpc
 
-    def get_default_vpc(self) -> Optional[VPC]:
+    def get_default_vpc(self) -> VPC | None:
         for vpc in self.vpcs.values():
             if vpc.is_default:
                 return vpc
@@ -781,8 +777,8 @@ class VPCBackend:
         cidr_block: str,
         instance_tenancy: str = "default",
         amazon_provided_ipv6_cidr_block: bool = False,
-        ipv6_cidr_block_network_border_group: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        ipv6_cidr_block_network_border_group: str | None = None,
+        tags: list[dict[str, str]] | None = None,
         is_default: bool = False,
     ) -> VPC:
         vpc_id = random_vpc_id()
@@ -827,7 +823,7 @@ class VPCBackend:
         return self.vpcs[vpc_id]
 
     def describe_vpcs(
-        self, vpc_ids: Optional[list[str]] = None, filters: Any = None
+        self, vpc_ids: list[str] | None = None, filters: Any = None
     ) -> list[VPC]:
         matches = list(self.vpcs.values())
         if vpc_ids:
@@ -971,16 +967,16 @@ class VPCBackend:
         self,
         vpc_id: str,
         service_name: str,
-        endpoint_type: Optional[str],
-        policy_document: Optional[str],
+        endpoint_type: str | None,
+        policy_document: str | None,
         route_table_ids: list[str],
-        subnet_ids: Optional[list[str]] = None,
-        network_interface_ids: Optional[list[str]] = None,
-        dns_entries: Optional[dict[str, str]] = None,
-        client_token: Optional[str] = None,
-        security_group_ids: Optional[list[str]] = None,
-        tags: Optional[dict[str, str]] = None,
-        private_dns_enabled: Optional[bool] = None,
+        subnet_ids: list[str] | None = None,
+        network_interface_ids: list[str] | None = None,
+        dns_entries: dict[str, str] | None = None,
+        client_token: str | None = None,
+        security_group_ids: list[str] | None = None,
+        tags: dict[str, str] | None = None,
+        private_dns_enabled: bool | None = None,
     ) -> VPCEndPoint:
         vpc_endpoint_id = random_vpc_ep_id()
 
@@ -1038,12 +1034,12 @@ class VPCBackend:
         self,
         vpc_id: str,
         policy_doc: str,
-        add_subnets: Optional[list[str]],
-        remove_subnets: Optional[list[str]],
-        remove_route_tables: Optional[list[str]],
-        add_route_tables: Optional[list[str]],
-        add_security_groups: Optional[list[str]],
-        remove_security_groups: Optional[list[str]],
+        add_subnets: list[str] | None,
+        remove_subnets: list[str] | None,
+        remove_route_tables: list[str] | None,
+        add_route_tables: list[str] | None,
+        add_security_groups: list[str] | None,
+        remove_security_groups: list[str] | None,
     ) -> None:
         endpoint = self.describe_vpc_endpoints(vpc_end_point_ids=[vpc_id])[0]
         endpoint.modify(
@@ -1056,7 +1052,7 @@ class VPCBackend:
             remove_security_groups,
         )
 
-    def delete_vpc_endpoints(self, vpce_ids: Optional[list[str]] = None) -> None:
+    def delete_vpc_endpoints(self, vpce_ids: list[str] | None = None) -> None:
         for vpce_id in vpce_ids or []:
             vpc_endpoint = self.vpc_end_points.get(vpce_id, None)
             if vpc_endpoint:
@@ -1071,7 +1067,7 @@ class VPCBackend:
                 vpc_endpoint.state = "deleted"
 
     def describe_vpc_endpoints(
-        self, vpc_end_point_ids: Optional[list[str]], filters: Any = None
+        self, vpc_end_point_ids: list[str] | None, filters: Any = None
     ) -> list[VPCEndPoint]:
         vpc_end_points = list(self.vpc_end_points.values())
 
@@ -1238,7 +1234,7 @@ class VPCBackend:
         service_names: list[str],
         filters: Any,
         max_results: int,
-        next_token: Optional[str],
+        next_token: str | None,
         region: str,
     ) -> dict[str, Any]:
         """Return info on services to which you can create a VPC endpoint.

--- a/moto/ec2/models/vpn_connections.py
+++ b/moto/ec2/models/vpn_connections.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from ..exceptions import (
     InvalidParameterValue,
@@ -16,9 +16,9 @@ class VPNConnection(TaggedEC2Resource):
         vpn_connection_id: str,
         vpn_conn_type: str,
         customer_gateway_id: str,
-        vpn_gateway_id: Optional[str] = None,
-        transit_gateway_id: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        vpn_gateway_id: str | None = None,
+        transit_gateway_id: str | None = None,
+        tags: dict[str, str] | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.id = vpn_connection_id
@@ -42,9 +42,7 @@ class VPNConnection(TaggedEC2Resource):
             vpn_connection_type=self.type,
         )
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         return super().get_filter_value(filter_name, "DescribeVpnConnections")
 
 
@@ -56,9 +54,9 @@ class VPNConnectionBackend:
         self,
         vpn_conn_type: str,
         customer_gateway_id: str,
-        vpn_gateway_id: Optional[str] = None,
-        transit_gateway_id: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        vpn_gateway_id: str | None = None,
+        transit_gateway_id: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> VPNConnection:
         if vpn_gateway_id and transit_gateway_id:
             # From the docs (parentheses mine):
@@ -92,7 +90,7 @@ class VPNConnectionBackend:
         return self.vpn_connections[vpn_connection_id]
 
     def describe_vpn_connections(
-        self, vpn_connection_ids: Optional[list[str]] = None, filters: Any = None
+        self, vpn_connection_ids: list[str] | None = None, filters: Any = None
     ) -> list[VPNConnection]:
         vpn_connections = list(self.vpn_connections.values())
 

--- a/moto/ec2/models/vpn_gateway.py
+++ b/moto/ec2/models/vpn_gateway.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import CloudFormationModel
 
@@ -10,7 +10,7 @@ from .core import TaggedEC2Resource
 class VPCGatewayAttachment(CloudFormationModel):
     # Represents both VPNGatewayAttachment and VPCGatewayAttachment
     def __init__(
-        self, vpc_id: str, gateway_id: Optional[str] = None, state: Optional[str] = None
+        self, vpc_id: str, gateway_id: str | None = None, state: str | None = None
     ):
         self.vpc_id = vpc_id
         self.gateway_id = gateway_id
@@ -62,9 +62,9 @@ class VpnGateway(CloudFormationModel, TaggedEC2Resource):
         ec2_backend: Any,
         gateway_id: str,
         gateway_type: str,
-        amazon_side_asn: Optional[str],
-        availability_zone: Optional[str],
-        tags: Optional[dict[str, str]] = None,
+        amazon_side_asn: str | None,
+        availability_zone: str | None,
+        tags: dict[str, str] | None = None,
         state: str = "available",
     ):
         self.ec2_backend = ec2_backend
@@ -112,9 +112,7 @@ class VpnGateway(CloudFormationModel, TaggedEC2Resource):
     def physical_resource_id(self) -> str:
         return self.id
 
-    def get_filter_value(
-        self, filter_name: str, method_name: Optional[str] = None
-    ) -> Any:
+    def get_filter_value(self, filter_name: str, method_name: str | None = None) -> Any:
         if filter_name == "attachment.vpc-id":
             return self.attachments.keys()
         elif filter_name == "attachment.state":
@@ -133,9 +131,9 @@ class VpnGatewayBackend:
     def create_vpn_gateway(
         self,
         gateway_type: str = "ipsec.1",
-        amazon_side_asn: Optional[str] = None,
-        availability_zone: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        amazon_side_asn: str | None = None,
+        availability_zone: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> VpnGateway:
         vpn_gateway_id = random_vpn_gateway_id()
         vpn_gateway = VpnGateway(
@@ -145,7 +143,7 @@ class VpnGatewayBackend:
         return vpn_gateway
 
     def describe_vpn_gateways(
-        self, filters: Any = None, vpn_gw_ids: Optional[list[str]] = None
+        self, filters: Any = None, vpn_gw_ids: list[str] | None = None
     ) -> list[VpnGateway]:
         vpn_gateways = list(self.vpn_gateways.values() or [])
         if vpn_gw_ids:

--- a/moto/ec2/responses/_base_response.py
+++ b/moto/ec2/responses/_base_response.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.responses import BaseResponse
 from moto.core.serialize import return_if_not_empty
@@ -68,7 +68,7 @@ class EC2BaseResponse(BaseResponse):
             )
 
     def _parse_tag_specification(
-        self, expected_type: Optional[str] = None
+        self, expected_type: str | None = None
     ) -> dict[str, dict[str, str]]:
         # [{"ResourceType": _type, "Tag": [{"Key": k, "Value": v}, ..]}]
         tag_spec_set = self._get_param("TagSpecification", [])

--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -5,7 +5,7 @@ import ipaddress
 import re
 from collections.abc import Callable
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Optional, TypeAlias, TypedDict, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeAlias, TypedDict, TypeVar
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -270,7 +270,7 @@ def random_dedicated_host_id() -> str:
     return random_id(prefix=EC2_RESOURCE_TO_PREFIX["dedicated_host"])
 
 
-def random_private_ip(cidr: Optional[str] = None, ipv6: bool = False) -> str:
+def random_private_ip(cidr: str | None = None, ipv6: bool = False) -> str:
     # prefix - ula.prefixlen : get number of remaing length for the IP.
     #                          prefix will be 32 for IPv4 and 128 for IPv6.
     #  random.getrandbits() will generate remaining bits for IPv6 or Ipv4 in decimal format
@@ -312,9 +312,9 @@ def random_subnet_cidr_reservation_id() -> str:
 
 def generate_route_id(
     route_table_id: str,
-    cidr_block: Optional[str],
-    ipv6_cidr_block: Optional[str] = None,
-    prefix_list: Optional[str] = None,
+    cidr_block: str | None,
+    ipv6_cidr_block: str | None = None,
+    prefix_list: str | None = None,
 ) -> str:
     if ipv6_cidr_block and not cidr_block:
         cidr_block = ipv6_cidr_block
@@ -367,7 +367,7 @@ def is_tag_filter(filter_name: str) -> bool:
     )
 
 
-def get_obj_tag(obj: Any, filter_name: str) -> Optional[str]:
+def get_obj_tag(obj: Any, filter_name: str) -> str | None:
     tag_name = filter_name.replace("tag:", "", 1)
     tags = {tag["key"]: tag["value"] for tag in obj.get_tags()}
     return tags.get(tag_name)
@@ -378,7 +378,7 @@ def get_obj_tag_names(obj: Any) -> set[str]:
     return tags
 
 
-def get_obj_tag_values(obj: Any, key: Optional[str] = None) -> set[str]:
+def get_obj_tag_values(obj: Any, key: str | None = None) -> set[str]:
     tags = {tag["value"] for tag in obj.get_tags() if tag["key"] == key or key is None}
     return tags
 
@@ -757,7 +757,7 @@ def _convert_rfc4716(data: bytes) -> bytes:
     return b" ".join(result_parts)
 
 
-def public_key_parse(key_material: bytes) -> Union[RSAPublicKey, Ed25519PublicKey]:
+def public_key_parse(key_material: bytes) -> RSAPublicKey | Ed25519PublicKey:
     try:
         if key_material.startswith(b"---- BEGIN SSH2 PUBLIC KEY ----"):
             # cryptography doesn't parse RFC4716 key format, so we have to convert it first
@@ -774,7 +774,7 @@ def public_key_parse(key_material: bytes) -> Union[RSAPublicKey, Ed25519PublicKe
 
 
 def public_key_fingerprint(
-    public_key: Union[RSAPublicKey, Ed25519PublicKey],
+    public_key: RSAPublicKey | Ed25519PublicKey,
     hash_constructor: Callable[[bytes], "HashType"],
 ) -> str:
     key_data = public_key.public_bytes(
@@ -787,7 +787,7 @@ def public_key_fingerprint(
 
 
 def select_hash_algorithm(
-    public_key: Union[RSAPublicKey, Ed25519PublicKey], is_imported: bool = True
+    public_key: RSAPublicKey | Ed25519PublicKey, is_imported: bool = True
 ) -> Callable[[bytes], "HashType"]:
     if isinstance(public_key, Ed25519PublicKey):
         return hashlib.sha256
@@ -822,8 +822,8 @@ def filter_iam_instance_profile_associations(
 def filter_iam_instance_profiles(
     account_id: str,
     partition: str,
-    iam_instance_profile_arn: Optional[str],
-    iam_instance_profile_name: Optional[str],
+    iam_instance_profile_arn: str | None,
+    iam_instance_profile_name: str | None,
 ) -> Any:
     instance_profile = None
     instance_profile_by_name = None
@@ -945,7 +945,7 @@ def convert_tag_spec(
     return tags
 
 
-def parse_user_data(value: Any) -> Optional[Base64EncodedString]:
+def parse_user_data(value: Any) -> Base64EncodedString | None:
     if value is None:
         return None
     try:

--- a/moto/ecr/models.py
+++ b/moto/ecr/models.py
@@ -66,8 +66,8 @@ class Repository(CloudFormationModel, BaseModel):
         account_id: str,
         region_name: str,
         repository_name: str,
-        registry_id: Optional[str],
-        encryption_config: Optional[dict[str, str]],
+        registry_id: str | None,
+        encryption_config: dict[str, str] | None,
         image_scan_config: str,
         image_tag_mutability: str,
         image_tag_mutability_exclusion_filters: Optional[
@@ -94,8 +94,8 @@ class Repository(CloudFormationModel, BaseModel):
         self.encryption_configuration = self._determine_encryption_config(
             encryption_config
         )
-        self.policy: Optional[str] = None
-        self.lifecycle_policy: Optional[str] = None
+        self.policy: str | None = None
+        self.lifecycle_policy: str | None = None
         self.images: list[Image] = []
         self.scanning_config = {
             "repositoryArn": self.arn,
@@ -106,7 +106,7 @@ class Repository(CloudFormationModel, BaseModel):
         }
 
     def _determine_encryption_config(
-        self, encryption_config: Optional[dict[str, str]]
+        self, encryption_config: dict[str, str] | None
     ) -> dict[str, str]:
         if not encryption_config:
             return {"encryptionType": "AES256"}
@@ -116,9 +116,7 @@ class Repository(CloudFormationModel, BaseModel):
             )
         return encryption_config
 
-    def _determine_image_tag_mutability(
-        self, image_tag_mutability: Optional[str]
-    ) -> str:
+    def _determine_image_tag_mutability(self, image_tag_mutability: str | None) -> str:
         if not image_tag_mutability:
             return RepoTagMutability.MUTABLE
         elif image_tag_mutability == RepoTagMutability.MUTABLE_WITH_EXCLUSION or (
@@ -140,9 +138,7 @@ class Repository(CloudFormationModel, BaseModel):
             RepoTagMutability.IMMUTABLE_WITH_EXCLUSION,
         ]
 
-    def _get_image(
-        self, image_tag: Optional[str], image_digest: Optional[str]
-    ) -> Image:
+    def _get_image(self, image_tag: str | None, image_digest: str | None) -> Image:
         # you can either search for one or both
         image = next(
             (
@@ -173,7 +169,7 @@ class Repository(CloudFormationModel, BaseModel):
 
     def _update_image_tag_mutability(
         self,
-        image_tag_mutability: Optional[str],
+        image_tag_mutability: str | None,
         image_tag_mutability_exclusion_filters: Optional[
             list[ImageTagMutabilityExclusionFilterT]
         ],
@@ -186,7 +182,7 @@ class Repository(CloudFormationModel, BaseModel):
         )
 
     def _update_image_scanning_configuration(
-        self, image_scanning_configuration: Optional[dict[str, bool]]
+        self, image_scanning_configuration: dict[str, bool] | None
     ) -> None:
         if image_scanning_configuration:
             self.image_scanning_configuration = image_scanning_configuration
@@ -332,8 +328,8 @@ class Repository(CloudFormationModel, BaseModel):
     @classmethod
     def _convert_cfn_mutability_exclusion_filters(
         cls,
-        exclusion_filters: Optional[list[dict[str, str]]],
-    ) -> Optional[list[ImageTagMutabilityExclusionFilterT]]:
+        exclusion_filters: list[dict[str, str]] | None,
+    ) -> list[ImageTagMutabilityExclusionFilterT] | None:
         if not exclusion_filters:
             return None
         image_tag_mutability_exclusion_filters: list[
@@ -360,9 +356,9 @@ class Image(BaseModel):
         tag: str,
         manifest: str,
         repository: str,
-        image_manifest_mediatype: Optional[str] = None,
-        digest: Optional[str] = None,
-        registry_id: Optional[str] = None,
+        image_manifest_mediatype: str | None = None,
+        digest: str | None = None,
+        registry_id: str | None = None,
     ):
         self.image_tag = tag
         self.image_tags = [tag] if tag is not None else []
@@ -372,7 +368,7 @@ class Image(BaseModel):
         self.registry_id = registry_id or account_id
         self._image_digest = digest
         self.image_pushed_at = int(datetime.now(timezone.utc).timestamp())
-        self.last_scan: Optional[datetime] = None
+        self.last_scan: datetime | None = None
 
         self.scan_finding_results_queue: list[Any] = []
         self.scan_finding_results: dict[str, Any] = {}
@@ -411,7 +407,7 @@ class Image(BaseModel):
             self._create_digest()
         return self._image_digest  # type: ignore[return-value]
 
-    def get_image_size_in_bytes(self) -> Optional[int]:
+    def get_image_size_in_bytes(self) -> int | None:
         image_manifest = json.loads(self.image_manifest)
         if "layers" in image_manifest:
             try:
@@ -439,7 +435,7 @@ class Image(BaseModel):
 class ECRBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.registry_policy: Optional[str] = None
+        self.registry_policy: str | None = None
         self.replication_config: dict[str, Any] = {"rules": []}
         self.repositories: dict[str, Repository] = {}
         self.registry_scanning_configuration: dict[str, Any] = {
@@ -477,9 +473,7 @@ class ECRBackend(BaseBackend):
             service_region, zones, "api.ecr", special_service_name="ecr.api"
         ) + [docker_endpoint]
 
-    def _get_repository(
-        self, name: str, registry_id: Optional[str] = None
-    ) -> Repository:
+    def _get_repository(self, name: str, registry_id: str | None = None) -> Repository:
         repo = self.repositories.get(name)
         reg_id = registry_id or self.account_id
 
@@ -499,8 +493,8 @@ class ECRBackend(BaseBackend):
 
     def describe_repositories(
         self,
-        registry_id: Optional[str] = None,
-        repository_names: Optional[list[str]] = None,
+        registry_id: str | None = None,
+        repository_names: list[str] | None = None,
     ) -> list[Repository]:
         """
         maxResults and nextToken not implemented
@@ -529,7 +523,7 @@ class ECRBackend(BaseBackend):
     def create_repository(
         self,
         repository_name: str,
-        registry_id: Optional[str],
+        registry_id: str | None,
         encryption_config: dict[str, str],
         image_scan_config: Any,
         image_tag_mutability: str,
@@ -599,7 +593,7 @@ class ECRBackend(BaseBackend):
     def delete_repository(
         self,
         repository_name: str,
-        registry_id: Optional[str] = None,
+        registry_id: str | None = None,
         force: bool = False,
     ) -> Repository:
         repo = self._get_repository(repository_name, registry_id)
@@ -613,7 +607,7 @@ class ECRBackend(BaseBackend):
         return self.repositories.pop(repository_name)
 
     def list_images(
-        self, repository_name: str, registry_id: Optional[str] = None
+        self, repository_name: str, registry_id: str | None = None
     ) -> list[Image]:
         """
         maxResults and filtering not implemented
@@ -638,8 +632,8 @@ class ECRBackend(BaseBackend):
     def describe_images(
         self,
         repository_name: str,
-        registry_id: Optional[str] = None,
-        image_ids: Optional[list[dict[str, str]]] = None,
+        registry_id: str | None = None,
+        image_ids: list[dict[str, str]] | None = None,
     ) -> Iterable[Image]:
         repository = self._get_repository(repository_name, registry_id)
 
@@ -659,8 +653,8 @@ class ECRBackend(BaseBackend):
         repository_name: str,
         image_manifest: str,
         image_tag: str,
-        image_manifest_mediatype: Optional[str] = None,
-        digest: Optional[str] = None,
+        image_manifest_mediatype: str | None = None,
+        digest: str | None = None,
     ) -> Image:
         if repository_name in self.repositories:
             repository = self.repositories[repository_name]
@@ -816,8 +810,8 @@ class ECRBackend(BaseBackend):
     def batch_get_image(
         self,
         repository_name: str,
-        registry_id: Optional[str] = None,
-        image_ids: Optional[list[dict[str, Any]]] = None,
+        registry_id: str | None = None,
+        image_ids: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
         """
         The parameter AcceptedMediaTypes has not yet been implemented
@@ -862,8 +856,8 @@ class ECRBackend(BaseBackend):
     def batch_delete_image(
         self,
         repository_name: str,
-        registry_id: Optional[str] = None,
-        image_ids: Optional[list[dict[str, str]]] = None,
+        registry_id: str | None = None,
+        image_ids: list[dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         if repository_name in self.repositories:
             repository = self.repositories[repository_name]
@@ -1437,7 +1431,7 @@ class ECRBackend(BaseBackend):
         image_tag_mutability_exclusion_filters: Optional[
             list[ImageTagMutabilityExclusionFilterT]
         ],
-    ) -> Optional[str]:
+    ) -> str | None:
         if image_tag_mutability_exclusion_filters is None:
             # It is not mandatory
             return None

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import Iterator
 from os import getenv
-from typing import Any, Optional
+from typing import Any
 
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -41,12 +41,12 @@ class Cluster(CloudFormationModel, BaseModel):
         cluster_name: str,
         account_id: str,
         region_name: str,
-        cluster_settings: Optional[list[dict[str, str]]] = None,
-        configuration: Optional[dict[str, Any]] = None,
-        capacity_providers: Optional[list[str]] = None,
-        default_capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        service_connect_defaults: Optional[dict[str, str]] = None,
+        cluster_settings: list[dict[str, str]] | None = None,
+        configuration: dict[str, Any] | None = None,
+        capacity_providers: list[str] | None = None,
+        default_capacity_provider_strategy: list[dict[str, Any]] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        service_connect_defaults: dict[str, str] | None = None,
     ):
         self.active_services_count = 0
         self.arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:cluster/{cluster_name}"
@@ -135,21 +135,21 @@ class TaskDefinition(CloudFormationModel, BaseModel):
         container_definitions: list[dict[str, Any]],
         account_id: str,
         region_name: str,
-        network_mode: Optional[str] = None,
-        volumes: Optional[list[dict[str, Any]]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        placement_constraints: Optional[list[dict[str, str]]] = None,
-        requires_compatibilities: Optional[list[str]] = None,
-        cpu: Optional[str] = None,
-        memory: Optional[str] = None,
-        task_role_arn: Optional[str] = None,
-        execution_role_arn: Optional[str] = None,
-        proxy_configuration: Optional[dict[str, Any]] = None,
-        inference_accelerators: Optional[list[dict[str, str]]] = None,
-        runtime_platform: Optional[dict[str, str]] = None,
-        ipc_mode: Optional[str] = None,
-        pid_mode: Optional[str] = None,
-        ephemeral_storage: Optional[dict[str, int]] = None,
+        network_mode: str | None = None,
+        volumes: list[dict[str, Any]] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        placement_constraints: list[dict[str, str]] | None = None,
+        requires_compatibilities: list[str] | None = None,
+        cpu: str | None = None,
+        memory: str | None = None,
+        task_role_arn: str | None = None,
+        execution_role_arn: str | None = None,
+        proxy_configuration: dict[str, Any] | None = None,
+        inference_accelerators: list[dict[str, str]] | None = None,
+        runtime_platform: dict[str, str] | None = None,
+        ipc_mode: str | None = None,
+        pid_mode: str | None = None,
+        ephemeral_storage: dict[str, int] | None = None,
     ):
         self.family = family
         self.revision = revision
@@ -188,9 +188,9 @@ class TaskDefinition(CloudFormationModel, BaseModel):
             self.compatibilities = ["EC2", "FARGATE"]
 
         if network_mode is None and "FARGATE" not in self.compatibilities:
-            self.network_mode: Optional[str] = "bridge"
+            self.network_mode: str | None = "bridge"
         elif "FARGATE" in self.compatibilities:
-            self.network_mode: Optional[str] = "awsvpc"  # type: ignore[no-redef]
+            self.network_mode: str | None = "awsvpc"  # type: ignore[no-redef]
         else:
             self.network_mode = network_mode
 
@@ -303,16 +303,16 @@ class Task(ManagedState, BaseModel):
         self,
         cluster: Cluster,
         task_definition: TaskDefinition,
-        container_instance_arn: Optional[str],
-        resource_requirements: Optional[dict[str, str]],
+        container_instance_arn: str | None,
+        resource_requirements: dict[str, str] | None,
         backend: "EC2ContainerServiceBackend",
         group: str,
         launch_type: str = "",
-        overrides: Optional[dict[str, Any]] = None,
+        overrides: dict[str, Any] | None = None,
         started_by: str = "",
-        tags: Optional[list[dict[str, str]]] = None,
-        networking_configuration: Optional[dict[str, Any]] = None,
-        platform_version: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        networking_configuration: dict[str, Any] | None = None,
+        platform_version: str | None = None,
     ):
         # Configure ManagedState
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html
@@ -408,7 +408,7 @@ class CapacityProvider(BaseModel):
         region_name: str,
         name: str,
         asg_details: dict[str, Any],
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ):
         self._id = str(mock_random.uuid4())
         self.capacity_provider_arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:capacity-provider/{name}"
@@ -417,7 +417,7 @@ class CapacityProvider(BaseModel):
         self.auto_scaling_group_provider = self._prepare_asg_provider(asg_details)
         self.tags = tags
 
-        self.update_status: Optional[str] = None
+        self.update_status: str | None = None
 
     def _prepare_asg_provider(self, asg_details: dict[str, Any]) -> dict[str, Any]:
         if "managedScaling" not in asg_details:
@@ -473,17 +473,17 @@ class Service(CloudFormationModel, BaseModel):
         service_name: str,
         desired_count: int,
         backend: "EC2ContainerServiceBackend",
-        task_definition: Optional[TaskDefinition] = None,
-        load_balancers: Optional[list[dict[str, Any]]] = None,
-        scheduling_strategy: Optional[list[dict[str, Any]]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        deployment_controller: Optional[dict[str, str]] = None,
-        launch_type: Optional[str] = None,
-        service_registries: Optional[list[dict[str, Any]]] = None,
-        platform_version: Optional[str] = None,
-        network_configuration: Optional[dict[str, dict[str, list[str]]]] = None,
+        task_definition: TaskDefinition | None = None,
+        load_balancers: list[dict[str, Any]] | None = None,
+        scheduling_strategy: list[dict[str, Any]] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        deployment_controller: dict[str, str] | None = None,
+        launch_type: str | None = None,
+        service_registries: list[dict[str, Any]] | None = None,
+        platform_version: str | None = None,
+        network_configuration: dict[str, dict[str, list[str]]] | None = None,
         propagate_tags: str = "NONE",
-        role_arn: Optional[str] = None,
+        role_arn: str | None = None,
     ):
         self.cluster_name = cluster.name
         self.cluster_arn = cluster.arn
@@ -849,16 +849,16 @@ class TaskSet(BaseModel):
         task_definition: str,
         account_id: str,
         region_name: str,
-        external_id: Optional[str] = None,
-        network_configuration: Optional[dict[str, Any]] = None,
-        load_balancers: Optional[list[dict[str, Any]]] = None,
-        service_registries: Optional[list[dict[str, Any]]] = None,
-        launch_type: Optional[str] = None,
-        capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
-        platform_version: Optional[str] = None,
-        scale: Optional[dict[str, Any]] = None,
-        client_token: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        external_id: str | None = None,
+        network_configuration: dict[str, Any] | None = None,
+        load_balancers: list[dict[str, Any]] | None = None,
+        service_registries: list[dict[str, Any]] | None = None,
+        launch_type: str | None = None,
+        capacity_provider_strategy: list[dict[str, Any]] | None = None,
+        platform_version: str | None = None,
+        scale: dict[str, Any] | None = None,
+        client_token: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.service = service
         self.cluster = cluster
@@ -930,7 +930,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         self,
         name: str,
         asg_details: dict[str, Any],
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ) -> CapacityProvider:
         capacity_provider = CapacityProvider(
             self.account_id, self.region_name, name, asg_details, tags
@@ -960,10 +960,10 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_name: str,
         tags: Any = None,
         cluster_settings: Any = None,
-        configuration: Optional[dict[str, Any]] = None,
-        capacity_providers: Optional[list[str]] = None,
-        default_capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
-        service_connect_defaults: Optional[dict[str, str]] = None,
+        configuration: dict[str, Any] | None = None,
+        capacity_providers: list[str] | None = None,
+        default_capacity_provider_strategy: list[dict[str, Any]] | None = None,
+        service_connect_defaults: dict[str, str] | None = None,
     ) -> Cluster:
         cluster = Cluster(
             cluster_name,
@@ -982,9 +982,9 @@ class EC2ContainerServiceBackend(BaseBackend):
     def update_cluster(
         self,
         cluster_name: str,
-        cluster_settings: Optional[list[dict[str, str]]],
-        configuration: Optional[dict[str, Any]],
-        service_connect_defaults: Optional[dict[str, str]],
+        cluster_settings: list[dict[str, str]] | None,
+        configuration: dict[str, Any] | None,
+        service_connect_defaults: dict[str, str] | None,
     ) -> Cluster:
         """
         The serviceConnectDefaults-parameter is not yet implemented
@@ -1002,7 +1002,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         self,
         cluster: Cluster,
         task_num: int,
-        task_state: Optional[str] = "RUNNING",
+        task_state: str | None = "RUNNING",
     ) -> None:
         """
         Modify the number tasks running on the cluster.
@@ -1015,8 +1015,8 @@ class EC2ContainerServiceBackend(BaseBackend):
     def put_cluster_capacity_providers(
         self,
         cluster_name: str,
-        capacity_providers: Optional[list[str]],
-        default_capacity_provider_strategy: Optional[list[dict[str, Any]]],
+        capacity_providers: list[str] | None,
+        default_capacity_provider_strategy: list[dict[str, Any]] | None,
     ) -> Cluster:
         cluster = self._get_cluster(cluster_name)
         if capacity_providers is not None:
@@ -1027,7 +1027,7 @@ class EC2ContainerServiceBackend(BaseBackend):
             )
         return cluster
 
-    def _get_provider(self, name_or_arn: str) -> Optional[CapacityProvider]:
+    def _get_provider(self, name_or_arn: str) -> CapacityProvider | None:
         for provider in self.capacity_providers.values():
             if (
                 provider.name == name_or_arn
@@ -1108,21 +1108,21 @@ class EC2ContainerServiceBackend(BaseBackend):
         self,
         family: str,
         container_definitions: list[dict[str, Any]],
-        volumes: Optional[list[dict[str, Any]]] = None,
-        network_mode: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        placement_constraints: Optional[list[dict[str, str]]] = None,
-        requires_compatibilities: Optional[list[str]] = None,
-        cpu: Optional[str] = None,
-        memory: Optional[str] = None,
-        task_role_arn: Optional[str] = None,
-        execution_role_arn: Optional[str] = None,
-        proxy_configuration: Optional[dict[str, Any]] = None,
-        inference_accelerators: Optional[list[dict[str, str]]] = None,
-        runtime_platform: Optional[dict[str, str]] = None,
-        ipc_mode: Optional[str] = None,
-        pid_mode: Optional[str] = None,
-        ephemeral_storage: Optional[dict[str, int]] = None,
+        volumes: list[dict[str, Any]] | None = None,
+        network_mode: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        placement_constraints: list[dict[str, str]] | None = None,
+        requires_compatibilities: list[str] | None = None,
+        cpu: str | None = None,
+        memory: str | None = None,
+        task_role_arn: str | None = None,
+        execution_role_arn: str | None = None,
+        proxy_configuration: dict[str, Any] | None = None,
+        inference_accelerators: list[dict[str, str]] | None = None,
+        runtime_platform: dict[str, str] | None = None,
+        ipc_mode: str | None = None,
+        pid_mode: str | None = None,
+        ephemeral_storage: dict[str, int] | None = None,
     ) -> TaskDefinition:
         if requires_compatibilities and "FARGATE" in requires_compatibilities:
             # TODO need more validation for Fargate
@@ -1168,9 +1168,9 @@ class EC2ContainerServiceBackend(BaseBackend):
 
     @staticmethod
     def _validate_container_defs(  # type: ignore[misc]
-        memory: Optional[str],
+        memory: str | None,
         container_definitions: list[dict[str, Any]],
-        requires_compatibilities: Optional[list[str]],
+        requires_compatibilities: list[str] | None,
     ) -> None:
         # The capitalised keys are passed by Cloudformation
         for cd in container_definitions:
@@ -1237,13 +1237,13 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_str: str,
         task_definition_str: str,
         count: int,
-        overrides: Optional[dict[str, Any]],
+        overrides: dict[str, Any] | None,
         started_by: str,
-        tags: Optional[list[dict[str, str]]],
-        launch_type: Optional[str],
-        networking_configuration: Optional[dict[str, Any]] = None,
-        group: Optional[str] = None,
-        platform_version: Optional[str] = None,
+        tags: list[dict[str, str]] | None,
+        launch_type: str | None,
+        networking_configuration: dict[str, Any] | None = None,
+        group: str | None = None,
+        platform_version: str | None = None,
     ) -> list[Task]:
         if launch_type and launch_type not in ["EC2", "FARGATE", "EXTERNAL"]:
             raise InvalidParameterException(
@@ -1415,8 +1415,8 @@ class EC2ContainerServiceBackend(BaseBackend):
         container_instances: list[str],
         overrides: dict[str, Any],
         started_by: str,
-        tags: Optional[list[dict[str, str]]] = None,
-        group: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        group: str | None = None,
     ) -> list[Task]:
         cluster = self._get_cluster(cluster_str)
 
@@ -1480,12 +1480,12 @@ class EC2ContainerServiceBackend(BaseBackend):
 
     def list_tasks(
         self,
-        cluster_str: Optional[str] = None,
-        container_instance: Optional[str] = None,
-        family: Optional[str] = None,
-        started_by: Optional[str] = None,
-        service_name: Optional[str] = None,
-        desiredStatus: Optional[str] = None,
+        cluster_str: str | None = None,
+        container_instance: str | None = None,
+        family: str | None = None,
+        started_by: str | None = None,
+        service_name: str | None = None,
+        desiredStatus: str | None = None,
     ) -> list[Task]:
         filtered_tasks = []
         for tasks in self.tasks.values():
@@ -1572,17 +1572,17 @@ class EC2ContainerServiceBackend(BaseBackend):
         cluster_str: str,
         service_name: str,
         desired_count: int,
-        task_definition_str: Optional[str] = None,
-        load_balancers: Optional[list[dict[str, Any]]] = None,
-        scheduling_strategy: Optional[list[dict[str, Any]]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        deployment_controller: Optional[dict[str, str]] = None,
-        launch_type: Optional[str] = None,
-        service_registries: Optional[list[dict[str, Any]]] = None,
-        platform_version: Optional[str] = None,
+        task_definition_str: str | None = None,
+        load_balancers: list[dict[str, Any]] | None = None,
+        scheduling_strategy: list[dict[str, Any]] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        deployment_controller: dict[str, str] | None = None,
+        launch_type: str | None = None,
+        service_registries: list[dict[str, Any]] | None = None,
+        platform_version: str | None = None,
         propagate_tags: str = "NONE",
-        network_configuration: Optional[dict[str, dict[str, list[str]]]] = None,
-        role_arn: Optional[str] = None,
+        network_configuration: dict[str, dict[str, list[str]]] | None = None,
+        role_arn: str | None = None,
     ) -> Service:
         cluster = self._get_cluster(cluster_str)
 
@@ -1628,8 +1628,8 @@ class EC2ContainerServiceBackend(BaseBackend):
     def list_services(
         self,
         cluster_str: str,
-        scheduling_strategy: Optional[str] = None,
-        launch_type: Optional[str] = None,
+        scheduling_strategy: str | None = None,
+        launch_type: str | None = None,
     ) -> list[str]:
         cluster = self._get_cluster(cluster_str)
         service_arns = []
@@ -1892,7 +1892,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         pass
 
     def put_attributes(
-        self, cluster_name: str, attributes: Optional[list[dict[str, Any]]] = None
+        self, cluster_name: str, attributes: list[dict[str, Any]] | None = None
     ) -> None:
         cluster = self._get_cluster(cluster_name)
 
@@ -1912,9 +1912,9 @@ class EC2ContainerServiceBackend(BaseBackend):
         self,
         cluster_name: str,
         name: str,
-        value: Optional[str] = None,
-        target_id: Optional[str] = None,
-        target_type: Optional[str] = None,
+        value: str | None = None,
+        target_id: str | None = None,
+        target_type: str | None = None,
     ) -> None:
         if target_id is None and target_type is None:
             for instance in self.container_instances[cluster_name].values():
@@ -1947,9 +1947,9 @@ class EC2ContainerServiceBackend(BaseBackend):
     def list_attributes(
         self,
         target_type: str,
-        cluster_name: Optional[str] = None,
-        attr_name: Optional[str] = None,
-        attr_value: Optional[str] = None,
+        cluster_name: str | None = None,
+        attr_name: str | None = None,
+        attr_value: str | None = None,
     ) -> Any:
         """
         Pagination is not yet implemented
@@ -1983,7 +1983,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         return filter(lambda x: all(f(x) for f in filters), all_attrs)  # type: ignore
 
     def delete_attributes(
-        self, cluster_name: str, attributes: Optional[list[dict[str, Any]]] = None
+        self, cluster_name: str, attributes: list[dict[str, Any]] | None = None
     ) -> None:
         cluster = self._get_cluster(cluster_name)
 
@@ -2003,9 +2003,9 @@ class EC2ContainerServiceBackend(BaseBackend):
         self,
         cluster_name: str,
         name: str,
-        value: Optional[str] = None,
-        target_id: Optional[str] = None,
-        target_type: Optional[str] = None,
+        value: str | None = None,
+        target_id: str | None = None,
+        target_type: str | None = None,
     ) -> None:
         if target_id is None and target_type is None:
             for instance in self.container_instances[cluster_name].values():
@@ -2039,7 +2039,7 @@ class EC2ContainerServiceBackend(BaseBackend):
                 )
 
     def list_task_definition_families(
-        self, family_prefix: Optional[str] = None
+        self, family_prefix: str | None = None
     ) -> Iterator[str]:
         """
         The Status and pagination parameters are not yet implemented
@@ -2138,16 +2138,16 @@ class EC2ContainerServiceBackend(BaseBackend):
         service: str,
         cluster_str: str,
         task_definition: str,
-        external_id: Optional[str] = None,
-        network_configuration: Optional[dict[str, Any]] = None,
-        load_balancers: Optional[list[dict[str, Any]]] = None,
-        service_registries: Optional[list[dict[str, Any]]] = None,
-        launch_type: Optional[str] = None,
-        capacity_provider_strategy: Optional[list[dict[str, Any]]] = None,
-        platform_version: Optional[str] = None,
-        scale: Optional[dict[str, Any]] = None,
-        client_token: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        external_id: str | None = None,
+        network_configuration: dict[str, Any] | None = None,
+        load_balancers: list[dict[str, Any]] | None = None,
+        service_registries: list[dict[str, Any]] | None = None,
+        launch_type: str | None = None,
+        capacity_provider_strategy: list[dict[str, Any]] | None = None,
+        platform_version: str | None = None,
+        scale: dict[str, Any] | None = None,
+        client_token: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> TaskSet:
         launch_type = launch_type if launch_type is not None else "EC2"
         if launch_type not in ["EC2", "FARGATE"]:
@@ -2295,7 +2295,7 @@ class EC2ContainerServiceBackend(BaseBackend):
         return task_set_obj
 
     def list_account_settings(
-        self, name: Optional[str] = None, value: Optional[str] = None
+        self, name: str | None = None, value: str | None = None
     ) -> list[AccountSetting]:
         expected_names = [
             "serviceLongArnFormat",

--- a/moto/efs/models.py
+++ b/moto/efs/models.py
@@ -8,7 +8,7 @@ import json
 import time
 from collections.abc import Iterator
 from copy import deepcopy
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import CloudFormationModel
@@ -35,7 +35,7 @@ from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition, md5_hash
 
 
-def _lookup_az_id(account_id: str, az_name: str) -> Optional[str]:
+def _lookup_az_id(account_id: str, az_name: str) -> str | None:
     """Find the Availability zone ID given the AZ name."""
     ec2 = ec2_backends[account_id][az_name[:-1]]
     for zone in ec2.describe_availability_zones():
@@ -51,7 +51,7 @@ class AccessPoint(CloudFormationModel):
         region_name: str,
         client_token: str,
         file_system_id: str,
-        name: Optional[str],
+        name: str | None,
         posix_user: dict[str, Any],
         root_directory: dict[str, str],
         context: "EFSBackend",
@@ -156,7 +156,7 @@ class FileSystem(CloudFormationModel):
             )
         self._backup = backup
         self.lifecycle_policies: list[dict[str, str]] = []
-        self.file_system_policy: Optional[str] = None
+        self.file_system_policy: str | None = None
 
         self._context = context
 
@@ -189,7 +189,7 @@ class FileSystem(CloudFormationModel):
         return len(self._mount_targets)
 
     @property
-    def backup_policy(self) -> Optional[dict[str, str]]:
+    def backup_policy(self) -> dict[str, str] | None:
         if self._backup:
             return {"Status": "ENABLED"}
         else:
@@ -305,8 +305,8 @@ class MountTarget(CloudFormationModel):
         account_id: str,
         file_system: FileSystem,
         subnet: Subnet,
-        ip_address: Optional[str],
-        security_groups: Optional[list[str]],
+        ip_address: str | None,
+        security_groups: list[str] | None,
     ):
         # Set the simple given parameters.
         self.file_system_id = file_system.file_system_id
@@ -342,7 +342,7 @@ class MountTarget(CloudFormationModel):
         self.owner_id = account_id
         self.mount_target_id = f"fsmt-{mock_random.get_random_hex()}"
         self.life_cycle_state = "available"
-        self.network_interface_id: Optional[str] = None
+        self.network_interface_id: str | None = None
         self.availability_zone_id = subnet.availability_zone_id
         self.availability_zone_name = subnet.availability_zone
 
@@ -427,12 +427,12 @@ class EFSBackend(BaseBackend):
         self.access_points: dict[str, AccessPoint] = {}
         self.file_systems_by_id: dict[str, FileSystem] = {}
         self.mount_targets_by_id: dict[str, MountTarget] = {}
-        self.next_markers: dict[str, Union[list[MountTarget], list[FileSystem]]] = {}
+        self.next_markers: dict[str, list[MountTarget] | list[FileSystem]] = {}
         self.tagging_service = TaggingService()
 
     def _mark_description(
-        self, corpus: Union[list[MountTarget], list[FileSystem]], max_items: int
-    ) -> Optional[str]:
+        self, corpus: list[MountTarget] | list[FileSystem], max_items: int
+    ) -> str | None:
         if max_items < len(corpus):
             new_corpus = corpus[max_items:]
             new_corpus_dict = [c.info_json() for c in new_corpus]
@@ -495,11 +495,11 @@ class EFSBackend(BaseBackend):
 
     def describe_file_systems(
         self,
-        marker: Optional[str] = None,
+        marker: str | None = None,
         max_items: int = 10,
-        creation_token: Optional[str] = None,
-        file_system_id: Optional[str] = None,
-    ) -> tuple[Optional[str], list[FileSystem]]:
+        creation_token: str | None = None,
+        file_system_id: str | None = None,
+    ) -> tuple[str | None, list[FileSystem]]:
         """Describe all the EFS File Systems, or specific File Systems.
 
         https://docs.aws.amazon.com/efs/latest/ug/API_DescribeFileSystems.html
@@ -538,8 +538,8 @@ class EFSBackend(BaseBackend):
         self,
         file_system_id: str,
         subnet_id: str,
-        ip_address: Optional[str] = None,
-        security_groups: Optional[list[str]] = None,
+        ip_address: str | None = None,
+        security_groups: list[str] | None = None,
     ) -> MountTarget:
         """Create a new EFS Mount Target for a given File System to a given subnet.
 
@@ -582,11 +582,11 @@ class EFSBackend(BaseBackend):
     def describe_mount_targets(
         self,
         max_items: int,
-        file_system_id: Optional[str],
-        mount_target_id: Optional[str],
-        access_point_id: Optional[str],
-        marker: Optional[str],
-    ) -> tuple[Optional[str], list[MountTarget]]:
+        file_system_id: str | None,
+        mount_target_id: str | None,
+        access_point_id: str | None,
+        marker: str | None,
+    ) -> tuple[str | None, list[MountTarget]]:
         """Describe the mount targets given an access point ID, mount target ID or a file system ID.
 
         https://docs.aws.amazon.com/efs/latest/ug/API_DescribeMountTargets.html
@@ -680,7 +680,7 @@ class EFSBackend(BaseBackend):
 
     def describe_mount_target_security_groups(
         self, mount_target_id: str
-    ) -> Optional[list[str]]:
+    ) -> list[str] | None:
         if mount_target_id not in self.mount_targets_by_id:
             raise MountTargetNotFound(mount_target_id)
 
@@ -725,8 +725,8 @@ class EFSBackend(BaseBackend):
 
     def describe_access_points(
         self,
-        access_point_id: Optional[str],
-        file_system_id: Optional[str],
+        access_point_id: str | None,
+        file_system_id: str | None,
     ) -> list[AccessPoint]:
         """
         Pagination is not yet implemented

--- a/moto/efs/responses.py
+++ b/moto/efs/responses.py
@@ -1,11 +1,11 @@
 import json
-from typing import Any, Union
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
 from .models import EFSBackend, efs_backends
 
-TYPE_RESPONSE = tuple[str, dict[str, Union[str, int]]]
+TYPE_RESPONSE = tuple[str, dict[str, str | int]]
 
 
 class EFSResponse(BaseResponse):

--- a/moto/eks/models.py
+++ b/moto/eks/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import utcnow
@@ -98,13 +98,13 @@ class Cluster:
         account_id: str,
         region_name: str,
         aws_partition: str,
-        version: Optional[str] = None,
-        kubernetes_network_config: Optional[dict[str, str]] = None,
-        logging: Optional[dict[str, Any]] = None,
-        client_request_token: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        encryption_config: Optional[list[dict[str, Any]]] = None,
-        remote_network_config: Optional[dict[str, list[dict[str, list[str]]]]] = None,
+        version: str | None = None,
+        kubernetes_network_config: dict[str, str] | None = None,
+        logging: dict[str, Any] | None = None,
+        client_request_token: str | None = None,
+        tags: dict[str, str] | None = None,
+        encryption_config: list[dict[str, Any]] | None = None,
+        remote_network_config: dict[str, list[dict[str, list[str]]]] | None = None,
     ):
         if encryption_config is None:
             encryption_config = []
@@ -159,9 +159,9 @@ class FargateProfile:
         account_id: str,
         region_name: str,
         aws_partition: str,
-        client_request_token: Optional[str] = None,
-        subnets: Optional[list[str]] = None,
-        tags: Optional[dict[str, str]] = None,
+        client_request_token: str | None = None,
+        subnets: list[str] | None = None,
+        tags: dict[str, str] | None = None,
     ):
         if subnets is None:
             subnets = []
@@ -199,21 +199,21 @@ class Nodegroup:
         account_id: str,
         region_name: str,
         aws_partition: str,
-        scaling_config: Optional[dict[str, int]] = None,
-        disk_size: Optional[int] = None,
-        instance_types: Optional[list[str]] = None,
-        ami_type: Optional[str] = None,
-        remote_access: Optional[dict[str, Any]] = None,
-        labels: Optional[dict[str, str]] = None,
-        taints: Optional[list[dict[str, str]]] = None,
-        tags: Optional[dict[str, str]] = None,
-        client_request_token: Optional[str] = None,
-        launch_template: Optional[dict[str, str]] = None,
-        capacity_type: Optional[str] = None,
-        version: Optional[str] = None,
-        release_version: Optional[str] = None,
-        update_config: Optional[dict[str, Any]] = None,
-        node_repair_config: Optional[dict[str, Any]] = None,
+        scaling_config: dict[str, int] | None = None,
+        disk_size: int | None = None,
+        instance_types: list[str] | None = None,
+        ami_type: str | None = None,
+        remote_access: dict[str, Any] | None = None,
+        labels: dict[str, str] | None = None,
+        taints: list[dict[str, str]] | None = None,
+        tags: dict[str, str] | None = None,
+        client_request_token: str | None = None,
+        launch_template: dict[str, str] | None = None,
+        capacity_type: str | None = None,
+        version: str | None = None,
+        release_version: str | None = None,
+        update_config: dict[str, Any] | None = None,
+        node_repair_config: dict[str, Any] | None = None,
     ):
         if tags is None:
             tags = {}
@@ -295,13 +295,13 @@ class EKSBackend(BaseBackend):
         name: str,
         role_arn: str,
         resources_vpc_config: dict[str, Any],
-        version: Optional[str] = None,
-        kubernetes_network_config: Optional[dict[str, str]] = None,
-        logging: Optional[dict[str, Any]] = None,
-        client_request_token: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        encryption_config: Optional[list[dict[str, Any]]] = None,
-        remote_network_config: Optional[dict[str, list[dict[str, list[str]]]]] = None,
+        version: str | None = None,
+        kubernetes_network_config: dict[str, str] | None = None,
+        logging: dict[str, Any] | None = None,
+        client_request_token: str | None = None,
+        tags: dict[str, str] | None = None,
+        encryption_config: list[dict[str, Any]] | None = None,
+        remote_network_config: dict[str, list[dict[str, list[str]]]] | None = None,
     ) -> Cluster:
         if name in self.clusters:
             # Cluster exists.
@@ -338,9 +338,9 @@ class EKSBackend(BaseBackend):
         cluster_name: str,
         selectors: list[dict[str, Any]],
         pod_execution_role_arn: str,
-        subnets: Optional[list[str]] = None,
-        client_request_token: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        subnets: list[str] | None = None,
+        client_request_token: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> FargateProfile:
         try:
             # Cluster exists.
@@ -392,19 +392,19 @@ class EKSBackend(BaseBackend):
         node_role: str,
         nodegroup_name: str,
         subnets: list[str],
-        scaling_config: Optional[dict[str, int]] = None,
-        disk_size: Optional[int] = None,
-        instance_types: Optional[list[str]] = None,
-        ami_type: Optional[str] = None,
-        remote_access: Optional[dict[str, Any]] = None,
-        labels: Optional[dict[str, str]] = None,
-        taints: Optional[list[dict[str, str]]] = None,
-        tags: Optional[dict[str, str]] = None,
-        client_request_token: Optional[str] = None,
-        launch_template: Optional[dict[str, str]] = None,
-        capacity_type: Optional[str] = None,
-        version: Optional[str] = None,
-        release_version: Optional[str] = None,
+        scaling_config: dict[str, int] | None = None,
+        disk_size: int | None = None,
+        instance_types: list[str] | None = None,
+        ami_type: str | None = None,
+        remote_access: dict[str, Any] | None = None,
+        labels: dict[str, str] | None = None,
+        taints: list[dict[str, str]] | None = None,
+        tags: dict[str, str] | None = None,
+        client_request_token: str | None = None,
+        launch_template: dict[str, str] | None = None,
+        capacity_type: str | None = None,
+        version: str | None = None,
+        release_version: str | None = None,
     ) -> Nodegroup:
         try:
             # Cluster exists.
@@ -684,21 +684,21 @@ class EKSBackend(BaseBackend):
         return cluster.tags
 
     def list_clusters(
-        self, max_results: int, next_token: Optional[str]
-    ) -> tuple[list[Cluster], Optional[Cluster]]:
+        self, max_results: int, next_token: str | None
+    ) -> tuple[list[Cluster], Cluster | None]:
         return paginated_list(list(self.clusters.keys()), max_results, next_token)
 
     def list_fargate_profiles(
-        self, cluster_name: str, max_results: int, next_token: Optional[str]
-    ) -> tuple[list[FargateProfile], Optional[FargateProfile]]:
+        self, cluster_name: str, max_results: int, next_token: str | None
+    ) -> tuple[list[FargateProfile], FargateProfile | None]:
         cluster = self.clusters[cluster_name]
         return paginated_list(
             list(cluster.fargate_profiles.keys()), max_results, next_token
         )
 
     def list_nodegroups(
-        self, cluster_name: str, max_results: int, next_token: Optional[str]
-    ) -> tuple[list[Nodegroup], Optional[Nodegroup]]:
+        self, cluster_name: str, max_results: int, next_token: str | None
+    ) -> tuple[list[Nodegroup], Nodegroup | None]:
         cluster = self.clusters[cluster_name]
         return paginated_list(list(cluster.nodegroups.keys()), max_results, next_token)
 
@@ -706,10 +706,10 @@ class EKSBackend(BaseBackend):
         self,
         name: str,
         resources_vpc_config: dict[str, Any],
-        logging: Optional[dict[str, Any]] = None,
-        client_request_token: Optional[str] = None,
-        kubernetes_network_config: Optional[dict[str, str]] = None,
-        remote_network_config: Optional[dict[str, list[dict[str, list[str]]]]] = None,
+        logging: dict[str, Any] | None = None,
+        client_request_token: str | None = None,
+        kubernetes_network_config: dict[str, str] | None = None,
+        remote_network_config: dict[str, list[dict[str, list[str]]]] | None = None,
     ) -> Cluster:
         cluster = self.clusters.get(name)
         if cluster:
@@ -738,12 +738,12 @@ class EKSBackend(BaseBackend):
         self,
         cluster_name: str,
         nodegroup_name: str,
-        labels: Optional[dict[str, Any]] = None,
-        taints: Optional[dict[str, Any]] = None,
-        scaling_config: Optional[dict[str, int]] = None,
-        update_config: Optional[dict[str, Any]] = None,
-        node_repair_config: Optional[dict[str, Any]] = None,
-        client_request_token: Optional[str] = None,
+        labels: dict[str, Any] | None = None,
+        taints: dict[str, Any] | None = None,
+        scaling_config: dict[str, int] | None = None,
+        update_config: dict[str, Any] | None = None,
+        node_repair_config: dict[str, Any] | None = None,
+        client_request_token: str | None = None,
     ) -> dict[str, Any]:
         # Validate cluster exists
         try:
@@ -844,8 +844,8 @@ class EKSBackend(BaseBackend):
 
 
 def paginated_list(
-    full_list: list[Any], max_results: int, next_token: Optional[str]
-) -> tuple[list[Any], Optional[Any]]:
+    full_list: list[Any], max_results: int, next_token: str | None
+) -> tuple[list[Any], Any]:
     """
     Returns a tuple containing a slice of the full list
     starting at next_token and ending with at most the
@@ -876,7 +876,7 @@ def validate_safe_to_delete(cluster: Cluster) -> None:
 
 
 def validate_launch_template_combination(
-    disk_size: Optional[int], remote_access: Optional[dict[str, Any]]
+    disk_size: int | None, remote_access: dict[str, Any] | None
 ) -> None:
     if not (disk_size or remote_access):
         return

--- a/moto/elasticache/models.py
+++ b/moto/elasticache/models.py
@@ -2,7 +2,7 @@ import copy
 import random
 import string
 from re import compile as re_compile
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -40,9 +40,9 @@ class User(BaseModel):
         access_string: str,
         engine: str,
         no_password_required: bool,
-        passwords: Optional[list[str]] = None,
-        authentication_type: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        passwords: list[str] | None = None,
+        authentication_type: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.id = user_id
         self.name = user_name
@@ -60,7 +60,7 @@ class User(BaseModel):
         self.tags = tags or []
 
     @property
-    def authentication(self) -> dict[str, Union[str, int, None]]:
+    def authentication(self) -> dict[str, str | int | None]:
         return {
             "Type": "no-password"
             if self.no_password_required
@@ -76,36 +76,36 @@ class CacheCluster(BaseModel):
         region_name: str,
         cache_cluster_id: str,
         cache_node_type: str,
-        replication_group_id: Optional[str],
-        az_mode: Optional[str],
-        preferred_availability_zone: Optional[str],
-        num_cache_nodes: Optional[int],
-        engine: Optional[str],
-        engine_version: Optional[str],
-        cache_parameter_group_name: Optional[str],
-        cache_subnet_group_name: Optional[str],
-        transit_encryption_enabled: Optional[bool],
-        network_type: Optional[str],
-        ip_discovery: Optional[str],
-        snapshot_name: Optional[str],
-        preferred_maintenance_window: Optional[str],
-        port: Optional[int],
-        notification_topic_arn: Optional[str],
-        auto_minor_version_upgrade: Optional[bool],
-        snapshot_retention_limit: Optional[int],
-        snapshot_window: Optional[str],
-        auth_token: Optional[str],
-        outpost_mode: Optional[str],
-        preferred_outpost_arn: Optional[str],
-        preferred_availability_zones: Optional[list[str]],
-        cache_security_group_names: Optional[list[str]],
-        security_group_ids: Optional[list[str]],
-        tags: Optional[list[dict[str, str]]],
-        snapshot_arns: Optional[list[str]],
-        preferred_outpost_arns: Optional[list[str]],
+        replication_group_id: str | None,
+        az_mode: str | None,
+        preferred_availability_zone: str | None,
+        num_cache_nodes: int | None,
+        engine: str | None,
+        engine_version: str | None,
+        cache_parameter_group_name: str | None,
+        cache_subnet_group_name: str | None,
+        transit_encryption_enabled: bool | None,
+        network_type: str | None,
+        ip_discovery: str | None,
+        snapshot_name: str | None,
+        preferred_maintenance_window: str | None,
+        port: int | None,
+        notification_topic_arn: str | None,
+        auto_minor_version_upgrade: bool | None,
+        snapshot_retention_limit: int | None,
+        snapshot_window: str | None,
+        auth_token: str | None,
+        outpost_mode: str | None,
+        preferred_outpost_arn: str | None,
+        preferred_availability_zones: list[str] | None,
+        cache_security_group_names: list[str] | None,
+        security_group_ids: list[str] | None,
+        tags: list[dict[str, str]] | None,
+        snapshot_arns: list[str] | None,
+        preferred_outpost_arns: list[str] | None,
         log_delivery_configurations: list[dict[str, Any]],
-        cache_node_ids_to_remove: Optional[list[str]],
-        cache_node_ids_to_reboot: Optional[list[str]],
+        cache_node_ids_to_remove: list[str] | None,
+        cache_node_ids_to_reboot: list[str] | None,
     ):
         self.cache_cluster_id = cache_cluster_id
         self.az_mode = az_mode
@@ -163,7 +163,7 @@ class CacheSubnetGroup(BaseModel):
         cache_subnet_group_name: str,
         cache_subnet_group_description: str,
         subnet_ids: list[str],
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ):
         self.cache_subnet_group_name = cache_subnet_group_name
         self.cache_subnet_group_description = cache_subnet_group_description
@@ -234,44 +234,44 @@ class ReplicationGroup(BaseModel):
         account_id: str,
         region_name: str,
         replication_group_id: str,
-        preferred_cache_cluster_azs: Optional[list[str]],
-        num_cache_clusters: Optional[int],
-        num_node_groups: Optional[int],
-        replicas_per_node_group: Optional[int],
+        preferred_cache_cluster_azs: list[str] | None,
+        num_cache_clusters: int | None,
+        num_node_groups: int | None,
+        replicas_per_node_group: int | None,
         node_group_configuration: list[dict[str, Any]],
-        preferred_maintenance_window: Optional[str],
+        preferred_maintenance_window: str | None,
         replication_group_description: str,
-        primary_cluster_id: Optional[str],
+        primary_cluster_id: str | None,
         automatic_failover_enabled: bool,
-        global_replication_group_id: Optional[str],
-        multi_az_enabled: Optional[bool],
-        port: Optional[int],
+        global_replication_group_id: str | None,
+        multi_az_enabled: bool | None,
+        port: int | None,
         snapshot_retention_limit: int,
-        snapshot_window: Optional[str],
-        cluster_mode: Optional[str],
-        cache_node_type: Optional[str],
-        auth_token: Optional[str],
-        transit_encryption_enabled: Optional[bool],
-        at_rest_encryption_enabled: Optional[bool],
-        kms_key_id: Optional[str],
+        snapshot_window: str | None,
+        cluster_mode: str | None,
+        cache_node_type: str | None,
+        auth_token: str | None,
+        transit_encryption_enabled: bool | None,
+        at_rest_encryption_enabled: bool | None,
+        kms_key_id: str | None,
         user_group_ids: list[str],
         log_delivery_configurations: list[dict[str, Any]],
-        data_tiering_enabled: Optional[bool],
-        auto_minor_version_upgrade: Optional[bool],
-        engine: Optional[str],
-        network_type: Optional[str],
-        ip_discovery: Optional[str],
-        transit_encryption_mode: Optional[str],
-        cache_security_group_names: Optional[list[str]],
-        cache_subnet_group_name: Optional[str],
-        security_group_ids: Optional[list[str]],
-        tags: Optional[list[dict[str, str]]],
-        notification_topic_arn: Optional[str],
-        serverless_cache_snapshot_name: Optional[str],
-        cache_parameter_group_name: Optional[str],
-        engine_version: Optional[str],
-        snapshot_arns: Optional[list[str]],
-        snapshot_name: Optional[str],
+        data_tiering_enabled: bool | None,
+        auto_minor_version_upgrade: bool | None,
+        engine: str | None,
+        network_type: str | None,
+        ip_discovery: str | None,
+        transit_encryption_mode: str | None,
+        cache_security_group_names: list[str] | None,
+        cache_subnet_group_name: str | None,
+        security_group_ids: list[str] | None,
+        tags: list[dict[str, str]] | None,
+        notification_topic_arn: str | None,
+        serverless_cache_snapshot_name: str | None,
+        cache_parameter_group_name: str | None,
+        engine_version: str | None,
+        snapshot_arns: list[str] | None,
+        snapshot_name: str | None,
     ):
         tags = tags or []
         self.cluster_mode = cluster_mode or "disabled"
@@ -586,32 +586,32 @@ class Snapshot(BaseModel):
         self,
         account_id: str,
         region_name: str,
-        automatic_failover: Optional[bool],
-        auto_minor_version_upgrade: Optional[bool],
-        cache_cluster_create_time: Optional[str],
-        cache_cluster_id: Optional[str],
-        cache_node_type: Optional[str],
-        cache_parameter_group_name: Optional[str],
-        cache_subnet_group_name: Optional[str],
-        engine: Optional[str],
-        engine_version: Optional[str],
-        kms_key_id: Optional[str],
-        num_cache_nodes: Optional[int],
-        num_node_groups: Optional[int],
-        port: Optional[int],
-        preferred_availability_zone: Optional[str],
-        preferred_maintenance_window: Optional[str],
-        preferred_outpost_arn: Optional[str],
-        replication_group_description: Optional[str],
-        replication_group_id: Optional[str],
-        snapshot_name: Optional[str],
-        snapshot_retention_limit: Optional[int],
-        snapshot_source: Optional[str],
-        snapshot_status: Optional[str],
-        snapshot_window: Optional[str],
-        topic_arn: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        vpc_id: Optional[str] = None,
+        automatic_failover: bool | None,
+        auto_minor_version_upgrade: bool | None,
+        cache_cluster_create_time: str | None,
+        cache_cluster_id: str | None,
+        cache_node_type: str | None,
+        cache_parameter_group_name: str | None,
+        cache_subnet_group_name: str | None,
+        engine: str | None,
+        engine_version: str | None,
+        kms_key_id: str | None,
+        num_cache_nodes: int | None,
+        num_node_groups: int | None,
+        port: int | None,
+        preferred_availability_zone: str | None,
+        preferred_maintenance_window: str | None,
+        preferred_outpost_arn: str | None,
+        replication_group_description: str | None,
+        replication_group_id: str | None,
+        snapshot_name: str | None,
+        snapshot_retention_limit: int | None,
+        snapshot_source: str | None,
+        snapshot_status: str | None,
+        snapshot_window: str | None,
+        topic_arn: str | None,
+        tags: list[dict[str, str]] | None,
+        vpc_id: str | None = None,
     ):
         self.arn = f"arn:{get_partition(region_name)}:elasticache:{region_name}:{account_id}:snapshot:{snapshot_name}"
         self.automatic_failover = automatic_failover
@@ -669,8 +669,8 @@ class ElastiCacheBackend(BaseBackend):
 
     def _get_snapshots_by_param(
         self,
-        ref_id: Optional[str] = None,
-        source: Optional[str] = None,
+        ref_id: str | None = None,
+        source: str | None = None,
     ) -> list[Snapshot]:
         source_map = {
             "system": "automated",
@@ -692,7 +692,7 @@ class ElastiCacheBackend(BaseBackend):
 
         return snapshots
 
-    def _get_vpc_id_from_cluster(self, cache_cluster_id: str) -> Optional[str]:
+    def _get_vpc_id_from_cluster(self, cache_cluster_id: str) -> str | None:
         if cache_cluster_id and cache_cluster_id in self.cache_clusters:
             cache_cluster = self.cache_clusters[cache_cluster_id]
             subnet_group_name = cache_cluster.cache_subnet_group_name
@@ -709,7 +709,7 @@ class ElastiCacheBackend(BaseBackend):
         access_string: str,
         no_password_required: bool,
         authentication_type: str,  # contain it to the str in the enums TODO
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> User:
         if user_id in self.users:
             raise UserAlreadyExists
@@ -764,7 +764,7 @@ class ElastiCacheBackend(BaseBackend):
             return user
         raise UserNotFound(user_id)
 
-    def describe_users(self, user_id: Optional[str]) -> list[User]:
+    def describe_users(self, user_id: str | None) -> list[User]:
         """
         Only the `user_id` parameter is currently supported.
         Pagination is not yet implemented.
@@ -864,7 +864,7 @@ class ElastiCacheBackend(BaseBackend):
         return cache_cluster
 
     def describe_cache_clusters(
-        self, cache_cluster_id: Optional[str] = None
+        self, cache_cluster_id: str | None = None
     ) -> list[CacheCluster]:
         if cache_cluster_id:
             if cache_cluster_id in self.cache_clusters:
@@ -887,7 +887,7 @@ class ElastiCacheBackend(BaseBackend):
         cache_subnet_group_name: str,
         cache_subnet_group_description: str,
         subnet_ids: list[str],
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ) -> CacheSubnetGroup:
         if cache_subnet_group_name in self.cache_subnet_groups:
             raise CacheSubnetGroupAlreadyExists(cache_subnet_group_name)
@@ -909,7 +909,7 @@ class ElastiCacheBackend(BaseBackend):
 
     def describe_cache_subnet_groups(
         self,
-        cache_subnet_group_name: Optional[str] = None,
+        cache_subnet_group_name: str | None = None,
     ) -> list[CacheSubnetGroup]:
         if cache_subnet_group_name:
             if cache_subnet_group_name in self.cache_subnet_groups:
@@ -1029,7 +1029,7 @@ class ElastiCacheBackend(BaseBackend):
 
     def describe_replication_groups(
         self,
-        replication_group_id: Optional[str] = None,
+        replication_group_id: str | None = None,
     ) -> list[ReplicationGroup]:
         if replication_group_id:
             if replication_group_id in self.replication_groups:
@@ -1040,7 +1040,7 @@ class ElastiCacheBackend(BaseBackend):
         return list(self.replication_groups.values())
 
     def delete_replication_group(
-        self, replication_group_id: str, retain_primary_cluster: Optional[bool]
+        self, replication_group_id: str, retain_primary_cluster: bool | None
     ) -> ReplicationGroup:
         if replication_group_id not in self.replication_groups:
             raise ReplicationGroupNotFound(replication_group_id)
@@ -1058,10 +1058,10 @@ class ElastiCacheBackend(BaseBackend):
     def create_snapshot(
         self,
         snapshot_name: str,
-        replication_group_id: Optional[str],
-        cache_cluster_id: Optional[str],
-        kms_key_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        replication_group_id: str | None,
+        cache_cluster_id: str | None,
+        kms_key_id: str | None,
+        tags: list[dict[str, str]] | None,
     ) -> Snapshot:
         resource = None
         num_node_groups = None
@@ -1139,13 +1139,13 @@ class ElastiCacheBackend(BaseBackend):
 
     def describe_snapshots(
         self,
-        replication_group_id: Optional[str] = None,
-        cache_cluster_id: Optional[str] = None,
-        snapshot_name: Optional[str] = None,
-        snapshot_source: Optional[str] = None,
-        marker: Optional[str] = None,
-        max_records: Optional[int] = None,
-        show_node_group_config: Optional[bool] = None,
+        replication_group_id: str | None = None,
+        cache_cluster_id: str | None = None,
+        snapshot_name: str | None = None,
+        snapshot_source: str | None = None,
+        marker: str | None = None,
+        max_records: int | None = None,
+        show_node_group_config: bool | None = None,
     ) -> list[Snapshot]:
         if snapshot_name:
             try:

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -2,7 +2,7 @@ import datetime
 import re
 from collections import OrderedDict
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -55,7 +55,7 @@ class FakeListener(BaseModel):
         load_balancer_port: str,
         instance_port: str,
         protocol: str,
-        ssl_certificate_id: Optional[str],
+        ssl_certificate_id: str | None,
     ):
         self.load_balancer_port = load_balancer_port
         self.instance_port = instance_port
@@ -87,14 +87,14 @@ class LoadBalancer(CloudFormationModel):
         name: str,
         zones: list[str],
         ports: list[dict[str, Any]],
-        scheme: Optional[str],
-        vpc_id: Optional[str],
-        subnets: Optional[list[str]],
-        security_groups: Optional[list[str]],
+        scheme: str | None,
+        vpc_id: str | None,
+        subnets: list[str] | None,
+        security_groups: list[str] | None,
     ):
         self.account_id = account_id
         self.name = name
-        self.health_check: Optional[FakeHealthCheck] = None
+        self.health_check: FakeHealthCheck | None = None
         self.instance_sparse_ids: list[str] = []
         self.instance_autoscaling_ids: list[str] = []
         self.availability_zones = zones
@@ -335,8 +335,8 @@ class ELBBackend(BaseBackend):
         zones: list[str],
         ports: list[dict[str, Any]],
         scheme: str = "internet-facing",
-        subnets: Optional[list[str]] = None,
-        security_groups: Optional[list[str]] = None,
+        subnets: list[str] | None = None,
+        security_groups: list[str] | None = None,
     ) -> LoadBalancer:
         vpc_id = None
         ec2_backend = ec2_backends[self.account_id][self.region_name]
@@ -387,7 +387,7 @@ class ELBBackend(BaseBackend):
 
     def create_load_balancer_listeners(
         self, name: str, ports: list[dict[str, Any]]
-    ) -> Optional[LoadBalancer]:
+    ) -> LoadBalancer | None:
         balancer = self.load_balancers.get(name, None)
         if balancer:
             for port in ports:
@@ -473,7 +473,7 @@ class ELBBackend(BaseBackend):
 
     def delete_load_balancer_listeners(
         self, name: str, ports: list[str]
-    ) -> Optional[LoadBalancer]:
+    ) -> LoadBalancer | None:
         balancer = self.get_load_balancer(name)
         listeners = []
         if balancer:
@@ -524,7 +524,7 @@ class ELBBackend(BaseBackend):
 
     def set_load_balancer_listener_ssl_certificate(
         self, name: str, lb_port: str, ssl_certificate_id: str
-    ) -> Optional[LoadBalancer]:
+    ) -> LoadBalancer | None:
         balancer = self.load_balancers.get(name, None)
         if balancer:
             for idx, listener in enumerate(balancer.listeners):
@@ -585,11 +585,11 @@ class ELBBackend(BaseBackend):
     def modify_load_balancer_attributes(
         self,
         load_balancer_name: str,
-        cross_zone: Optional[dict[str, Any]] = None,
-        connection_settings: Optional[dict[str, Any]] = None,
-        connection_draining: Optional[dict[str, Any]] = None,
-        access_log: Optional[dict[str, Any]] = None,
-        additional_attributes: Optional[list[dict[str, str]]] = None,
+        cross_zone: dict[str, Any] | None = None,
+        connection_settings: dict[str, Any] | None = None,
+        connection_draining: dict[str, Any] | None = None,
+        access_log: dict[str, Any] | None = None,
+        additional_attributes: list[dict[str, str]] | None = None,
     ) -> None:
         load_balancer = self.get_load_balancer(load_balancer_name)
         if cross_zone:
@@ -642,7 +642,7 @@ class ELBBackend(BaseBackend):
         self,
         load_balancer_name: str,
         policy_name: str,
-        cookie_expiration_period: Optional[int],
+        cookie_expiration_period: int | None,
     ) -> LoadBalancer:
         load_balancer = self.get_load_balancer(load_balancer_name)
         policy = LbCookieStickinessPolicy(policy_name, cookie_expiration_period)

--- a/moto/elb/policies.py
+++ b/moto/elb/policies.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 
 class Policy:
@@ -14,7 +14,7 @@ class AppCookieStickinessPolicy(Policy):
 
 
 class LbCookieStickinessPolicy(Policy):
-    def __init__(self, policy_name: str, cookie_expiration_period: Optional[int]):
+    def __init__(self, policy_name: str, cookie_expiration_period: int | None):
         super().__init__(policy_name, policy_type_name="LbCookieStickinessPolicy")
         self.cookie_expiration_period = cookie_expiration_period
 

--- a/moto/elbv2/exceptions.py
+++ b/moto/elbv2/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.exceptions import ServiceException
 
@@ -140,7 +140,7 @@ class ResourceInUseError(ELBClientError):
 
 
 class RuleNotFoundError(ELBClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         msg = msg or "The specified rule does not exist."
         super().__init__("RuleNotFound", msg)
 

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1,7 +1,7 @@
 import re
 from collections import OrderedDict
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 from botocore.exceptions import ParamValidationError
 
@@ -62,10 +62,10 @@ class FakeHealthStatus(BaseModel):
         self,
         instance_id: str,
         port: str,
-        health_port: Optional[str],
+        health_port: str | None,
         status: str,
-        reason: Optional[str] = None,
-        description: Optional[str] = None,
+        reason: str | None = None,
+        description: str | None = None,
     ):
         self.instance_id = instance_id
         self.port = port
@@ -82,7 +82,7 @@ class FakeHealthStatus(BaseModel):
         }
 
     @property
-    def target_health(self) -> dict[str, Optional[str]]:
+    def target_health(self) -> dict[str, str | None]:
         return {
             "State": self.status,
             "Reason": self.reason,
@@ -101,18 +101,18 @@ class FakeTargetGroup(CloudFormationModel):
         vpc_id: str,
         protocol: str,
         port: str,
-        protocol_version: Optional[str] = None,
-        healthcheck_protocol: Optional[str] = None,
-        healthcheck_port: Optional[str] = None,
-        healthcheck_path: Optional[str] = None,
-        healthcheck_interval_seconds: Optional[int] = None,
-        healthcheck_timeout_seconds: Optional[int] = None,
-        healthcheck_enabled: Optional[str] = None,
-        healthy_threshold_count: Optional[str] = None,
-        unhealthy_threshold_count: Optional[str] = None,
-        matcher: Optional[dict[str, Any]] = None,
-        target_type: Optional[str] = None,
-        ip_address_type: Optional[str] = None,
+        protocol_version: str | None = None,
+        healthcheck_protocol: str | None = None,
+        healthcheck_port: str | None = None,
+        healthcheck_path: str | None = None,
+        healthcheck_interval_seconds: int | None = None,
+        healthcheck_timeout_seconds: int | None = None,
+        healthcheck_enabled: str | None = None,
+        healthy_threshold_count: str | None = None,
+        unhealthy_threshold_count: str | None = None,
+        matcher: dict[str, Any] | None = None,
+        target_type: str | None = None,
+        ip_address_type: str | None = None,
     ):
         # TODO: default values differs when you add Network Load balancer
         self.name = name
@@ -332,9 +332,9 @@ class FakeListener(CloudFormationModel):
         protocol: str,
         port: str,
         ssl_policy: str,
-        certificate: Optional[str],
+        certificate: str | None,
         default_actions: list["FakeAction"],
-        alpn_policy: Optional[list[str]],
+        alpn_policy: list[str] | None,
     ):
         self.load_balancer_arn = load_balancer_arn
         self.arn = arn
@@ -597,7 +597,7 @@ class FakeLoadBalancer(CloudFormationModel):
         dns_name: str,
         state: str,
         scheme: str = "internet-facing",
-        loadbalancer_type: Optional[str] = None,
+        loadbalancer_type: str | None = None,
         ip_address_type: str = "ipv4",
     ):
         self.name = name
@@ -734,11 +734,11 @@ class ELBv2Backend(BaseBackend):
         name: str,
         security_groups: list[str],
         subnet_ids: list[str],
-        subnet_mappings: Optional[list[dict[str, str]]] = None,
+        subnet_mappings: list[dict[str, str]] | None = None,
         scheme: str = "internet-facing",
-        loadbalancer_type: Optional[str] = None,
+        loadbalancer_type: str | None = None,
         ip_address_type: str = "ipv4",
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> FakeLoadBalancer:
         vpc_id = None
         subnets = []
@@ -812,7 +812,7 @@ class ELBv2Backend(BaseBackend):
         conditions: list[dict[str, Any]],
         priority: int,
         actions: list[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> FakeListenerRule:
         fake_actions = [FakeAction(action) for action in actions]
         listeners = self.describe_listeners(None, [listener_arn])
@@ -1032,7 +1032,7 @@ class ELBv2Backend(BaseBackend):
                 raise InvalidActionTypeError(action_type, index)
 
     def _validate_port_and_protocol(
-        self, loadbalancer_type: str, port: Optional[str], protocol: Optional[str]
+        self, loadbalancer_type: str, port: str | None, protocol: str | None
     ) -> None:
         if loadbalancer_type in {"application", "network"}:
             if port is None:
@@ -1397,10 +1397,10 @@ Member must satisfy regular expression pattern: {expression}"
         protocol: str,
         port: str,
         ssl_policy: str,
-        certificate: Optional[str],
+        certificate: str | None,
         actions: list[dict[str, Any]],
-        alpn_policy: Optional[list[str]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        alpn_policy: list[str] | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> FakeListener:
         default_actions = [FakeAction(action) for action in actions]
         balancer = self.load_balancers.get(load_balancer_arn)
@@ -1446,7 +1446,7 @@ Member must satisfy regular expression pattern: {expression}"
         return listener
 
     def describe_load_balancers(
-        self, arns: Optional[list[str]], names: Optional[list[str]]
+        self, arns: list[str] | None, names: list[str] | None
     ) -> list[FakeLoadBalancer]:
         balancers = list(self.load_balancers.values())
         arns = arns or []
@@ -1482,7 +1482,7 @@ Member must satisfy regular expression pattern: {expression}"
         return matched_balancers
 
     def describe_rules(
-        self, listener_arn: Optional[str], rule_arns: Optional[list[str]]
+        self, listener_arn: str | None, rule_arns: list[str] | None
     ) -> list[FakeRule]:
         if listener_arn is None and not rule_arns:
             raise InvalidDescribeRulesRequest(
@@ -1510,9 +1510,9 @@ Member must satisfy regular expression pattern: {expression}"
 
     def describe_target_groups(
         self,
-        load_balancer_arn: Optional[str],
+        load_balancer_arn: str | None,
         target_group_arns: list[str],
-        names: Optional[list[str]],
+        names: list[str] | None,
     ) -> Iterable[FakeTargetGroup]:
         args = sum(bool(arg) for arg in [load_balancer_arn, target_group_arns, names])
 
@@ -1555,7 +1555,7 @@ Member must satisfy regular expression pattern: {expression}"
         return sorted(self.target_groups.values(), key=lambda tg: tg.name)
 
     def describe_listeners(
-        self, load_balancer_arn: Optional[str], listener_arns: list[str]
+        self, load_balancer_arn: str | None, listener_arns: list[str]
     ) -> list[FakeListener]:
         if load_balancer_arn:
             if load_balancer_arn not in self.load_balancers:
@@ -1587,18 +1587,17 @@ Member must satisfy regular expression pattern: {expression}"
         # should raise RuleNotFound Error according to the AWS API doc
         # however, boto3 does't raise error even if rule is not found
 
-    def delete_target_group(self, target_group_arn: str) -> Optional[FakeTargetGroup]:  # type: ignore[return]
+    def delete_target_group(self, target_group_arn: str) -> FakeTargetGroup:
         if target_group_arn not in self.target_groups:
             raise TargetGroupNotFoundError()
 
         target_group = self.target_groups[target_group_arn]
-        if target_group:
-            if self._any_listener_using(target_group_arn):
-                raise ResourceInUseError(
-                    f"The target group '{target_group_arn}' is currently in use by a listener or a rule"
-                )
-            del self.target_groups[target_group_arn]
-            return target_group
+        if self._any_listener_using(target_group_arn):
+            raise ResourceInUseError(
+                f"The target group '{target_group_arn}' is currently in use by a listener or a rule"
+            )
+        del self.target_groups[target_group_arn]
+        return target_group
 
     def delete_listener(self, listener_arn: str) -> FakeListener:
         for load_balancer in self.load_balancers.values():
@@ -1799,15 +1798,15 @@ Member must satisfy regular expression pattern: {expression}"
     def modify_target_group(
         self,
         arn: str,
-        health_check_proto: Optional[str] = None,
-        health_check_port: Optional[str] = None,
-        health_check_path: Optional[str] = None,
-        health_check_interval: Optional[int] = None,
-        health_check_timeout: Optional[int] = None,
-        healthy_threshold_count: Optional[str] = None,
-        unhealthy_threshold_count: Optional[str] = None,
-        http_codes: Optional[str] = None,
-        health_check_enabled: Optional[bool] = None,
+        health_check_proto: str | None = None,
+        health_check_port: str | None = None,
+        health_check_path: str | None = None,
+        health_check_interval: int | None = None,
+        health_check_timeout: int | None = None,
+        healthy_threshold_count: str | None = None,
+        unhealthy_threshold_count: str | None = None,
+        http_codes: str | None = None,
+        health_check_enabled: bool | None = None,
     ) -> FakeTargetGroup:
         target_group = self.target_groups.get(arn)
         if target_group is None:
@@ -1846,11 +1845,11 @@ Member must satisfy regular expression pattern: {expression}"
     def modify_listener(
         self,
         arn: str,
-        port: Optional[str] = None,
-        protocol: Optional[str] = None,
-        ssl_policy: Optional[str] = None,
-        certificates: Optional[list[dict[str, Any]]] = None,
-        actions: Optional[list[dict[str, Any]]] = None,
+        port: str | None = None,
+        protocol: str | None = None,
+        ssl_policy: str | None = None,
+        certificates: list[dict[str, Any]] | None = None,
+        actions: list[dict[str, Any]] | None = None,
     ) -> FakeListener:
         default_actions = [FakeAction(action) for action in actions]  # type: ignore
         listener = self.describe_listeners(load_balancer_arn=None, listener_arns=[arn])[

--- a/moto/elbv2/responses.py
+++ b/moto/elbv2/responses.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 from moto.core.serialize import return_if_not_empty
 from moto.elbv2.exceptions import ELBClientError as RESTError
@@ -14,7 +12,7 @@ def transform_dict(data: dict[str, str]) -> list[dict[str, str]]:
     return transformed
 
 
-def transform_certificates(data: list[str]) -> Optional[list[dict[str, str]]]:
+def transform_certificates(data: list[str]) -> list[dict[str, str]] | None:
     return [{"CertificateArn": cert} for cert in data] or None
 
 

--- a/moto/elbv2/ssl_policies.py
+++ b/moto/elbv2/ssl_policies.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 # AWS Docs: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html
 
@@ -357,7 +357,7 @@ SSL_POLICIES = {
 }
 
 
-def build_policy(name: str, data: dict[str, Any]) -> dict[str, Optional[object]]:
+def build_policy(name: str, data: dict[str, Any]) -> dict[str, object] | None:
     # Adding priority numbers to ciphers and restructuring output to required format
     ciphers = [
         {"Name": c, "Priority": i + 1} for i, c in enumerate(data.get("ciphers", []))

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from functools import cache, cached_property
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -23,6 +23,9 @@ from .utils import (
     random_step_id,
 )
 
+if TYPE_CHECKING:
+    from moto.ec2.models import EC2Backend
+
 EXAMPLE_AMI_ID = "ami-12c6146b"
 
 
@@ -42,7 +45,7 @@ class BootstrapAction(BaseModel):
         self.script_bootstrap_action = script_bootstrap_action
 
     @property
-    def script_path(self) -> Optional[str]:
+    def script_path(self) -> str | None:
         return self.script_bootstrap_action.get("path")
 
     @property
@@ -55,8 +58,8 @@ class Instance(BaseModel):
         self,
         ec2_instance: EC2Instance,
         instance_group: InstanceGroup,
-        instance_fleet_id: Optional[str] = None,
-        instance_id: Optional[str] = None,
+        instance_fleet_id: str | None = None,
+        instance_id: str | None = None,
     ):
         self.id = instance_id or random_instance_group_id()
         self.ec2_instance = ec2_instance
@@ -130,11 +133,11 @@ class InstanceGroup(CloudFormationModel):
         instance_role: str,
         instance_type: str,
         market: str = "ON_DEMAND",
-        name: Optional[str] = None,
-        instance_group_id: Optional[str] = None,
-        bid_price: Optional[str] = None,
-        ebs_configuration: Optional[dict[str, Any]] = None,
-        auto_scaling_policy: Optional[dict[str, Any]] = None,
+        name: str | None = None,
+        instance_group_id: str | None = None,
+        bid_price: str | None = None,
+        ebs_configuration: dict[str, Any] | None = None,
+        auto_scaling_policy: dict[str, Any] | None = None,
     ) -> None:
         self.id = instance_group_id or random_instance_group_id()
         self.cluster_id = cluster_id
@@ -158,7 +161,7 @@ class InstanceGroup(CloudFormationModel):
         self.creation_date_time: datetime = utcnow()
         self.start_date_time: datetime = utcnow()
         self.ready_date_time: datetime = utcnow()
-        self.end_date_time: Optional[datetime] = None
+        self.end_date_time: datetime | None = None
         self.state: str = "RUNNING"
 
     def set_instance_count(self, instance_count: int) -> None:
@@ -292,7 +295,7 @@ class Step(BaseModel):
         self,
         state: str,
         name: str = "",
-        hadoop_jar_step: Optional[dict[str, Any]] = None,
+        hadoop_jar_step: dict[str, Any] | None = None,
         action_on_failure: str = "TERMINATE_CLUSTER",
     ):
         self.id = random_step_id()
@@ -305,7 +308,7 @@ class Step(BaseModel):
         self.creation_date_time = utcnow()
         self.end_date_time = None
         self.ready_date_time = None
-        self.start_date_time: Optional[datetime] = None
+        self.start_date_time: datetime | None = None
         self.state = state
 
     @property
@@ -377,21 +380,21 @@ class Cluster(CloudFormationModel):
         service_role: str,
         steps: list[dict[str, Any]],
         instance_attrs: dict[str, Any],
-        bootstrap_actions: Optional[list[dict[str, Any]]] = None,
-        configurations: Optional[list[dict[str, Any]]] = None,
-        cluster_id: Optional[str] = None,
+        bootstrap_actions: list[dict[str, Any]] | None = None,
+        configurations: list[dict[str, Any]] | None = None,
+        cluster_id: str | None = None,
         visible_to_all_users: bool = False,
-        release_label: Optional[str] = None,
-        requested_ami_version: Optional[str] = None,
-        running_ami_version: Optional[str] = None,
-        custom_ami_id: Optional[str] = None,
+        release_label: str | None = None,
+        requested_ami_version: str | None = None,
+        running_ami_version: str | None = None,
+        custom_ami_id: str | None = None,
         step_concurrency_level: int = 1,
-        security_configuration: Optional[str] = None,
-        kerberos_attributes: Optional[dict[str, str]] = None,
-        auto_scaling_role: Optional[str] = None,
-        ebs_root_volume_size: Optional[int] = None,
-        ebs_root_volume_iops: Optional[int] = None,
-        ebs_root_volume_throughput: Optional[int] = None,
+        security_configuration: str | None = None,
+        kerberos_attributes: dict[str, str] | None = None,
+        auto_scaling_role: str | None = None,
+        ebs_root_volume_size: int | None = None,
+        ebs_root_volume_iops: int | None = None,
+        ebs_root_volume_throughput: int | None = None,
     ):
         self.id = cluster_id or random_cluster_id()
         emr_backend.clusters[self.id] = self
@@ -418,8 +421,8 @@ class Cluster(CloudFormationModel):
 
         self.instance_group_ids: list[str] = []
         self.ec2_instances: list[Instance] = []
-        self.master_instance_group_id: Optional[str] = None
-        self.core_instance_group_id: Optional[str] = None
+        self.master_instance_group_id: str | None = None
+        self.core_instance_group_id: str | None = None
         if (
             "master_instance_type" in instance_attrs
             and instance_attrs["master_instance_type"]
@@ -490,10 +493,10 @@ class Cluster(CloudFormationModel):
         self.step_concurrency_level = step_concurrency_level
 
         self.creation_datetime = utcnow()
-        self.start_datetime: Optional[datetime] = None
-        self.ready_datetime: Optional[datetime] = None
-        self.end_datetime: Optional[datetime] = None
-        self.state: Optional[str] = None
+        self.start_datetime: datetime | None = None
+        self.ready_datetime: datetime | None = None
+        self.end_datetime: datetime | None = None
+        self.state: str | None = None
 
         self.start_cluster()
         self.run_bootstrap_actions()
@@ -857,11 +860,7 @@ class ElasticMapReduceBackend(BaseBackend):
         return load_resource(__name__, "resources/instance_types.json")
 
     @property
-    def ec2_backend(self) -> Any:
-        """
-        :return: EC2 Backend
-        :rtype: moto.ec2.models.EC2Backend
-        """
+    def ec2_backend(self) -> EC2Backend:
         from moto.ec2 import ec2_backends
 
         return ec2_backends[self.account_id][self.region_name]
@@ -893,7 +892,7 @@ class ElasticMapReduceBackend(BaseBackend):
         cluster = self.clusters[cluster_id]
         instances["is_instance_type_default"] = not instances.get("instance_type")
         response = self.ec2_backend.run_instances(
-            EXAMPLE_AMI_ID, instances["instance_count"], "", [], **instances
+            EXAMPLE_AMI_ID, instances["instance_count"], None, [], **instances
         )
         for instance in response.instances:
             instance = Instance(ec2_instance=instance, instance_group=instance_group)
@@ -911,10 +910,10 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def describe_job_flows(
         self,
-        job_flow_ids: Optional[list[str]] = None,
-        job_flow_states: Optional[list[str]] = None,
-        created_after: Optional[datetime] = None,
-        created_before: Optional[datetime] = None,
+        job_flow_ids: list[str] | None = None,
+        job_flow_states: list[str] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
     ) -> list[Cluster]:
         clusters = list(self.clusters.values())
 
@@ -933,7 +932,7 @@ class ElasticMapReduceBackend(BaseBackend):
         # Amazon EMR can return a maximum of 512 job flow descriptions
         return sorted(clusters, key=lambda x: x.id)[:512]
 
-    def describe_step(self, cluster_id: str, step_id: str) -> Optional[Step]:
+    def describe_step(self, cluster_id: str, step_id: str) -> Step | None:
         cluster = self.clusters[cluster_id]
         for step in cluster.steps:
             if step.id == step_id:
@@ -958,9 +957,9 @@ class ElasticMapReduceBackend(BaseBackend):
 
     def list_clusters(
         self,
-        cluster_states: Optional[list[str]] = None,
-        created_after: Optional[datetime] = None,
-        created_before: Optional[datetime] = None,
+        cluster_states: list[str] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
     ) -> list[Cluster]:
         clusters = list(self.clusters.values())
         if cluster_states:
@@ -979,8 +978,8 @@ class ElasticMapReduceBackend(BaseBackend):
     def list_instances(
         self,
         cluster_id: str,
-        instance_group_id: Optional[str] = None,
-        instance_group_types: Optional[list[str]] = None,
+        instance_group_id: str | None = None,
+        instance_group_types: list[str] | None = None,
     ) -> list[Instance]:
         groups = sorted(self.clusters[cluster_id].ec2_instances, key=lambda x: x.id)
         if instance_group_id:
@@ -994,8 +993,8 @@ class ElasticMapReduceBackend(BaseBackend):
     def list_steps(
         self,
         cluster_id: str,
-        step_ids: Optional[list[str]] = None,
-        step_states: Optional[list[str]] = None,
+        step_ids: list[str] | None = None,
+        step_states: list[str] | None = None,
     ) -> list[Step]:
         steps = sorted(
             self.clusters[cluster_id].steps,
@@ -1091,8 +1090,8 @@ class ElasticMapReduceBackend(BaseBackend):
         return clusters_terminated
 
     def put_auto_scaling_policy(
-        self, instance_group_id: str, auto_scaling_policy: Optional[dict[str, Any]]
-    ) -> Optional[InstanceGroup]:
+        self, instance_group_id: str, auto_scaling_policy: dict[str, Any] | None
+    ) -> InstanceGroup | None:
         instance_groups = self.get_instance_groups(
             instance_group_ids=[instance_group_id]
         )
@@ -1140,7 +1139,7 @@ class ElasticMapReduceBackend(BaseBackend):
     def put_block_public_access_configuration(
         self,
         block_public_security_group_rules: bool,
-        rule_ranges: Optional[list[dict[str, int]]],
+        rule_ranges: list[dict[str, int]] | None,
     ) -> None:
         from moto.sts import sts_backends
 

--- a/moto/emrcontainers/models.py
+++ b/moto/emrcontainers/models.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -31,8 +31,8 @@ class VirtualCluster(BaseModel):
         account_id: str,
         region_name: str,
         aws_partition: str,
-        tags: Optional[dict[str, str]] = None,
-        virtual_cluster_id: Optional[str] = None,
+        tags: dict[str, str] | None = None,
+        virtual_cluster_id: str | None = None,
     ):
         self.id = virtual_cluster_id or random_cluster_id()
 
@@ -65,7 +65,7 @@ class JobRun(BaseModel):
         account_id: str,
         region_name: str,
         aws_partition: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ):
         self.id = random_job_id()
         self.name = name
@@ -85,8 +85,8 @@ class JobRun(BaseModel):
         self.configuration_overrides = configuration_overrides
         self.created_at = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
         self.created_by = None
-        self.finished_at: Optional[datetime] = None
-        self.state_details: Optional[str] = None
+        self.finished_at: datetime | None = None
+        self.state_details: str | None = None
         self.failure_reason = None
         self.tags = tags
 
@@ -107,7 +107,7 @@ class EMRContainersBackend(BaseBackend):
         name: str,
         container_provider: dict[str, Any],
         client_token: str,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> VirtualCluster:
         occupied_namespaces = [
             virtual_cluster.namespace
@@ -152,7 +152,7 @@ class EMRContainersBackend(BaseBackend):
         container_provider_type: str,
         created_after: datetime,
         created_before: datetime,
-        states: Optional[list[str]],
+        states: list[str] | None,
     ) -> list[VirtualCluster]:
         virtual_clusters = list(self.virtual_clusters.values())
 
@@ -266,7 +266,7 @@ class EMRContainersBackend(BaseBackend):
         created_before: datetime,
         created_after: datetime,
         name: str,
-        states: Optional[list[str]],
+        states: list[str] | None,
     ) -> list[JobRun]:
         jobs = list(self.job_runs.values())
 

--- a/moto/emrserverless/models.py
+++ b/moto/emrserverless/models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -45,7 +45,7 @@ class Application(BaseModel):
         tags: dict[str, str],
         auto_start_configuration: str,
         auto_stop_configuration: str,
-        network_configuration: Optional[dict[str, Any]],
+        network_configuration: dict[str, Any] | None,
     ):
         # Provided parameters
         self.name = name
@@ -87,12 +87,12 @@ class JobRun(BaseModel):
         region_name: str,
         release_label: str,
         application_type: str,
-        job_driver: Optional[dict[str, dict[str, Union[str, list[str]]]]],
-        configuration_overrides: Optional[dict[str, Union[list[Any], dict[str, Any]]]],
-        tags: Optional[dict[str, str]],
-        network_configuration: Optional[dict[str, list[str]]],
-        execution_timeout_minutes: Optional[int],
-        name: Optional[str],
+        job_driver: dict[str, dict[str, str | list[str]]] | None,
+        configuration_overrides: dict[str, list[Any] | dict[str, Any]] | None,
+        tags: dict[str, str] | None,
+        network_configuration: dict[str, list[str]] | None,
+        execution_timeout_minutes: int | None,
+        name: str | None,
     ):
         self.name = name
         self.application_id = application_id
@@ -118,9 +118,9 @@ class JobRun(BaseModel):
         self.application_type = application_type
 
         self.state = JOB_STATUS
-        self.state_details: Optional[str] = None
+        self.state_details: str | None = None
 
-        self.created_by: Optional[str] = None
+        self.created_by: str | None = None
 
         self.created_at = utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
         self.updated_at = self.created_at
@@ -158,7 +158,7 @@ class EMRServerlessBackend(BaseBackend):
         tags: dict[str, str],
         auto_start_configuration: str,
         auto_stop_configuration: str,
-        network_configuration: Optional[dict[str, Any]],
+        network_configuration: dict[str, Any] | None,
     ) -> Application:
         if application_type not in ["HIVE", "SPARK"]:
             raise ValidationException(f"Unsupported engine {application_type}")
@@ -202,7 +202,7 @@ class EMRServerlessBackend(BaseBackend):
 
         return self.applications[application_id]
 
-    def list_applications(self, states: Optional[list[str]]) -> list[Application]:
+    def list_applications(self, states: list[str] | None) -> list[Application]:
         applications = list(self.applications.values())
         if states:
             applications = [
@@ -225,11 +225,11 @@ class EMRServerlessBackend(BaseBackend):
     def update_application(
         self,
         application_id: str,
-        initial_capacity: Optional[str],
-        maximum_capacity: Optional[str],
-        auto_start_configuration: Optional[str],
-        auto_stop_configuration: Optional[str],
-        network_configuration: Optional[dict[str, Any]],
+        initial_capacity: str | None,
+        maximum_capacity: str | None,
+        auto_start_configuration: str | None,
+        auto_stop_configuration: str | None,
+        network_configuration: dict[str, Any] | None,
     ) -> Application:
         if application_id not in self.applications.keys():
             raise ResourceNotFoundException(application_id)
@@ -272,11 +272,11 @@ class EMRServerlessBackend(BaseBackend):
         application_id: str,
         client_token: str,
         execution_role_arn: str,
-        job_driver: Optional[dict[str, dict[str, Union[str, list[str]]]]],
-        configuration_overrides: Optional[dict[str, Union[list[Any], dict[str, Any]]]],
-        tags: Optional[dict[str, str]],
-        execution_timeout_minutes: Optional[int],
-        name: Optional[str],
+        job_driver: dict[str, dict[str, str | list[str]]] | None,
+        configuration_overrides: dict[str, list[Any] | dict[str, Any]] | None,
+        tags: dict[str, str] | None,
+        execution_timeout_minutes: int | None,
+        name: str | None,
     ) -> JobRun:
         role_account_id = execution_role_arn.split(":")[4]
         if role_account_id != self.account_id:
@@ -345,9 +345,9 @@ class EMRServerlessBackend(BaseBackend):
     def list_job_runs(
         self,
         application_id: str,
-        created_at_after: Optional[datetime],
-        created_at_before: Optional[datetime],
-        states: Optional[list[str]],
+        created_at_after: datetime | None,
+        created_at_before: datetime | None,
+        states: list[str] | None,
     ) -> list[JobRun]:
         if application_id not in self.job_runs.keys():
             raise ResourceNotFoundException(application_id, "Application")

--- a/moto/events/exceptions.py
+++ b/moto/events/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -13,7 +11,7 @@ class IllegalStatusException(JsonRESTError):
 class InvalidEventPatternException(JsonRESTError):
     code = 400
 
-    def __init__(self, reason: Optional[str] = None):
+    def __init__(self, reason: str | None = None):
         msg = "Event pattern is not valid. "
         if reason:
             msg += f"Reason: {reason}"

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import ipaddress
 import json
@@ -8,7 +10,7 @@ from collections import OrderedDict
 from enum import Enum, unique
 from json import JSONDecodeError
 from operator import eq, ge, gt, le, lt
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import requests
 
@@ -53,9 +55,7 @@ if TYPE_CHECKING:
 UNDEFINED = object()
 
 
-def get_secrets_manager_backend(
-    account_id: str, region: str
-) -> "SecretsManagerBackend":
+def get_secrets_manager_backend(account_id: str, region: str) -> SecretsManagerBackend:
     from moto.secretsmanager import secretsmanager_backends
 
     return secretsmanager_backends[account_id][region]
@@ -67,14 +67,14 @@ class Rule(CloudFormationModel):
         name: str,
         account_id: str,
         region_name: str,
-        description: Optional[str],
-        event_pattern: Optional[str],
-        schedule_exp: Optional[str],
-        role_arn: Optional[str],
+        description: str | None,
+        event_pattern: str | None,
+        schedule_exp: str | None,
+        role_arn: str | None,
         event_bus_name: str,
-        state: Optional[str],
-        managed_by: Optional[str] = None,
-        targets: Optional[list[dict[str, Any]]] = None,
+        state: str | None,
+        managed_by: str | None = None,
+        targets: list[dict[str, Any]] | None = None,
     ):
         self.name = name
         self.account_id = account_id
@@ -103,7 +103,7 @@ class Rule(CloudFormationModel):
 
     # This song and dance for targets is because we need order for Limits and NextTokens, but can't use OrderedDicts
     # with Python 2.6, so tracking it with an array it is.
-    def _check_target_exists(self, target_id: str) -> Optional[int]:
+    def _check_target_exists(self, target_id: str) -> int | None:
         for i in range(0, len(self.targets)):
             if target_id == self.targets[i]["Id"]:
                 return i
@@ -224,13 +224,13 @@ class Rule(CloudFormationModel):
         if archive.uuid == archive_uuid:  # type: ignore[union-attr]
             archive.events.append(event)  # type: ignore[union-attr]
 
-    def _find_api_destination(self, resource_id: str) -> "Destination":
+    def _find_api_destination(self, resource_id: str) -> Destination:
         backend: EventsBackend = events_backends[self.account_id][self.region_name]
         destination_name = resource_id.split("/")[0]
         return backend.destinations[destination_name]
 
     def _send_to_sqs_queue(
-        self, resource_id: str, event: dict[str, Any], group_id: Optional[str] = None
+        self, resource_id: str, event: dict[str, Any], group_id: str | None = None
     ) -> None:
         from moto.sqs import sqs_backends
 
@@ -287,7 +287,7 @@ class Rule(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "Rule":
+    ) -> Rule:
         properties = cloudformation_json["Properties"]
         properties.setdefault("EventBusName", "default")
 
@@ -334,7 +334,7 @@ class Rule(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "Rule":
+    ) -> Rule:
         original_resource.delete(account_id, region_name)
         return cls.create_from_cloudformation_json(
             new_resource_name, cloudformation_json, account_id, region_name
@@ -379,10 +379,10 @@ class EventBus(CloudFormationModel):
         account_id: str,
         region_name: str,
         name: str,
-        description: Optional[str] = None,
-        kms_key_identifier: Optional[str] = None,
-        dead_letter_config: Optional[dict[str, str]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        description: str | None = None,
+        kms_key_identifier: str | None = None,
+        dead_letter_config: dict[str, str] | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.account_id = account_id
         self.region = region_name
@@ -401,7 +401,7 @@ class EventBus(CloudFormationModel):
         self.rules: dict[str, Rule] = OrderedDict()
 
     @property
-    def policy(self) -> Optional[str]:
+    def policy(self) -> str | None:
         if self._statements:
             policy = {
                 "Version": "2012-10-17",
@@ -452,7 +452,7 @@ class EventBus(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "EventBus":
+    ) -> EventBus:
         properties = cloudformation_json["Properties"]
         event_backend = events_backends[account_id][region_name]
         event_name = resource_name
@@ -469,7 +469,7 @@ class EventBus(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "EventBus":
+    ) -> EventBus:
         original_resource.delete(account_id, region_name)
         return cls.create_from_cloudformation_json(
             new_resource_name, cloudformation_json, account_id, region_name
@@ -505,7 +505,7 @@ class EventBus(CloudFormationModel):
         statement_id: str,
         action: str,
         principal: dict[str, str],
-        condition: Optional[dict[str, Any]],
+        condition: dict[str, Any] | None,
     ) -> None:
         self._remove_principals_statements(principal)
         statement = EventBusPolicyStatement(
@@ -527,7 +527,7 @@ class EventBus(CloudFormationModel):
             sid = new_statement["Sid"]
             self._statements[sid] = EventBusPolicyStatement.from_dict(new_statement)
 
-    def remove_statement(self, sid: str) -> Optional["EventBusPolicyStatement"]:
+    def remove_statement(self, sid: str) -> EventBusPolicyStatement | None:
         return self._statements.pop(sid, None)
 
     def remove_statements(self) -> None:
@@ -542,7 +542,7 @@ class EventBusPolicyStatement:
         action: str,
         resource: str,
         effect: str = "Allow",
-        condition: Optional[dict[str, Any]] = None,
+        condition: dict[str, Any] | None = None,
     ):
         self.sid = sid
         self.principal = principal
@@ -565,7 +565,7 @@ class EventBusPolicyStatement:
         return statement
 
     @classmethod
-    def from_dict(cls, statement_dict: dict[str, Any]) -> "EventBusPolicyStatement":  # type: ignore[misc]
+    def from_dict(cls, statement_dict: dict[str, Any]) -> EventBusPolicyStatement:  # type: ignore[misc]
         params = {
             "sid": statement_dict["Sid"],
             "effect": statement_dict["Effect"],
@@ -615,7 +615,7 @@ class Archive(CloudFormationModel):
 
         self.events: list[EventMessageType] = []
         self.event_bus_name = source_arn.split("/")[-1]
-        self.rule: Optional[Rule] = None
+        self.rule: Rule | None = None
 
     def describe_short(self) -> dict[str, Any]:
         return {
@@ -640,9 +640,9 @@ class Archive(CloudFormationModel):
 
     def update(
         self,
-        description: Optional[str],
-        event_pattern: Optional[str],
-        retention: Optional[str],
+        description: str | None,
+        event_pattern: str | None,
+        retention: str | None,
     ) -> None:
         if description:
             self.description = description
@@ -690,7 +690,7 @@ class Archive(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "Archive":
+    ) -> Archive:
         properties = cloudformation_json["Properties"]
         event_backend = events_backends[account_id][region_name]
 
@@ -711,7 +711,7 @@ class Archive(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "Archive":
+    ) -> Archive:
         if new_resource_name == original_resource.name:
             properties = cloudformation_json["Properties"]
 
@@ -764,7 +764,7 @@ class Replay(BaseModel):
         self.arn = f"arn:{get_partition(region_name)}:events:{region_name}:{account_id}:replay/{name}"
         self.state = ReplayState.STARTING
         self.start_time = unix_time()
-        self.end_time: Optional[float] = None
+        self.end_time: float | None = None
 
     def describe_short(self) -> dict[str, Any]:
         return {
@@ -946,7 +946,7 @@ class Destination(BaseModel):
 
 
 class EventPattern:
-    def __init__(self, raw_pattern: Optional[str], pattern: dict[str, Any]):
+    def __init__(self, raw_pattern: str | None, pattern: dict[str, Any]):
         self._raw_pattern = raw_pattern
         self._pattern = pattern
 
@@ -962,7 +962,7 @@ class EventPattern:
 
     @staticmethod
     def _flatten_dict(
-        node: Any, prefix: str = "", result: Optional[dict[str, Any]] = None
+        node: Any, prefix: str = "", result: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         if result is None:
             result = {}
@@ -1124,17 +1124,17 @@ class EventPattern:
         return re.fullmatch(regex, item) is not None
 
     @classmethod
-    def load(cls, raw_pattern: Optional[str]) -> "EventPattern":
+    def load(cls, raw_pattern: str | None) -> EventPattern:
         parser = EventPatternParser(raw_pattern)
         pattern = parser.parse()
         return cls(raw_pattern, pattern)
 
-    def dump(self) -> Optional[str]:
+    def dump(self) -> str | None:
         return self._raw_pattern
 
 
 class EventPatternParser:
-    def __init__(self, pattern: Optional[str]):
+    def __init__(self, pattern: str | None):
         self.pattern = pattern
 
     def _validate_event_pattern(self, pattern: dict[str, Any]) -> None:
@@ -1241,14 +1241,14 @@ class EventsBackend(BaseBackend):
     def put_rule(
         self,
         name: str,
-        description: Optional[str] = None,
-        event_bus_arn: Optional[str] = None,
-        event_pattern: Optional[str] = None,
-        role_arn: Optional[str] = None,
-        scheduled_expression: Optional[str] = None,
-        state: Optional[str] = None,
-        managed_by: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        description: str | None = None,
+        event_bus_arn: str | None = None,
+        event_pattern: str | None = None,
+        role_arn: str | None = None,
+        scheduled_expression: str | None = None,
+        state: str | None = None,
+        managed_by: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> Rule:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
 
@@ -1293,12 +1293,12 @@ class EventsBackend(BaseBackend):
 
         return rule
 
-    def _normalize_event_bus_arn(self, event_bus_arn: Optional[str]) -> str:
+    def _normalize_event_bus_arn(self, event_bus_arn: str | None) -> str:
         if event_bus_arn is None:
             return "default"
         return event_bus_arn.split("/")[-1]
 
-    def delete_rule(self, name: str, event_bus_arn: Optional[str]) -> None:
+    def delete_rule(self, name: str, event_bus_arn: str | None) -> None:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         try:
             event_bus = self._get_event_bus(event_bus_name)
@@ -1316,7 +1316,7 @@ class EventsBackend(BaseBackend):
             self.tagger.delete_all_tags_for_resource(arn)
         event_bus.rules.pop(name)
 
-    def describe_rule(self, name: str, event_bus_arn: Optional[str]) -> Rule:
+    def describe_rule(self, name: str, event_bus_arn: str | None) -> Rule:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
         rule = event_bus.rules.get(name)
@@ -1324,7 +1324,7 @@ class EventsBackend(BaseBackend):
             raise ResourceNotFoundException(f"Rule {name} does not exist.")
         return rule
 
-    def disable_rule(self, name: str, event_bus_arn: Optional[str]) -> bool:
+    def disable_rule(self, name: str, event_bus_arn: str | None) -> bool:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
         if name in event_bus.rules:
@@ -1333,7 +1333,7 @@ class EventsBackend(BaseBackend):
 
         return False
 
-    def enable_rule(self, name: str, event_bus_arn: Optional[str]) -> bool:
+    def enable_rule(self, name: str, event_bus_arn: str | None) -> bool:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
         if name in event_bus.rules:
@@ -1344,7 +1344,7 @@ class EventsBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_rule_names_by_target(
-        self, target_arn: str, event_bus_arn: Optional[str]
+        self, target_arn: str, event_bus_arn: str | None
     ) -> list[Rule]:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
@@ -1358,7 +1358,7 @@ class EventsBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_rules(
-        self, prefix: Optional[str] = None, event_bus_arn: Optional[str] = None
+        self, prefix: str | None = None, event_bus_arn: str | None = None
     ) -> list[Rule]:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
@@ -1378,7 +1378,7 @@ class EventsBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_targets_by_rule(  # type: ignore[misc]
-        self, rule_id: str, event_bus_arn: Optional[str]
+        self, rule_id: str, event_bus_arn: str | None
     ) -> list[dict[str, Any]]:
         # We'll let a KeyError exception be thrown for response to handle if
         # rule doesn't exist.
@@ -1388,7 +1388,7 @@ class EventsBackend(BaseBackend):
         return rule.targets
 
     def put_targets(
-        self, name: str, event_bus_arn: Optional[str], targets: list[dict[str, Any]]
+        self, name: str, event_bus_arn: str | None, targets: list[dict[str, Any]]
     ) -> None:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
@@ -1512,7 +1512,7 @@ class EventsBackend(BaseBackend):
         return entries
 
     def remove_targets(
-        self, name: str, event_bus_arn: Optional[str], ids: list[str]
+        self, name: str, event_bus_arn: str | None, ids: list[str]
     ) -> None:
         event_bus_name = self._normalize_event_bus_arn(event_bus_arn)
         event_bus = self._get_event_bus(event_bus_name)
@@ -1540,8 +1540,8 @@ class EventsBackend(BaseBackend):
 
     @staticmethod
     def _condition_param_to_stmt_condition(  # type: ignore[misc]
-        condition: Optional[dict[str, Any]],
-    ) -> Optional[dict[str, Any]]:
+        condition: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
         if condition:
             key = condition["Key"]
             value = condition["Value"]
@@ -1552,7 +1552,7 @@ class EventsBackend(BaseBackend):
     def _put_permission_from_params(
         self,
         event_bus: EventBus,
-        action: Optional[str],
+        action: str | None,
         principal: str,
         statement_id: str,
         condition: dict[str, str],
@@ -1615,7 +1615,7 @@ class EventsBackend(BaseBackend):
 
     def remove_permission(
         self,
-        event_bus_name: Optional[str],
+        event_bus_name: str | None,
         statement_id: str,
         remove_all_permissions: bool,
     ) -> None:
@@ -1650,11 +1650,11 @@ class EventsBackend(BaseBackend):
     def create_event_bus(
         self,
         name: str,
-        event_source_name: Optional[str] = None,
-        description: Optional[str] = None,
-        kms_key_identifier: Optional[str] = None,
-        dead_letter_config: Optional[dict[str, str]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        event_source_name: str | None = None,
+        description: str | None = None,
+        kms_key_identifier: str | None = None,
+        dead_letter_config: dict[str, str] | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> EventBus:
         if name in self.event_buses:
             raise JsonRESTError(
@@ -1687,7 +1687,7 @@ class EventsBackend(BaseBackend):
 
         return self.event_buses[name]
 
-    def list_event_buses(self, name_prefix: Optional[str]) -> list[EventBus]:
+    def list_event_buses(self, name_prefix: str | None) -> list[EventBus]:
         if name_prefix:
             return [
                 event_bus
@@ -1809,9 +1809,9 @@ class EventsBackend(BaseBackend):
 
     def list_archives(
         self,
-        name_prefix: Optional[str],
-        source_arn: Optional[str],
-        state: Optional[str],
+        name_prefix: str | None,
+        source_arn: str | None,
+        state: str | None,
     ) -> list[dict[str, Any]]:
         if [name_prefix, source_arn, state].count(None) < 2:
             raise ValidationException(

--- a/moto/events/utils.py
+++ b/moto/events/utils.py
@@ -2,8 +2,6 @@ import json
 from typing import TYPE_CHECKING, Any, TypedDict
 
 if TYPE_CHECKING:
-    from typing import Union
-
     from typing_extensions import Any, Required
 
 
@@ -13,11 +11,11 @@ EventMessageType = TypedDict(
     {
         "version": str,
         "id": str,
-        "detail-type": "Required[Union[str, list[str]]]",
-        "source": "Required[Union[str, list[str]]]",
+        "detail-type": "Required[str | list[str]]",
+        "source": "Required[str | list[str]]",
         "account": str,
         # support float type for internal use of moto.
-        "time": "Union[str, float]",
+        "time": "str | float",
         "replay-name": str,
         "region": str,
         "resources": list[str],

--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -17,7 +17,7 @@ import json
 import warnings
 from gzip import GzipFile
 from time import time
-from typing import Any, Optional
+from typing import Any
 
 import requests
 
@@ -337,7 +337,7 @@ class FirehoseBackend(BaseBackend):
 
     def list_delivery_streams(
         self,
-        limit: Optional[int],
+        limit: int | None,
         delivery_stream_type: str,
         exclusive_start_delivery_stream_name: str,
     ) -> dict[str, Any]:
@@ -379,7 +379,7 @@ class FirehoseBackend(BaseBackend):
         self,
         delivery_stream_name: str,
         exclusive_start_tag_key: str,
-        limit: Optional[int],
+        limit: int | None,
     ) -> dict[str, Any]:
         """Return list of tags."""
         result = {"Tags": [], "HasMoreTags": False}
@@ -694,7 +694,7 @@ class FirehoseBackend(BaseBackend):
         # S3 backup if it is disabled.  If backup is enabled, you can't update
         # the delivery stream to disable it."
 
-    def lookup_name_from_arn(self, arn: str) -> Optional[DeliveryStream]:
+    def lookup_name_from_arn(self, arn: str) -> DeliveryStream | None:
         """Given an ARN, return the associated delivery stream name."""
         return self.delivery_streams.get(arn.split("/")[-1])
 

--- a/moto/forecast/models.py
+++ b/moto/forecast/models.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime
-from typing import Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import iso_8601_datetime_without_milliseconds
@@ -34,7 +33,7 @@ class DatasetGroup:
         dataset_arns: list[str],
         dataset_group_name: str,
         domain: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.creation_date = iso_8601_datetime_without_milliseconds(datetime.now())
         self.modified_date = self.creation_date

--- a/moto/fsx/models.py
+++ b/moto/fsx/models.py
@@ -1,7 +1,7 @@
 """FSxBackend class with methods for supported APIs."""
 
 import time
-from typing import Any, Optional
+from typing import Any
 from uuid import uuid4
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -39,12 +39,12 @@ class FileSystem(BaseModel):
         storage_type: str,
         subnet_ids: list[str],
         security_group_ids: list[str],
-        tags: Optional[list[dict[str, str]]],
-        kms_key_id: Optional[str],
-        windows_configuration: Optional[dict[str, Any]],
-        lustre_configuration: Optional[dict[str, Any]],
-        ontap_configuration: Optional[dict[str, Any]],
-        open_zfs_configuration: Optional[dict[str, Any]],
+        tags: list[dict[str, str]] | None,
+        kms_key_id: str | None,
+        windows_configuration: dict[str, Any] | None,
+        lustre_configuration: dict[str, Any] | None,
+        ontap_configuration: dict[str, Any] | None,
+        open_zfs_configuration: dict[str, Any] | None,
         backend: "FSxBackend",
     ) -> None:
         self.file_system_id = f"fs-{uuid4().hex[:8]}"
@@ -94,9 +94,9 @@ class Backup(BaseModel):
         account_id: str,
         region_name: str,
         file_system_id: str,
-        client_request_token: Optional[str],
-        volume_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        client_request_token: str | None,
+        volume_id: str | None,
+        tags: list[dict[str, str]] | None,
         backend: "FSxBackend",
     ) -> None:
         self.backup_id = f"backup-{uuid4().hex[:8]}"
@@ -143,13 +143,13 @@ class FSxBackend(BaseBackend):
         storage_type: str,
         subnet_ids: list[str],
         security_group_ids: list[str],
-        tags: Optional[list[dict[str, str]]],
-        kms_key_id: Optional[str],
-        windows_configuration: Optional[dict[str, Any]],
-        lustre_configuration: Optional[dict[str, Any]],
-        ontap_configuration: Optional[dict[str, Any]],
-        file_system_type_version: Optional[str],
-        open_zfs_configuration: Optional[dict[str, Any]],
+        tags: list[dict[str, str]] | None,
+        kms_key_id: str | None,
+        windows_configuration: dict[str, Any] | None,
+        lustre_configuration: dict[str, Any] | None,
+        ontap_configuration: dict[str, Any] | None,
+        file_system_type_version: str | None,
+        open_zfs_configuration: dict[str, Any] | None,
     ) -> FileSystem:
         file_system = FileSystem(
             account_id=self.account_id,
@@ -190,15 +190,15 @@ class FSxBackend(BaseBackend):
         self,
         file_system_id: str,
         client_request_token: str,
-        windows_configuration: Optional[dict[str, Any]],
-        lustre_configuration: Optional[dict[str, Any]],
-        open_zfs_configuration: Optional[dict[str, Any]],
+        windows_configuration: dict[str, Any] | None,
+        lustre_configuration: dict[str, Any] | None,
+        open_zfs_configuration: dict[str, Any] | None,
     ) -> tuple[
         str,
         str,
-        Optional[dict[str, Any]],
-        Optional[dict[str, Any]],
-        Optional[dict[str, Any]],
+        dict[str, Any] | None,
+        dict[str, Any] | None,
+        dict[str, Any] | None,
     ]:
         response_template = {"FinalBackUpId": "", "FinalBackUpTags": []}
 
@@ -229,9 +229,9 @@ class FSxBackend(BaseBackend):
     def create_backup(
         self,
         file_system_id: str,
-        client_request_token: Optional[str],
-        volume_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        client_request_token: str | None,
+        volume_id: str | None,
+        tags: list[dict[str, str]] | None,
     ) -> Backup:
         backup = Backup(
             account_id=self.account_id,
@@ -252,7 +252,7 @@ class FSxBackend(BaseBackend):
         return backup
 
     def delete_backup(
-        self, backup_id: str, client_request_token: Optional[str]
+        self, backup_id: str, client_request_token: str | None
     ) -> dict[str, Any]:
         if backup_id not in self.backups:
             raise ResourceNotFoundException(
@@ -266,7 +266,7 @@ class FSxBackend(BaseBackend):
     def describe_backups(
         self,
         backup_ids: list[str],
-        filters: Optional[list[dict[str, Any]]] = None,
+        filters: list[dict[str, Any]] | None = None,
     ) -> list[Backup]:
         backups = []
         if not backup_ids:

--- a/moto/glacier/models.py
+++ b/moto/glacier/models.py
@@ -1,6 +1,6 @@
 import datetime
 import hashlib
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -27,7 +27,7 @@ class Job(BaseModel):
 
 
 class ArchiveJob(Job):
-    def __init__(self, job_id: str, tier: str, arn: str, archive_id: Optional[str]):
+    def __init__(self, job_id: str, tier: str, arn: str, archive_id: str | None):
         self.job_id = job_id
         self.tier = tier
         self.arn = arn
@@ -149,7 +149,7 @@ class Vault(BaseModel):
     def delete_archive(self, archive_id: str) -> dict[str, Any]:
         return self.archives.pop(archive_id)
 
-    def initiate_job(self, job_type: str, tier: str, archive_id: Optional[str]) -> str:
+    def initiate_job(self, job_type: str, tier: str, archive_id: str | None) -> str:
         job_id = get_job_id()
 
         if job_type == "inventory-retrieval":
@@ -162,7 +162,7 @@ class Vault(BaseModel):
     def list_jobs(self) -> list[Job]:
         return list(self.jobs.values())
 
-    def describe_job(self, job_id: str) -> Optional[Job]:
+    def describe_job(self, job_id: str) -> Job | None:
         return self.jobs.get(job_id)
 
     def job_ready(self, job_id: str) -> str:
@@ -170,7 +170,7 @@ class Vault(BaseModel):
         jobj = job.to_dict()  # type: ignore
         return jobj["Completed"]
 
-    def get_job_output(self, job_id: str) -> Union[str, dict[str, Any]]:
+    def get_job_output(self, job_id: str) -> str | dict[str, Any]:
         job = self.describe_job(job_id)
         jobj = job.to_dict()  # type: ignore
         if jobj["Action"] == "InventoryRetrieval":
@@ -205,13 +205,13 @@ class GlacierBackend(BaseBackend):
         self.vaults.pop(vault_name)
 
     def initiate_job(
-        self, vault_name: str, job_type: str, tier: str, archive_id: Optional[str]
+        self, vault_name: str, job_type: str, tier: str, archive_id: str | None
     ) -> str:
         vault = self.describe_vault(vault_name)
         job_id = vault.initiate_job(job_type, tier, archive_id)
         return job_id
 
-    def describe_job(self, vault_name: str, archive_id: str) -> Optional[Job]:
+    def describe_job(self, vault_name: str, archive_id: str) -> Job | None:
         vault = self.describe_vault(vault_name)
         return vault.describe_job(archive_id)
 
@@ -221,7 +221,7 @@ class GlacierBackend(BaseBackend):
 
     def get_job_output(
         self, vault_name: str, job_id: str
-    ) -> Union[str, dict[str, Any], None]:
+    ) -> str | dict[str, Any] | None:
         vault = self.describe_vault(vault_name)
         if vault.job_ready(job_id):
             return vault.get_job_output(job_id)

--- a/moto/glue/exceptions.py
+++ b/moto/glue/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -82,7 +80,7 @@ class SchemaNotFoundException(EntityNotFoundException):
         self,
         schema_name: str,
         registry_name: str,
-        schema_arn: Optional[str],
+        schema_arn: str | None,
         null: str = "null",
     ):
         super().__init__(
@@ -93,11 +91,11 @@ class SchemaNotFoundException(EntityNotFoundException):
 class SchemaVersionNotFoundFromSchemaIdException(EntityNotFoundException):
     def __init__(
         self,
-        registry_name: Optional[str],
-        schema_name: Optional[str],
-        schema_arn: Optional[str],
-        version_number: Optional[str],
-        latest_version: Optional[str],
+        registry_name: str | None,
+        schema_name: str | None,
+        schema_arn: str | None,
+        version_number: str | None,
+        latest_version: str | None,
         null: str = "null",
         false: str = "false",
     ):
@@ -124,7 +122,7 @@ class IllegalSessionStateException(GlueClientError):
 
 
 class RegistryNotFoundException(EntityNotFoundException):
-    def __init__(self, resource: str, param_name: str, param_value: Optional[str]):
+    def __init__(self, resource: str, param_name: str, param_value: str | None):
         super().__init__(
             resource + " is not found. " + param_name + ": " + param_value,  # type: ignore
         )
@@ -301,7 +299,7 @@ class DisabledCompatibilityVersioningException(GSRInvalidInputException):
         self,
         schema_name: str,
         registry_name: str,
-        schema_arn: Optional[str],
+        schema_arn: str | None,
         null: str = "null",
     ):
         super().__init__(

--- a/moto/glue/glue_schema_registry_utils.py
+++ b/moto/glue/glue_schema_registry_utils.py
@@ -1,7 +1,7 @@
 import json
 import re
 from re import Pattern
-from typing import Any, Optional
+from typing import Any
 
 from .exceptions import (
     DisabledCompatibilityVersioningException,
@@ -181,8 +181,8 @@ def validate_registry_id(
 def validate_registry_params(
     registries: Any,
     registry_name: str,
-    description: Optional[str] = None,
-    tags: Optional[dict[str, str]] = None,
+    description: str | None = None,
+    tags: dict[str, str] | None = None,
 ) -> None:
     validate_registry_name_pattern_and_length(registry_name)
 
@@ -205,7 +205,7 @@ def validate_registry_params(
 
 def validate_schema_id(
     schema_id: dict[str, str], registries: dict[str, Any]
-) -> tuple[str, str, Optional[str]]:
+) -> tuple[str, str, str | None]:
     schema_arn = schema_id.get(SCHEMA_ARN)
     registry_name = schema_id.get(REGISTRY_NAME)
     schema_name = schema_id.get(SCHEMA_NAME)
@@ -239,8 +239,8 @@ def validate_schema_params(
     compatibility: str,
     schema_definition: str,
     num_schemas: int,
-    description: Optional[str] = None,
-    tags: Optional[dict[str, str]] = None,
+    description: str | None = None,
+    tags: dict[str, str] | None = None,
 ) -> None:
     validate_schema_name_pattern_and_length(schema_name)
 
@@ -281,7 +281,7 @@ def validate_schema_params(
 def validate_register_schema_version_params(
     registry_name: str,
     schema_name: str,
-    schema_arn: Optional[str],
+    schema_arn: str | None,
     num_schema_versions: int,
     schema_definition: str,
     compatibility: str,
@@ -300,16 +300,16 @@ def validate_register_schema_version_params(
 
 def validate_schema_version_params(  # type: ignore[return]
     registries: dict[str, Any],
-    schema_id: Optional[dict[str, Any]],
-    schema_version_id: Optional[str],
-    schema_version_number: Optional[dict[str, Any]],
+    schema_id: dict[str, Any] | None,
+    schema_version_id: str | None,
+    schema_version_number: dict[str, Any] | None,
 ) -> tuple[
-    Optional[str],
-    Optional[str],
-    Optional[str],
-    Optional[str],
-    Optional[str],
-    Optional[str],
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
 ]:
     if not schema_version_id and not schema_id and not schema_version_number:
         raise InvalidSchemaIdNotProvidedException()
@@ -388,7 +388,7 @@ def validate_number_of_schema_version_metadata_allowed(
 
 def get_schema_version_if_definition_exists(
     schema_versions: Any, data_format: str, schema_definition: str
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     if data_format in ["AVRO", "JSON"]:
         for schema_version in schema_versions:
             if json.loads(schema_definition) == json.loads(
@@ -404,7 +404,7 @@ def get_schema_version_if_definition_exists(
 
 def get_put_schema_version_metadata_response(
     schema_id: dict[str, Any],
-    schema_version_number: Optional[dict[str, str]],
+    schema_version_number: dict[str, str] | None,
     schema_version_id: str,
     metadata_key_value: dict[str, str],
 ) -> dict[str, Any]:

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -2,7 +2,7 @@ import hashlib
 import re
 from collections import OrderedDict
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -74,11 +74,11 @@ class FakeDevEndpoint(BaseModel):
         glue_version: str = "1.0",
         number_of_workers: int = 5,
         number_of_nodes: int = 5,
-        extra_python_libs_s3_path: Optional[str] = None,
-        extra_jars_s3_path: Optional[str] = None,
-        security_configuration: Optional[str] = None,
-        arguments: Optional[dict[str, str]] = None,
-        tags: Optional[dict[str, str]] = None,
+        extra_python_libs_s3_path: str | None = None,
+        extra_jars_s3_path: str | None = None,
+        security_configuration: str | None = None,
+        arguments: dict[str, str] | None = None,
+        tags: dict[str, str] | None = None,
     ):
         pubkey = """ssh-rsa
         AAAAB3NzaC1yc2EAAAADAQABAAABAQDV5+voluw2zmzqpqCAqtsyoP01TQ8Ydx1eS1yD6wUsHcPqMIqpo57YxiC8XPwrdeKQ6GG6MC3bHsgXoPypGP0LyixbiuLTU31DnnqorcHt4bWs6rQa7dK2pCCflz2fhYRt5ZjqSNsAKivIbqkH66JozN0SySIka3kEV79GdB0BicioKeEJlCwM9vvxafyzjWf/z8E0lh4ni3vkLpIVJ0t5l+Qd9QMJrT6Is0SCQPVagTYZoi8+fWDoGsBa8vyRwDjEzBl28ZplKh9tSyDkRIYszWTpmK8qHiqjLYZBfAxXjGJbEYL1iig4ZxvbYzKEiKSBi1ZMW9iWjHfZDZuxXAmB
@@ -255,7 +255,7 @@ class GlueBackend(BaseBackend):
         self,
         database_name: str,
         database_input: dict[str, Any],
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> "FakeDatabase":
         if database_name in self.databases:
             raise DatabaseAlreadyExistsException()
@@ -295,7 +295,7 @@ class GlueBackend(BaseBackend):
         database_name: str,
         table_name: str,
         table_input: dict[str, Any],
-        open_table_format_input: Optional[dict[str, Any]] = None,
+        open_table_format_input: dict[str, Any] | None = None,
     ) -> "FakeTable":
         database = self.get_database(database_name)
 
@@ -320,7 +320,7 @@ class GlueBackend(BaseBackend):
             raise TableNotFoundException(table_name)
 
     def get_tables(
-        self, database_name: str, expression: Optional[str]
+        self, database_name: str, expression: str | None
     ) -> list["FakeTable"]:
         database = self.get_database(database_name)
         if expression:
@@ -497,52 +497,52 @@ class GlueBackend(BaseBackend):
         for filter in filters:
             if filter.field_name == FilterField.CRAWL_ID:
 
-                def get_field(crawl: FakeCrawl) -> Optional[str]:
+                def get_field(crawl: FakeCrawl) -> str | None:
                     return crawl.crawl_id
 
             elif filter.field_name == FilterField.STATE:
 
-                def get_field(crawl: FakeCrawl) -> Optional[str]:
+                def get_field(crawl: FakeCrawl) -> str | None:
                     return crawl.status
 
             elif filter.field_name == FilterField.START_TIME:
 
-                def get_field(crawl: FakeCrawl) -> Optional[str]:
+                def get_field(crawl: FakeCrawl) -> str | None:
                     return crawl.start_time.isoformat()
 
             elif filter.field_name == FilterField.END_TIME:
 
-                def get_field(crawl: FakeCrawl) -> Optional[str]:
+                def get_field(crawl: FakeCrawl) -> str | None:
                     return crawl.end_time.isoformat() if crawl.end_time else None
 
             if filter.operator == FilterOperator.GT:
 
-                def compare(crawl_value: Optional[str], field_value: str) -> bool:
+                def compare(crawl_value: str | None, field_value: str) -> bool:
                     return crawl_value > field_value if crawl_value else False
 
             elif filter.operator == FilterOperator.GE:
 
-                def compare(crawl_value: Optional[str], field_value: str) -> bool:
+                def compare(crawl_value: str | None, field_value: str) -> bool:
                     return crawl_value >= field_value if crawl_value else False
 
             elif filter.operator == FilterOperator.LT:
 
-                def compare(crawl_value: Optional[str], field_value: str) -> bool:
+                def compare(crawl_value: str | None, field_value: str) -> bool:
                     return crawl_value < field_value if crawl_value else False
 
             elif filter.operator == FilterOperator.LE:
 
-                def compare(crawl_value: Optional[str], field_value: str) -> bool:
+                def compare(crawl_value: str | None, field_value: str) -> bool:
                     return crawl_value <= field_value if crawl_value else False
 
             elif filter.operator == FilterOperator.EQ:
 
-                def compare(crawl_value: Optional[str], field_value: str) -> bool:
+                def compare(crawl_value: str | None, field_value: str) -> bool:
                     return crawl_value == field_value
 
             elif filter.operator == FilterOperator.NE:
 
-                def compare(crawl_value: Optional[str], field_value: str) -> bool:
+                def compare(crawl_value: str | None, field_value: str) -> bool:
                     return crawl_value != field_value
 
             def filter_function(crawl: FakeCrawl) -> bool:
@@ -624,15 +624,15 @@ class GlueBackend(BaseBackend):
     def start_job_run(
         self,
         name: str,
-        arguments: Optional[dict[str, str]],
-        allocated_capacity: Optional[int],
-        max_capacity: Optional[float],
-        timeout: Optional[int],
-        worker_type: Optional[str],
-        security_configuration: Optional[str],
-        number_of_workers: Optional[int],
-        notification_property: Optional[dict[str, int]],
-        previous_run_id: Optional[str],
+        arguments: dict[str, str] | None,
+        allocated_capacity: int | None,
+        max_capacity: float | None,
+        timeout: int | None,
+        worker_type: str | None,
+        security_configuration: str | None,
+        number_of_workers: int | None,
+        notification_property: dict[str, int] | None,
+        previous_run_id: str | None,
     ) -> str:
         job = self.get_job(name)
         return job.start_job_run(
@@ -667,7 +667,7 @@ class GlueBackend(BaseBackend):
     def get_tags(self, resource_id: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_id)
 
-    def tag_resource(self, resource_arn: str, tags: Optional[dict[str, str]]) -> None:
+    def tag_resource(self, resource_arn: str, tags: dict[str, str] | None) -> None:
         tag_list = TaggingService.convert_dict_to_tags_input(tags or {})
         self.tagger.tag_resource(resource_arn, tag_list)
 
@@ -677,8 +677,8 @@ class GlueBackend(BaseBackend):
     def create_registry(
         self,
         registry_name: str,
-        description: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         # If registry name id default-registry, create default-registry
         if registry_name == DEFAULT_REGISTRY_NAME:
@@ -711,8 +711,8 @@ class GlueBackend(BaseBackend):
         data_format: str,
         compatibility: str,
         schema_definition: str,
-        description: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """
         The following parameters/features are not yet implemented: Glue Schema Registry: compatibility checks NONE | BACKWARD | BACKWARD_ALL | FORWARD | FORWARD_ALL | FULL | FULL_ALL and  Data format parsing and syntax validation.
@@ -833,9 +833,9 @@ class GlueBackend(BaseBackend):
 
     def get_schema_version(
         self,
-        schema_id: Optional[dict[str, str]] = None,
-        schema_version_id: Optional[str] = None,
-        schema_version_number: Optional[dict[str, Any]] = None,
+        schema_id: dict[str, str] | None = None,
+        schema_version_id: str | None = None,
+        schema_version_number: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         # Validate Schema Parameters
         (
@@ -1087,7 +1087,7 @@ class GlueBackend(BaseBackend):
         workflow_name: str,
         trigger_type: str,
         schedule: str,
-        predicate: Optional[Predicate],
+        predicate: Predicate | None,
         actions: list[Action],
         description: str,
         start_on_creation: bool,
@@ -1282,19 +1282,19 @@ class GlueBackend(BaseBackend):
         self,
         endpoint_name: str,
         role_arn: str,
-        security_group_ids: Optional[list[str]] = None,
-        subnet_id: Optional[str] = None,
-        public_key: Optional[str] = None,
-        public_keys: Optional[list[str]] = None,
-        number_of_nodes: Optional[int] = None,
+        security_group_ids: list[str] | None = None,
+        subnet_id: str | None = None,
+        public_key: str | None = None,
+        public_keys: list[str] | None = None,
+        number_of_nodes: int | None = None,
         worker_type: str = "Standard",
         glue_version: str = "5.0",
-        number_of_workers: Optional[int] = None,
-        extra_python_libs_s3_path: Optional[str] = None,
-        extra_jars_s3_path: Optional[str] = None,
-        security_configuration: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        arguments: Optional[dict[str, str]] = None,
+        number_of_workers: int | None = None,
+        extra_python_libs_s3_path: str | None = None,
+        extra_jars_s3_path: str | None = None,
+        security_configuration: str | None = None,
+        tags: dict[str, str] | None = None,
+        arguments: dict[str, str] | None = None,
     ) -> FakeDevEndpoint:
         if endpoint_name in self.dev_endpoints:
             raise AlreadyExistsException(f"DevEndpoint {endpoint_name} already exists")
@@ -1371,7 +1371,7 @@ class GlueBackend(BaseBackend):
 
     def put_data_catalog_encryption_settings(
         self,
-        catalog_id: Optional[str],
+        catalog_id: str | None,
         data_catalog_encryption_settings: dict[str, Any],
     ) -> dict[str, Any]:
         if catalog_id is None:
@@ -1383,7 +1383,7 @@ class GlueBackend(BaseBackend):
         return {}
 
     def get_data_catalog_encryption_settings(
-        self, catalog_id: Optional[str]
+        self, catalog_id: str | None
     ) -> dict[str, Any]:
         if catalog_id is None or catalog_id == "":
             catalog_id = self.account_id
@@ -1410,10 +1410,10 @@ class GlueBackend(BaseBackend):
     def put_resource_policy(
         self,
         policy_in_json: str,
-        resource_arn: Optional[str] = None,
-        policy_hash_condition: Optional[str] = None,
-        policy_exists_condition: Optional[str] = None,
-        enable_hybrid: Optional[str] = None,
+        resource_arn: str | None = None,
+        policy_hash_condition: str | None = None,
+        policy_exists_condition: str | None = None,
+        enable_hybrid: str | None = None,
     ) -> dict[str, str]:
         if resource_arn is None:
             resource_arn = self.default_catalog_arn
@@ -1464,7 +1464,7 @@ class GlueBackend(BaseBackend):
 
         return {"PolicyHash": policy_hash}
 
-    def get_resource_policy(self, resource_arn: Optional[str] = None) -> dict[str, Any]:
+    def get_resource_policy(self, resource_arn: str | None = None) -> dict[str, Any]:
         if resource_arn is None:
             resource_arn = self.default_catalog_arn
 
@@ -1484,8 +1484,8 @@ class GlueBackend(BaseBackend):
 
     def delete_resource_policy(
         self,
-        resource_arn: Optional[str] = None,
-        policy_hash_condition: Optional[str] = None,
+        resource_arn: str | None = None,
+        policy_hash_condition: str | None = None,
     ) -> dict[str, str]:
         if resource_arn is None:
             resource_arn = self.default_catalog_arn
@@ -1511,10 +1511,10 @@ class GlueBackend(BaseBackend):
     def create_workflow(
         self,
         name: str,
-        default_run_properties: Optional[dict[str, str]],
-        description: Optional[str],
-        max_concurrent_runs: Optional[int],
-        tags: Optional[dict[str, str]],
+        default_run_properties: dict[str, str] | None,
+        description: str | None,
+        max_concurrent_runs: int | None,
+        tags: dict[str, str] | None,
     ) -> str:
         self.workflows[name] = FakeWorkflow(
             name, default_run_properties, description, max_concurrent_runs, tags
@@ -1538,9 +1538,9 @@ class GlueBackend(BaseBackend):
     def update_workflow(
         self,
         name: str,
-        default_run_properties: Optional[dict[str, str]],
-        description: Optional[str],
-        max_concurrent_runs: Optional[int],
+        default_run_properties: dict[str, str] | None,
+        description: str | None,
+        max_concurrent_runs: int | None,
     ) -> str:
         workflow = self.workflows.get(name)
         if workflow:
@@ -1577,14 +1577,14 @@ class GlueBackend(BaseBackend):
     def get_workflow_runs(
         self,
         workflow_name: str,
-    ) -> list[dict[str, Union[str, datetime, dict[str, str]]]]:
+    ) -> list[dict[str, str | datetime | dict[str, str]]]:
         workflow = self.workflows.get(workflow_name)
         if not workflow:
             raise EntityNotFoundException("Entity not found")
         return [run.as_dict() for run in workflow.runs.values()]
 
     def start_workflow_run(
-        self, workflow_name: str, properties: Optional[dict[str, str]]
+        self, workflow_name: str, properties: dict[str, str] | None
     ) -> str:
         workflow = self.workflows.get(workflow_name)
         if not workflow:
@@ -1694,14 +1694,14 @@ class FakeTable(BaseModel):
         table_name: str,
         table_input: dict[str, Any],
         catalog_id: str,
-        open_table_format_input: Optional[dict[str, Any]] = None,
+        open_table_format_input: dict[str, Any] | None = None,
     ):
         self.database_name = database_name
         self.name = table_name
         self.catalog_id = catalog_id
         self.partitions: dict[str, FakePartition] = OrderedDict()
         self.created_time = utcnow()
-        self.updated_time: Optional[datetime] = None
+        self.updated_time: datetime | None = None
         self._current_version = 1
         if open_table_format_input and "IcebergInput" in open_table_format_input:
             table_input.setdefault("Parameters", {})
@@ -1729,7 +1729,7 @@ class FakeTable(BaseModel):
     def delete_version(self, version_id: str) -> None:
         self.versions.pop(version_id)
 
-    def as_dict(self, version: Optional[str] = None) -> dict[str, Any]:
+    def as_dict(self, version: str | None = None) -> dict[str, Any]:
         version = version or self._current_version  # type: ignore
         obj = {
             "DatabaseName": self.database_name,
@@ -1937,14 +1937,14 @@ class FakeCrawl(ManagedState):
         )
         self.crawl_id = str(mock_random.uuid4())
         self.dpu_hour = 100
-        self.end_time: Optional[datetime] = None
+        self.end_time: datetime | None = None
         self.log_group = "/aws-glue/crawlers"
         self.log_stream = crawler_name
         self.message_prefix = self.crawl_id
         self.start_time = utcnow()
 
-    def as_dict(self) -> dict[str, Union[str, int, datetime]]:
-        response_dict: dict[str, Union[str, int, datetime]] = {
+    def as_dict(self) -> dict[str, str | int | datetime]:
+        response_dict: dict[str, str | int | datetime] = {
             "CrawlId": self.crawl_id,
             "DPUHour": self.dpu_hour,
             "LogGroup": self.log_group,
@@ -2060,15 +2060,15 @@ class FakeJob:
 
     def start_job_run(
         self,
-        allocated_capacity: Optional[int],
-        max_capacity: Optional[float],
-        timeout: Optional[int],
-        worker_type: Optional[str],
-        security_configuration: Optional[str],
-        number_of_workers: Optional[int],
-        notification_property: Optional[dict[str, int]],
-        previous_run_id: Optional[str],
-        arguments: Optional[dict[str, str]],
+        allocated_capacity: int | None,
+        max_capacity: float | None,
+        timeout: int | None,
+        worker_type: str | None,
+        security_configuration: str | None,
+        number_of_workers: int | None,
+        notification_property: dict[str, int] | None,
+        previous_run_id: str | None,
+        arguments: dict[str, str] | None,
     ) -> str:
         running_jobs = len(
             [jr for jr in self.job_runs if jr.status in ["STARTING", "RUNNING"]]
@@ -2115,15 +2115,15 @@ class FakeJobRun(ManagedState):
     def __init__(
         self,
         job_name: str,
-        job_run_id: Optional[str] = None,
-        arguments: Optional[dict[str, Any]] = None,
-        allocated_capacity: Optional[int] = 10,
-        max_capacity: Optional[float] = 10.0,
-        timeout: Optional[int] = None,
-        worker_type: Optional[str] = "Standard",
-        notification_property: Optional[dict[str, int]] = None,
-        security_configuration: Optional[str] = None,
-        number_of_workers: Optional[int] = 10,
+        job_run_id: str | None = None,
+        arguments: dict[str, Any] | None = None,
+        allocated_capacity: int | None = 10,
+        max_capacity: float | None = 10.0,
+        timeout: int | None = None,
+        worker_type: str | None = "Standard",
+        notification_property: dict[str, int] | None = None,
+        security_configuration: str | None = None,
+        number_of_workers: int | None = 10,
     ):
         ManagedState.__init__(
             self,
@@ -2184,8 +2184,8 @@ class FakeRegistry(BaseModel):
         self,
         backend: GlueBackend,
         registry_name: str,
-        description: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
     ):
         self.name = registry_name
         self.description = description
@@ -2214,7 +2214,7 @@ class FakeSchema(BaseModel):
         data_format: str,
         compatibility: str,
         schema_version_id: str,
-        description: Optional[str] = None,
+        description: str | None = None,
     ):
         self.registry_name = registry_name
         self.registry_arn = f"arn:{get_partition(backend.region_name)}:glue:{backend.region_name}:{backend.account_id}:registry/{self.registry_name}"
@@ -2387,7 +2387,7 @@ class FakeTrigger(BaseModel):
         workflow_name: str,
         trigger_type: str,  # to avoid any issues with built-in function type()
         schedule: str,
-        predicate: Optional[Predicate],
+        predicate: Predicate | None,
         actions: list[Action],
         description: str,
         start_on_creation: bool,
@@ -2493,8 +2493,8 @@ class FakeWorkflowRun:
     def __init__(
         self,
         workflow_name: str,
-        previous_run_id: Optional[str] = None,
-        properties: Optional[dict[str, str]] = None,
+        previous_run_id: str | None = None,
+        properties: dict[str, str] | None = None,
     ) -> None:
         self.workflow_name = workflow_name
         self.run_id = f"wr_{mock_random.get_random_hex(64)}"
@@ -2502,10 +2502,10 @@ class FakeWorkflowRun:
         self.properties = properties or {}
         self.status = "RUNNING"
         self.started_on = utcnow()
-        self.completed_on: Optional[datetime] = None
+        self.completed_on: datetime | None = None
 
-    def as_dict(self) -> dict[str, Union[str, datetime, dict[str, str]]]:
-        return_dict: dict[str, Union[str, datetime, dict[str, str]]] = {
+    def as_dict(self) -> dict[str, str | datetime | dict[str, str]]:
+        return_dict: dict[str, str | datetime | dict[str, str]] = {
             "Name": self.workflow_name,
             "WorkflowRunId": self.run_id,
             "StartedOn": self.started_on,
@@ -2524,10 +2524,10 @@ class FakeWorkflow:
     def __init__(
         self,
         name: str,
-        default_run_properties: Optional[dict[str, str]],
-        description: Optional[str],
-        max_concurrent_runs: Optional[int],
-        tags: Optional[dict[str, str]],
+        default_run_properties: dict[str, str] | None,
+        description: str | None,
+        max_concurrent_runs: int | None,
+        tags: dict[str, str] | None,
     ) -> None:
         self.name = name
         self.default_run_properties = default_run_properties
@@ -2554,7 +2554,7 @@ class FakeWorkflow:
             return_dict["LastRun"] = self.runs[next(reversed(self.runs))].as_dict()
         return return_dict
 
-    def start_run(self, properties: Optional[dict[str, str]]) -> str:
+    def start_run(self, properties: dict[str, str] | None) -> str:
         run_properties = (
             self.default_run_properties.copy() if self.default_run_properties else {}
         )

--- a/moto/glue/responses.py
+++ b/moto/glue/responses.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 
@@ -708,8 +708,8 @@ class GlueResponse(BaseResponse):
         trigger_type = self._get_param("Type")
         schedule = self._get_param("Schedule")
 
-        predicate_input: Optional[dict[str, Union[str, list[dict[str, str]]]]] = (
-            self._get_param("Predicate")
+        predicate_input: dict[str, str | list[dict[str, str]]] | None = self._get_param(
+            "Predicate"
         )
         if predicate_input:
             predicate = Predicate(predicate_input)

--- a/moto/glue/utils.py
+++ b/moto/glue/utils.py
@@ -4,7 +4,7 @@ import re
 from datetime import date, datetime
 from enum import Enum
 from itertools import repeat
-from typing import Any, Optional, Union
+from typing import Any
 
 from pyparsing import (
     CaselessKeyword,
@@ -65,8 +65,8 @@ class Condition:
         # if there's a job name present, the API creates a job trigger, even if crawler trigger args are provided
         self.job_name = inputs.get("JobName")
         self.crawler_name = inputs.get("CrawlerName")
-        self.state: Optional[ConditionState] = None
-        self.crawl_state: Optional[CrawlState] = None
+        self.state: ConditionState | None = None
+        self.crawl_state: CrawlState | None = None
         if self.job_name:
             self.crawler_name = None
             if inputs.get("State"):
@@ -126,8 +126,8 @@ class Predicate:
             for index, condition in enumerate(inputs.get("Conditions", []))
         ]
 
-    def as_dict(self) -> dict[str, Union[str, list[dict[str, str]]]]:
-        return_dict: dict[str, Union[str, list[dict[str, str]]]] = {}
+    def as_dict(self) -> dict[str, str | list[dict[str, str]]]:
+        return_dict: dict[str, str | list[dict[str, str]]] = {}
         if self.logical:
             return_dict["Logical"] = self.logical.value
         if self.conditions:
@@ -138,7 +138,7 @@ class Predicate:
 
 
 class Action:
-    def __init__(self, inputs: dict[str, Union[str, dict[str, str], int]]) -> None:
+    def __init__(self, inputs: dict[str, str | dict[str, str] | int]) -> None:
         self.arguments = inputs.get("Arguments")
         self.crawler_name = inputs.get("CrawlerName")
         self.job_name = inputs.get("JobName")
@@ -152,8 +152,8 @@ class Action:
                 "Both JobName and CrawlerName cannot be set together in an action",
             )
 
-    def as_dict(self) -> dict[str, Union[str, dict[str, str], int]]:
-        return_dict: dict[str, Union[str, dict[str, str], int]] = {}
+    def as_dict(self) -> dict[str, str | dict[str, str] | int]:
+        return_dict: dict[str, str | dict[str, str] | int] = {}
         if self.arguments:
             return_dict["Arguments"] = self.arguments
         if self.crawler_name:
@@ -233,7 +233,7 @@ def validate_crawl_filters(filters: list[dict[str, str]]) -> list[CrawlFilter]:
     return filter_objects
 
 
-def _cast(type_: str, value: Any) -> Union[date, datetime, float, int, str]:
+def _cast(type_: str, value: Any) -> date | datetime | float | int | str:
     # values are always cast from string to target type
     value = str(value)
 
@@ -526,7 +526,7 @@ class _PartitionFilterExpressionCache:
 
         self._cache: dict[str, _Expr] = {}
 
-    def get(self, expression: Optional[str]) -> Optional[_Expr]:
+    def get(self, expression: str | None) -> _Expr | None:
         if expression is None:
             return None
 
@@ -548,7 +548,7 @@ _PARTITION_FILTER_EXPRESSION_CACHE = _PartitionFilterExpressionCache()
 
 
 class PartitionFilter:
-    def __init__(self, expression: Optional[str], fake_table: Any):
+    def __init__(self, expression: str | None, fake_table: Any):
         self.expression = expression
         self.fake_table = fake_table
 

--- a/moto/greengrass/models.py
+++ b/moto/greengrass/models.py
@@ -3,7 +3,7 @@ import re
 from collections import OrderedDict
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -367,11 +367,11 @@ class FakeGroupVersion(BaseModel):
         account_id: str,
         region_name: str,
         group_id: str,
-        core_definition_version_arn: Optional[str],
-        device_definition_version_arn: Optional[str],
-        function_definition_version_arn: Optional[str],
-        resource_definition_version_arn: Optional[str],
-        subscription_definition_version_arn: Optional[str],
+        core_definition_version_arn: str | None,
+        device_definition_version_arn: str | None,
+        function_definition_version_arn: str | None,
+        resource_definition_version_arn: str | None,
+        subscription_definition_version_arn: str | None,
     ):
         self.region_name = region_name
         self.group_id = group_id
@@ -1079,7 +1079,7 @@ class GreengrassBackend(BaseBackend):
     def list_groups(self) -> list[FakeGroup]:
         return list(self.groups.values())
 
-    def get_group(self, group_id: str) -> Optional[FakeGroup]:
+    def get_group(self, group_id: str) -> FakeGroup | None:
         if group_id not in self.groups:
             raise IdNotFoundException("That Group Definition does not exist.")
         return self.groups.get(group_id)
@@ -1103,11 +1103,11 @@ class GreengrassBackend(BaseBackend):
     def create_group_version(
         self,
         group_id: str,
-        core_definition_version_arn: Optional[str],
-        device_definition_version_arn: Optional[str],
-        function_definition_version_arn: Optional[str],
-        resource_definition_version_arn: Optional[str],
-        subscription_definition_version_arn: Optional[str],
+        core_definition_version_arn: str | None,
+        device_definition_version_arn: str | None,
+        function_definition_version_arn: str | None,
+        resource_definition_version_arn: str | None,
+        subscription_definition_version_arn: str | None,
     ) -> FakeGroupVersion:
         if group_id not in self.groups:
             raise IdNotFoundException("That group does not exist.")
@@ -1139,14 +1139,14 @@ class GreengrassBackend(BaseBackend):
 
     def _validate_group_version_definitions(
         self,
-        core_definition_version_arn: Optional[str] = None,
-        device_definition_version_arn: Optional[str] = None,
-        function_definition_version_arn: Optional[str] = None,
-        resource_definition_version_arn: Optional[str] = None,
-        subscription_definition_version_arn: Optional[str] = None,
+        core_definition_version_arn: str | None = None,
+        device_definition_version_arn: str | None = None,
+        function_definition_version_arn: str | None = None,
+        resource_definition_version_arn: str | None = None,
+        subscription_definition_version_arn: str | None = None,
     ) -> None:
         def _is_valid_def_ver_arn(
-            definition_version_arn: Optional[str], kind: str = "cores"
+            definition_version_arn: str | None, kind: str = "cores"
         ) -> bool:
             if definition_version_arn is None:
                 return True
@@ -1239,7 +1239,7 @@ class GreengrassBackend(BaseBackend):
         group_id: str,
         group_version_id: str,
         deployment_type: str,
-        deployment_id: Optional[str] = None,
+        deployment_id: str | None = None,
     ) -> FakeDeployment:
         deployment_types = (
             "NewDeployment",

--- a/moto/guardduty/models.py
+++ b/moto/guardduty/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -154,10 +154,10 @@ class Filter(BaseModel):
 
     def update(
         self,
-        action: Optional[str],
-        description: Optional[str],
-        finding_criteria: Optional[dict[str, Any]],
-        rank: Optional[int],
+        action: str | None,
+        description: str | None,
+        finding_criteria: dict[str, Any] | None,
+        rank: int | None,
     ) -> None:
         if action is not None:
             self.action = action

--- a/moto/iam/access_control.py
+++ b/moto/iam/access_control.py
@@ -12,13 +12,15 @@ TODO add support for resource-based policies
 
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import re
 from abc import ABCMeta, abstractmethod
 from enum import Enum
 from re import Match
-from typing import Any, Optional, Union
+from typing import Any
 
 from botocore.auth import S3SigV4Auth, SigV4Auth
 from botocore.awsrequest import AWSRequest
@@ -56,7 +58,7 @@ log = logging.getLogger(__name__)
 
 def create_access_key(
     account_id: str, partition: str, access_key_id: str, headers: dict[str, str]
-) -> Union["IAMUserAccessKey", "AssumedRoleAccessKey"]:
+) -> IAMUserAccessKey | AssumedRoleAccessKey:
     if access_key_id.startswith("AKIA") or "X-Amz-Security-Token" not in headers:
         return IAMUserAccessKey(
             account_id=account_id,
@@ -433,9 +435,9 @@ class IAMPolicy:
         self,
         action: str,
         resource: str = "*",
-        principal: Optional[str] = None,
-        incoming_condition_values: Optional[dict[str, str]] = None,
-    ) -> "PermissionResult":
+        principal: str | None = None,
+        incoming_condition_values: dict[str, str] | None = None,
+    ) -> PermissionResult:
         permitted = False
         if isinstance(self._policy_json["Statement"], list):
             for policy_statement in self._policy_json["Statement"]:
@@ -470,9 +472,9 @@ class IAMPolicyStatement:
         self,
         action: str,
         resource: str = "*",
-        principal: Optional[str] = None,
-        incoming_condition_values: Optional[dict[str, str]] = None,
-    ) -> "PermissionResult":
+        principal: str | None = None,
+        incoming_condition_values: dict[str, str] | None = None,
+    ) -> PermissionResult:
         is_action_concerned = False
 
         if "NotAction" in self._statement:
@@ -506,7 +508,7 @@ class IAMPolicyStatement:
         else:
             return PermissionResult.NEUTRAL
 
-    def is_unknown_principal(self, principal: Optional[str]) -> bool:
+    def is_unknown_principal(self, principal: str | None) -> bool:
         # https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-bucket-user-policy-specifying-principal-intro.html
         # For now, Moto only verifies principal == *
         # 'Unknown' principals are not verified
@@ -543,7 +545,7 @@ class IAMPolicyStatement:
         )
 
     def _check_conditions(
-        self, incoming_condition_values: Optional[dict[str, str]]
+        self, incoming_condition_values: dict[str, str] | None
     ) -> bool:
         expected_conditions = self._statement.get("Condition")
         if not expected_conditions:
@@ -567,7 +569,7 @@ class IAMPolicyStatement:
         return True
 
     @staticmethod
-    def _match(pattern: str, string: str) -> Optional[Match[str]]:
+    def _match(pattern: str, string: str) -> Match[str] | None:
         pattern = pattern.replace("*", ".*")
         pattern = f"^{pattern}$"
         return re.match(pattern, string)

--- a/moto/iam/config.py
+++ b/moto/iam/config.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Optional
+from typing import Any
 
 import boto3
 
@@ -15,14 +15,14 @@ class RoleConfigQuery(ConfigQueryModel[IAMBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[list[str]],
-        resource_name: Optional[str],
+        resource_ids: list[str] | None,
+        resource_name: str | None,
         limit: int,
-        next_token: Optional[str],
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-        aggregator: Optional[dict[str, Any]] = None,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        next_token: str | None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+        aggregator: dict[str, Any] | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         # IAM roles are "global" and aren't assigned into any availability zone
         # The resource ID is a AWS-assigned random string like "AROA0BSVNSZKXVHS00SBJ"
         # The resource name is a user-assigned string like "MyDevelopmentAdminRole"
@@ -138,10 +138,10 @@ class RoleConfigQuery(ConfigQueryModel[IAMBackend]):
         account_id: str,
         partition: str,
         resource_id: str,
-        resource_name: Optional[str] = None,
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        resource_name: str | None = None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+    ) -> dict[str, Any] | None:
         role = self.backends[account_id][partition].roles.get(resource_id)
 
         if not role:
@@ -169,14 +169,14 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[list[str]],
-        resource_name: Optional[str],
+        resource_ids: list[str] | None,
+        resource_name: str | None,
         limit: int,
-        next_token: Optional[str],
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-        aggregator: Optional[dict[str, Any]] = None,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        next_token: str | None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+        aggregator: dict[str, Any] | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         # IAM policies are "global" and aren't assigned into any availability zone
         # The resource ID is a AWS-assigned random string like "ANPA0BSVNSZK00SJSPVUJ"
         # The resource name is a user-assigned string like "my-development-policy"
@@ -314,10 +314,10 @@ class PolicyConfigQuery(ConfigQueryModel[IAMBackend]):
         account_id: str,
         partition: str,
         resource_id: str,
-        resource_name: Optional[str] = None,
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        resource_name: str | None = None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+    ) -> dict[str, Any] | None:
         # policies are listed in the backend as arns, but we have to accept the PolicyID as the resource_id
         # we'll make a really crude search for it
         policy = None

--- a/moto/iam/models.py
+++ b/moto/iam/models.py
@@ -6,7 +6,7 @@ import re
 import string
 from collections.abc import Iterable
 from datetime import date, datetime
-from typing import Any, Optional, Union
+from typing import Any
 from urllib import parse
 
 from cryptography import x509
@@ -130,9 +130,9 @@ class VirtualMfaDevice:
         self.base32_string_seed = random_base32_string
         self.qr_code_png = os.urandom(64)  # this would be a generated PNG
 
-        self.enable_date: Optional[datetime] = None
-        self.user_attribute: Optional[dict[str, Any]] = None
-        self.user: Optional[User] = None
+        self.enable_date: datetime | None = None
+        self.user_attribute: dict[str, Any] | None = None
+        self.user: User | None = None
 
 
 class Policy(CloudFormationModel):
@@ -146,13 +146,13 @@ class Policy(CloudFormationModel):
         name: str,
         account_id: str,
         region: str,
-        default_version_id: Optional[str] = None,
-        description: Optional[str] = None,
-        document: Optional[str] = None,
-        path: Optional[str] = None,
-        create_date: Optional[datetime] = None,
-        update_date: Optional[datetime] = None,
-        tags: Optional[dict[str, dict[str, str]]] = None,
+        default_version_id: str | None = None,
+        description: str | None = None,
+        document: str | None = None,
+        path: str | None = None,
+        create_date: datetime | None = None,
+        update_date: datetime | None = None,
+        tags: dict[str, dict[str, str]] | None = None,
     ):
         self.name = name
         self.account_id = account_id
@@ -216,7 +216,7 @@ class SAMLProvider(BaseModel):
         account_id: str,
         region_name: str,
         name: str,
-        saml_metadata_document: Optional[str] = None,
+        saml_metadata_document: str | None = None,
     ):
         self.account_id = account_id
         self.create_date = utcnow()
@@ -333,10 +333,10 @@ class PolicyVersion:
     def __init__(
         self,
         policy_arn: str,
-        document: Optional[str],
+        document: str | None,
         is_default: bool = False,
         version_id: str = "v1",
-        create_date: Optional[datetime] = None,
+        create_date: datetime | None = None,
     ):
         self.policy_arn = policy_arn
         self.document = document or ""
@@ -359,11 +359,11 @@ class ManagedPolicy(Policy, CloudFormationModel):
 
     is_attachable = True
 
-    def attach_to(self, obj: Union[Role, Group, User]) -> None:
+    def attach_to(self, obj: Role | Group | User) -> None:
         self.attachment_count += 1
         obj.managed_policies[self.arn] = self
 
-    def detach_from(self, obj: Union[Role, Group, User]) -> None:
+    def detach_from(self, obj: Role | Group | User) -> None:
         self.attachment_count -= 1
         del obj.managed_policies[self.arn]
 
@@ -678,11 +678,11 @@ class Role(CloudFormationModel):
         name: str,
         assume_role_policy_document: str,
         path: str,
-        permissions_boundary: Optional[str],
+        permissions_boundary: str | None,
         description: str,
         tags: list[dict[str, str]],
-        max_session_duration: Optional[str],
-        linked_service: Optional[str] = None,
+        max_session_duration: str | None,
+        linked_service: str | None = None,
     ):
         self.account_id = account_id
         self.partition = partition
@@ -696,10 +696,10 @@ class Role(CloudFormationModel):
         self.tags = tags
         # last_used should be treated as part of the public API
         # https://github.com/getmoto/moto/issues/6859
-        self.last_used: Optional[datetime] = None
+        self.last_used: datetime | None = None
         self.last_used_region = None
         self.description = description
-        self.permissions_boundary_arn: Optional[str] = permissions_boundary
+        self.permissions_boundary_arn: str | None = permissions_boundary
         self.max_session_duration = max_session_duration
         self._linked_service = linked_service
 
@@ -733,7 +733,7 @@ class Role(CloudFormationModel):
         return policy_list
 
     @property
-    def permissions_boundary(self) -> Optional[dict[str, str]]:
+    def permissions_boundary(self) -> dict[str, str] | None:
         if self.permissions_boundary_arn:
             return {
                 "PermissionsBoundaryType": "PermissionsBoundaryPolicy",
@@ -742,7 +742,7 @@ class Role(CloudFormationModel):
         return None
 
     @property
-    def role_last_used(self) -> dict[str, Optional[str | datetime]]:
+    def role_last_used(self) -> dict[str, str | datetime | None]:
         """Returns a dict with the last used information of the role."""
         return {
             "LastUsedDate": self.last_used,
@@ -952,7 +952,7 @@ class InstanceProfile(CloudFormationModel):
         name: str,
         path: str,
         roles: list[Role],
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.id = instance_profile_id
         self.account_id = account_id
@@ -1067,8 +1067,8 @@ class Certificate(BaseModel):
         cert_name: str,
         cert_body: str,
         private_key: str,
-        cert_chain: Optional[str] = None,
-        path: Optional[str] = None,
+        cert_chain: str | None = None,
+        path: str | None = None,
     ):
         self.account_id = account_id
         self.partition = get_partition(region_name)
@@ -1123,7 +1123,7 @@ class AccessKeyLastUsed:
 class AccessKey(CloudFormationModel):
     def __init__(
         self,
-        user_name: Optional[str],
+        user_name: str | None,
         prefix: str,
         account_id: str,
         status: str = "Active",
@@ -1143,8 +1143,8 @@ class AccessKey(CloudFormationModel):
         # The `to_csv` method calls `last_used.strptime`, which currently works on both AccessKeyLastUsed and datetime
         # In the next major release we should communicate that this only accepts AccessKeyLastUsed
         # (And rework to_csv accordingly)
-        self.last_used: Optional[AccessKeyLastUsed] = None
-        self.role_arn: Optional[str] = None
+        self.last_used: AccessKeyLastUsed | None = None
+        self.role_arn: str | None = None
 
     @classmethod
     def has_cfn_attr(cls, attr: str) -> bool:
@@ -1330,7 +1330,7 @@ class Group(BaseModel):
 
 class User(CloudFormationModel):
     def __init__(
-        self, account_id: str, region_name: str, name: str, path: Optional[str] = None
+        self, account_id: str, region_name: str, name: str, path: str | None = None
     ):
         self.account_id = account_id
         self.region_name = region_name
@@ -1343,7 +1343,7 @@ class User(CloudFormationModel):
         self.managed_policies: dict[str, ManagedPolicy] = {}
         self.access_keys: list[AccessKey] = []
         self.ssh_public_keys: list[SshPublicKey] = []
-        self.password: Optional[str] = None
+        self.password: str | None = None
         # last_used should be treated as part of the public API
         # https://github.com/getmoto/moto/issues/5927
         self.password_last_used = None
@@ -1377,7 +1377,7 @@ class User(CloudFormationModel):
         return [group.name for group in groups]
 
     @property
-    def tags(self) -> Optional[list[dict[str, str]]]:
+    def tags(self) -> list[dict[str, str]] | None:
         backend = iam_backends[self.account_id][get_partition(self.region_name)]
         tags = backend.tagger.list_tags_for_resource(self.arn)["Tags"]
         return tags if tags else None
@@ -1433,7 +1433,7 @@ class User(CloudFormationModel):
         self.access_keys.remove(key)
 
     def update_access_key(
-        self, access_key_id: str, status: Optional[str] = None
+        self, access_key_id: str, status: str | None = None
     ) -> AccessKey:
         key = self.get_access_key_by_id(access_key_id)
         if status is not None:
@@ -1729,7 +1729,7 @@ class AccountPasswordPolicy(BaseModel):
 
         self._raise_errors()
 
-    def _format_error(self, key: str, value: Union[str, int], constraint: str) -> str:
+    def _format_error(self, key: str, value: str | int, constraint: str) -> str:
         return f'Value "{value}" at "{key}" failed to satisfy constraint: {constraint}'
 
     def _raise_errors(self) -> None:
@@ -1885,7 +1885,7 @@ class IAMBackend(BaseBackend):
         self.certificates: dict[str, Certificate] = {}
         self.groups: dict[str, Group] = {}
         self.users: dict[str, User] = {}
-        self.credential_report: Optional[bool] = None
+        self.credential_report: bool | None = None
         self.aws_managed_policies = self._init_aws_policies()
         self.managed_policies = self._init_managed_policies()
         self.account_aliases: list[str] = []
@@ -1895,7 +1895,7 @@ class IAMBackend(BaseBackend):
             ARN_PARTITION_REGEX + r":iam::(aws|[0-9]*):policy/.*$"
         )
         self.virtual_mfa_devices: dict[str, VirtualMfaDevice] = {}
-        self.account_password_policy: Optional[AccountPasswordPolicy] = None
+        self.account_password_policy: AccountPasswordPolicy | None = None
         self.account_summary = AccountSummary(self)
         self.inline_policies: dict[str, InlinePolicy] = {}
         self.access_keys: dict[str, AccessKey] = {}
@@ -2056,41 +2056,41 @@ class IAMBackend(BaseBackend):
     def list_attached_role_policies(
         self,
         role_name: str,
-        marker: Optional[str] = None,
+        marker: str | None = None,
         max_items: int = 100,
         path_prefix: str = "/",
-    ) -> tuple[Iterable[ManagedPolicy], Optional[str]]:
+    ) -> tuple[Iterable[ManagedPolicy], str | None]:
         policies = self.get_role(role_name).managed_policies.values()
         return self._filter_attached_policies(policies, marker, max_items, path_prefix)
 
     def list_attached_group_policies(
         self,
         group_name: str,
-        marker: Optional[str] = None,
+        marker: str | None = None,
         max_items: int = 100,
         path_prefix: str = "/",
-    ) -> tuple[Iterable[Any], Optional[str]]:
+    ) -> tuple[Iterable[Any], str | None]:
         policies = self.get_group(group_name).managed_policies.values()
         return self._filter_attached_policies(policies, marker, max_items, path_prefix)
 
     def list_attached_user_policies(
         self,
         user_name: str,
-        marker: Optional[str] = None,
+        marker: str | None = None,
         max_items: int = 100,
         path_prefix: str = "/",
-    ) -> tuple[Iterable[Any], Optional[str]]:
+    ) -> tuple[Iterable[Any], str | None]:
         policies = self.get_user(user_name).managed_policies.values()
         return self._filter_attached_policies(policies, marker, max_items, path_prefix)
 
     def list_policies(
         self,
-        marker: Optional[str],
+        marker: str | None,
         max_items: int,
         only_attached: bool,
         path_prefix: str,
         scope: str,
-    ) -> tuple[Iterable[ManagedPolicy], Optional[str]]:
+    ) -> tuple[Iterable[ManagedPolicy], str | None]:
         policies = list(self.managed_policies.values())
 
         if only_attached:
@@ -2123,10 +2123,10 @@ class IAMBackend(BaseBackend):
     def _filter_attached_policies(
         self,
         policies: Iterable[Any],
-        marker: Optional[str],
+        marker: str | None,
         max_items: int,
         path_prefix: str,
-    ) -> tuple[Iterable[Any], Optional[str]]:
+    ) -> tuple[Iterable[Any], str | None]:
         if path_prefix:
             policies = [p for p in policies if p.path.startswith(path_prefix)]
 
@@ -2147,11 +2147,11 @@ class IAMBackend(BaseBackend):
         role_name: str,
         assume_role_policy_document: str,
         path: str,
-        permissions_boundary: Optional[str],
+        permissions_boundary: str | None,
         description: str,
         tags: list[dict[str, str]],
-        max_session_duration: Optional[str],
-        linked_service: Optional[str] = None,
+        max_session_duration: str | None,
+        linked_service: str | None = None,
     ) -> Role:
         role_id = random_role_id(self.account_id)
         if permissions_boundary and not self.policy_arn_regex.match(
@@ -2181,7 +2181,7 @@ class IAMBackend(BaseBackend):
         self.roles[role_id] = role
         return role
 
-    def get_role_by_id(self, role_id: str) -> Optional[Role]:
+    def get_role_by_id(self, role_id: str) -> Role | None:
         return self.roles.get(role_id)
 
     def get_role(self, role_name: str) -> Role:
@@ -2302,8 +2302,8 @@ class IAMBackend(BaseBackend):
             raise DuplicateTags()
 
     def list_role_tags(
-        self, role_name: str, marker: Optional[str], max_items: int = 100
-    ) -> tuple[list[dict[str, str]], Optional[str]]:
+        self, role_name: str, marker: str | None, max_items: int = 100
+    ) -> tuple[list[dict[str, str]], str | None]:
         role = self.get_role(role_name)
 
         max_items = int(max_items)
@@ -2339,8 +2339,8 @@ class IAMBackend(BaseBackend):
         role.tags = [tag for tag in role.tags if tag["Key"] not in tag_keys]
 
     def list_policy_tags(
-        self, policy_arn: str, marker: Optional[str], max_items: int = 100
-    ) -> tuple[list[dict[str, str]], Optional[str]]:
+        self, policy_arn: str, marker: str | None, max_items: int = 100
+    ) -> tuple[list[dict[str, str]], str | None]:
         policy = self.get_policy(policy_arn)
 
         max_items = int(max_items)
@@ -2431,7 +2431,7 @@ class IAMBackend(BaseBackend):
         name: str,
         path: str,
         role_names: list[str],
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> InstanceProfile:
         if self.instance_profiles.get(name):
             raise EntityAlreadyExists(
@@ -2518,8 +2518,8 @@ class IAMBackend(BaseBackend):
         cert_name: str,
         cert_body: str,
         private_key: str,
-        cert_chain: Optional[str] = None,
-        path: Optional[str] = None,
+        cert_chain: str | None = None,
+        path: str | None = None,
     ) -> Certificate:
         certificate_id = random_resource_id()
         cert = Certificate(
@@ -2543,7 +2543,7 @@ class IAMBackend(BaseBackend):
             f"The Server Certificate with name {name} cannot be found."
         )
 
-    def get_certificate_by_arn(self, arn: str) -> Optional[Certificate]:
+    def get_certificate_by_arn(self, arn: str) -> Certificate | None:
         for cert in self.certificates.values():
             if arn == cert.arn:
                 return cert
@@ -2625,7 +2625,7 @@ class IAMBackend(BaseBackend):
             )
 
     def update_group(
-        self, group_name: str, new_group_name: Optional[str], new_path: Optional[str]
+        self, group_name: str, new_group_name: str | None, new_path: str | None
     ) -> None:
         if new_group_name:
             if new_group_name in self.groups:
@@ -2652,7 +2652,7 @@ class IAMBackend(BaseBackend):
         region_name: str,
         user_name: str,
         path: str = "/",
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> User:
         if user_name in self.users:
             raise EntityAlreadyExists(f"User {user_name} already exists")
@@ -2672,9 +2672,9 @@ class IAMBackend(BaseBackend):
 
     def list_users(
         self,
-        path_prefix: Optional[str],
-        marker: Optional[str],
-        max_items: Optional[int],
+        path_prefix: str | None,
+        marker: str | None,
+        max_items: int | None,
     ) -> Iterable[User]:
         try:
             users: Iterable[User] = list(self.users.values())
@@ -2691,8 +2691,8 @@ class IAMBackend(BaseBackend):
     def update_user(
         self,
         user_name: str,
-        new_path: Optional[str] = None,
-        new_user_name: Optional[str] = None,
+        new_path: str | None = None,
+        new_user_name: str | None = None,
     ) -> None:
         try:
             user = self.users[user_name]
@@ -2707,10 +2707,10 @@ class IAMBackend(BaseBackend):
 
     def list_roles(
         self,
-        path_prefix: Optional[str] = None,
-        marker: Optional[str] = None,
-        max_items: Optional[int] = None,
-    ) -> tuple[list[Role], Optional[str]]:
+        path_prefix: str | None = None,
+        marker: str | None = None,
+        max_items: int | None = None,
+    ) -> tuple[list[Role], str | None]:
         path_prefix = path_prefix if path_prefix else "/"
         max_items = int(max_items) if max_items else 100
         start_index = int(marker) if marker else 0
@@ -2879,7 +2879,7 @@ class IAMBackend(BaseBackend):
         return key
 
     def update_access_key(
-        self, user_name: str, access_key_id: str, status: Optional[str] = None
+        self, user_name: str, access_key_id: str, status: str | None = None
     ) -> AccessKey:
         user = self.get_user(user_name)
         return user.update_access_key(access_key_id, status)
@@ -3046,8 +3046,8 @@ class IAMBackend(BaseBackend):
             )
 
     def list_virtual_mfa_devices(
-        self, assignment_status: str, marker: Optional[str], max_items: int
-    ) -> tuple[list[VirtualMfaDevice], Optional[str]]:
+        self, assignment_status: str, marker: str | None, max_items: int
+    ) -> tuple[list[VirtualMfaDevice], str | None]:
         devices = list(self.virtual_mfa_devices.values())
 
         if assignment_status == "Assigned":
@@ -3085,7 +3085,7 @@ class IAMBackend(BaseBackend):
         self.tagger.delete_all_tags_for_resource(user.arn)
         del self.users[user_name]
 
-    def report_generated(self) -> Optional[bool]:
+    def report_generated(self) -> bool | None:
         return self.credential_report
 
     def generate_report(self) -> None:
@@ -3174,7 +3174,7 @@ class IAMBackend(BaseBackend):
                 return saml_provider
         raise NotFoundException(f"SamlProvider {saml_provider_arn} not found")
 
-    def get_user_from_access_key_id(self, access_key_id: str) -> Optional[User]:
+    def get_user_from_access_key_id(self, access_key_id: str) -> User | None:
         for user_name, user in self.users.items():
             access_keys = self.list_access_keys(user_name)
             for access_key in access_keys:
@@ -3227,8 +3227,8 @@ class IAMBackend(BaseBackend):
             open_id_provider.tags.pop(ref_key, None)
 
     def list_open_id_connect_provider_tags(
-        self, arn: str, marker: Optional[str], max_items: int = 100
-    ) -> tuple[list[dict[str, str]], Optional[str]]:
+        self, arn: str, marker: str | None, max_items: int = 100
+    ) -> tuple[list[dict[str, str]], str | None]:
         open_id_provider = self.get_open_id_connect_provider(arn)
 
         max_items = int(max_items)

--- a/moto/iam/policy_conditions.py
+++ b/moto/iam/policy_conditions.py
@@ -1,10 +1,7 @@
 from collections.abc import Iterator
-from typing import Union
 
 
-def string_equals_operation(
-    expected_value: Union[list[str], str], actual_value: str
-) -> bool:
+def string_equals_operation(expected_value: list[str] | str, actual_value: str) -> bool:
     if isinstance(expected_value, str):
         return actual_value == expected_value
 
@@ -23,7 +20,7 @@ class TrustCondition:
     def __init__(
         self,
         condition: str,
-        expected_value: list[Union[list[str], str]],
+        expected_value: list[list[str] | str],
         expected_value_source: list[str],
     ) -> None:
         self._condition = condition
@@ -49,7 +46,7 @@ class TrustCondition:
         return True
 
 
-ConditionData = dict[str, dict[str, Union[str, list[str]]]]
+ConditionData = dict[str, dict[str, str | list[str]]]
 
 
 class TrustRelationShipConditions:
@@ -59,9 +56,7 @@ class TrustRelationShipConditions:
         self._conditions: list[TrustCondition] = []
         for conditions_operation, condition_values in conditions.items():
             expected_value_source: list[str] = list(condition_values.keys())
-            expected_value_data: list[Union[str, list[str]]] = list(
-                condition_values.values()
-            )
+            expected_value_data: list[str | list[str]] = list(condition_values.values())
 
             self._conditions.append(
                 TrustCondition(

--- a/moto/identitystore/models.py
+++ b/moto/identitystore/models.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from botocore.exceptions import ParamValidationError
 
@@ -20,21 +20,21 @@ if TYPE_CHECKING:
 class Group(NamedTuple):
     GroupId: str
     DisplayName: str
-    ExternalIds: list[Optional[dict[str, str]]]
+    ExternalIds: list[dict[str, str] | None]
     Description: str
     IdentityStoreId: str
 
 
 class Name(NamedTuple):
-    Formatted: Optional[str]
-    FamilyName: Optional[str]
-    GivenName: Optional[str]
-    MiddleName: Optional[str]
-    HonorificPrefix: Optional[str]
-    HonorificSuffix: Optional[str]
+    Formatted: str | None
+    FamilyName: str | None
+    GivenName: str | None
+    MiddleName: str | None
+    HonorificPrefix: str | None
+    HonorificSuffix: str | None
 
     @classmethod
-    def from_dict(cls, name_dict: dict[str, str]) -> "Optional[Self]":
+    def from_dict(cls, name_dict: dict[str, str]) -> "Self | None":
         if not name_dict:
             return None
         return cls(
@@ -51,7 +51,7 @@ class User(NamedTuple):
     UserId: str
     IdentityStoreId: str
     UserName: str
-    Name: Optional[Name]
+    Name: Name | None
     DisplayName: str
     NickName: str
     ProfileUrl: str

--- a/moto/identitystore/responses.py
+++ b/moto/identitystore/responses.py
@@ -252,9 +252,9 @@ class IdentityStoreResponse(BaseResponse):
         )
         return json.dumps({})
 
-    def named_tuple_to_dict(
-        self, value: Optional[NamedTuple]
-    ) -> Optional[dict[str, Any]]:
+    # Need a Optional here, as 'NamedTuple | None' only works in 3.14+
+    # https://github.com/astral-sh/ruff/issues/19144#issuecomment-3036476276
+    def named_tuple_to_dict(self, value: Optional[NamedTuple]) -> dict[str, Any] | None:
         if value:
             return value._asdict()
         return None

--- a/moto/inspector2/models.py
+++ b/moto/inspector2/models.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -16,9 +16,9 @@ class FilterResource(BaseModel):
         region: str,
         account_id: str,
         name: str,
-        reason: Optional[str],
+        reason: str | None,
         action: str,
-        description: Optional[str],
+        description: str | None,
         filter_criteria: dict[str, Any],
         backend: "Inspector2Backend",
     ):

--- a/moto/iot/exceptions.py
+++ b/moto/iot/exceptions.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 
 from moto.core.exceptions import JsonRESTError
 
@@ -9,7 +8,7 @@ class IoTClientError(JsonRESTError):
 
 
 class ResourceNotFoundException(IoTClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 404
         super().__init__(
             "ResourceNotFoundException", msg or "The specified resource does not exist"
@@ -17,13 +16,13 @@ class ResourceNotFoundException(IoTClientError):
 
 
 class InvalidRequestException(IoTClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 400
         super().__init__("InvalidRequestException", msg or "The request is not valid.")
 
 
 class InvalidStateTransitionException(IoTClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 409
         super().__init__(
             "InvalidStateTransitionException",

--- a/moto/iot/models.py
+++ b/moto/iot/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import json
 import re
@@ -11,8 +13,6 @@ from re import Pattern
 from typing import (
     TYPE_CHECKING,
     Any,
-    Optional,
-    Union,
 )
 
 from cryptography import x509
@@ -51,11 +51,11 @@ class FakeThing(CloudFormationModel):
     def __init__(
         self,
         thing_name: str,
-        thing_type: Optional["FakeThingType"],
+        thing_type: FakeThingType | None,
         attributes: dict[str, Any],
         account_id: str,
         region_name: str,
-        billing_group_name: Optional[str] = None,
+        billing_group_name: str | None = None,
     ):
         self.region_name = region_name
         self.account_id = account_id
@@ -69,7 +69,7 @@ class FakeThing(CloudFormationModel):
         # TODO: we need to handle "version"?
 
         # for iot-data
-        self.thing_shadows: dict[Optional[str], FakeShadow] = {}
+        self.thing_shadows: dict[str | None, FakeShadow] = {}
 
     def _matches_single_query(self, query_string: str) -> bool:
         if query_string == "*":
@@ -282,7 +282,7 @@ class FakeThing(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeThing":
+    ) -> FakeThing:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
 
@@ -302,12 +302,12 @@ class FakeThing(CloudFormationModel):
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
         cls,
-        original_resource: "FakeThing",
+        original_resource: FakeThing,
         new_resource_name: str,
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakeThing":
+    ) -> FakeThing:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
         thing_name = properties.get("ThingName", new_resource_name)
@@ -350,7 +350,7 @@ class FakeThingType(CloudFormationModel):
     def __init__(
         self,
         thing_type_name: str,
-        thing_type_properties: Optional[dict[str, Any]],
+        thing_type_properties: dict[str, Any] | None,
         account_id: str,
         region_name: str,
     ):
@@ -406,7 +406,7 @@ class FakeThingType(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeThingType":
+    ) -> FakeThingType:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
 
@@ -421,12 +421,12 @@ class FakeThingType(CloudFormationModel):
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
         cls,
-        original_resource: "FakeThingType",
+        original_resource: FakeThingType,
         new_resource_name: str,
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakeThingType":
+    ) -> FakeThingType:
         iot_backend = iot_backends[account_id][region_name]
 
         iot_backend.delete_thing_type(thing_type_name=original_resource.thing_type_name)
@@ -457,7 +457,7 @@ class FakeThingGroup(BaseModel):
         thing_group_properties: dict[str, str],
         account_id: str,
         region_name: str,
-        thing_groups: dict[str, "FakeThingGroup"],
+        thing_groups: dict[str, FakeThingGroup],
     ):
         self.account_id = account_id
         self.region_name = region_name
@@ -510,7 +510,7 @@ class FakeBillingGroup(CloudFormationModel):
     def __init__(
         self,
         billing_group_name: str,
-        billing_group_properties: Optional[dict[str, Any]],
+        billing_group_properties: dict[str, Any] | None,
         account_id: str,
         region_name: str,
     ):
@@ -575,7 +575,7 @@ class FakeBillingGroup(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeBillingGroup":
+    ) -> FakeBillingGroup:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json.get("Properties", {})
         billing_group_name = properties.get("BillingGroupName", resource_name)
@@ -589,12 +589,12 @@ class FakeBillingGroup(CloudFormationModel):
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
         cls,
-        original_resource: "FakeBillingGroup",
+        original_resource: FakeBillingGroup,
         new_resource_name: str,
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakeBillingGroup":
+    ) -> FakeBillingGroup:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json.get("Properties", {})
         billing_group_name = properties.get("BillingGroupName", new_resource_name)
@@ -634,7 +634,7 @@ class FakeCertificate(BaseModel):
         status: str,
         account_id: str,
         region_name: str,
-        ca_certificate_id: Optional[str] = None,
+        ca_certificate_id: str | None = None,
     ):
         self.certificate_id = self.compute_cert_id(certificate_pem)
         self.arn = f"arn:{get_partition(region_name)}:iot:{region_name}:{account_id}:cert/{self.certificate_id}"
@@ -795,7 +795,7 @@ class FakePolicy(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakePolicy":
+    ) -> FakePolicy:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
 
@@ -809,12 +809,12 @@ class FakePolicy(CloudFormationModel):
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
         cls,
-        original_resource: "FakePolicy",
+        original_resource: FakePolicy,
         new_resource_name: str,
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakePolicy":
+    ) -> FakePolicy:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
         new_policy_name = properties.get("PolicyName", new_resource_name)
@@ -941,8 +941,8 @@ class FakeJob(BaseModel):
         self.scheduling_config = scheduling_config
         self.timeout_config = timeout_config
         self.status = "QUEUED"  # IN_PROGRESS | CANCELED | COMPLETED
-        self.comment: Optional[str] = None
-        self.reason_code: Optional[str] = None
+        self.comment: str | None = None
+        self.reason_code: str | None = None
         self.created_at = utcnow()
         self.last_updated_at = utcnow()
         self.completed_at = None
@@ -995,7 +995,7 @@ class FakeJobExecution(BaseModel):
         thing_arn: str,
         status: str = "QUEUED",
         force_canceled: bool = False,
-        status_details_map: Optional[dict[str, Any]] = None,
+        status_details_map: dict[str, Any] | None = None,
     ):
         self.job_id = job_id
         self.status = status  # IN_PROGRESS | CANCELED | COMPLETED
@@ -1073,7 +1073,7 @@ class FakeJobTemplate(CloudFormationModel):
         self.timeout_config = timeout_config
         self.created_at = utcnow()
 
-    def to_dict(self) -> dict[str, Union[str, datetime]]:
+    def to_dict(self) -> dict[str, str | datetime]:
         return {
             "jobTemplateArn": self.job_template_arn,
             "jobTemplateId": self.job_template_id,
@@ -1116,7 +1116,7 @@ class FakeJobTemplate(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeJobTemplate":
+    ) -> FakeJobTemplate:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
 
@@ -1141,12 +1141,12 @@ class FakeJobTemplate(CloudFormationModel):
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
         cls,
-        original_resource: "FakeJobTemplate",
+        original_resource: FakeJobTemplate,
         new_resource_name: str,
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakeJobTemplate":
+    ) -> FakeJobTemplate:
         iot_backend = iot_backends[account_id][region_name]
         iot_backend.delete_job_template(
             job_template_id=original_resource.job_template_id
@@ -1215,7 +1215,7 @@ class FakeRule(BaseModel):
         description: str,
         created_at: datetime,
         rule_disabled: bool,
-        topic_pattern: Optional[str],
+        topic_pattern: str | None,
         actions: list[dict[str, Any]],
         error_action: dict[str, Any],
         sql: str,
@@ -1271,7 +1271,7 @@ class FakeDomainConfiguration(BaseModel):
         server_certificate_arns: list[str],
         domain_configuration_status: str,
         service_type: str,
-        authorizer_config: Optional[dict[str, Any]],
+        authorizer_config: dict[str, Any] | None,
         domain_type: str,
     ):
         if service_type and service_type not in ["DATA", "CREDENTIAL_PROVIDER", "JOBS"]:
@@ -1372,7 +1372,7 @@ class FakeRoleAlias(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeRoleAlias":
+    ) -> FakeRoleAlias:
         iot_backend = iot_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
 
@@ -1389,12 +1389,12 @@ class FakeRoleAlias(CloudFormationModel):
     @classmethod
     def update_from_cloudformation_json(  # type: ignore[misc]
         cls,
-        original_resource: "FakeRoleAlias",
+        original_resource: FakeRoleAlias,
         new_resource_name: str,
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakeRoleAlias":
+    ) -> FakeRoleAlias:
         iot_backend = iot_backends[account_id][region_name]
         iot_backend.delete_role_alias(role_alias_name=original_resource.role_alias)
         return cls.create_from_cloudformation_json(
@@ -1514,7 +1514,7 @@ class IoTBackend(BaseBackend):
         )
         self.rules: dict[str, FakeRule] = OrderedDict()
         self.role_aliases: dict[str, FakeRoleAlias] = OrderedDict()
-        self.endpoint: Optional[FakeEndpoint] = None
+        self.endpoint: FakeEndpoint | None = None
         self.domain_configurations: dict[str, FakeDomainConfiguration] = OrderedDict()
         self.indexing_configuration = FakeIndexingConfiguration(region_name, account_id)
 
@@ -1549,7 +1549,7 @@ class IoTBackend(BaseBackend):
         self,
         domain_name: str,
         subject: x509.Name,
-        key: Optional[rsa.RSAPrivateKey] = None,
+        key: rsa.RSAPrivateKey | None = None,
     ) -> str:
         sans = [x509.DNSName(domain_name)]
 
@@ -1584,8 +1584,8 @@ class IoTBackend(BaseBackend):
         self,
         thing_name: str,
         thing_type_name: str,
-        attribute_payload: Optional[dict[str, Any]],
-        billing_group_name: Optional[str] = None,
+        attribute_payload: dict[str, Any] | None,
+        billing_group_name: str | None = None,
     ) -> FakeThing:
         thing_types = self.list_thing_types()
         thing_type = None
@@ -1635,7 +1635,7 @@ class IoTBackend(BaseBackend):
         return thing_type.thing_type_name, thing_type.arn
 
     def list_thing_types(
-        self, thing_type_name: Optional[str] = None
+        self, thing_type_name: str | None = None
     ) -> Iterable[FakeThingType]:
         if thing_type_name:
             # It's weird but thing_type_name is filtered by forward match, not complete match
@@ -1745,7 +1745,7 @@ class IoTBackend(BaseBackend):
         self,
         thing_name: str,
         thing_type_name: str,
-        attribute_payload: Optional[dict[str, Any]],
+        attribute_payload: dict[str, Any] | None,
         remove_thing_type: bool,
     ) -> None:
         """
@@ -1922,7 +1922,7 @@ class IoTBackend(BaseBackend):
         self.ca_certificates[certificate.certificate_id] = certificate
         return certificate
 
-    def _find_ca_certificate(self, ca_certificate_pem: Optional[str]) -> Optional[str]:
+    def _find_ca_certificate(self, ca_certificate_pem: str | None) -> str | None:
         for ca_cert in self.ca_certificates.values():
             if ca_cert.certificate_pem == ca_certificate_pem:
                 return ca_cert.certificate_id
@@ -1931,7 +1931,7 @@ class IoTBackend(BaseBackend):
     def register_certificate(
         self,
         certificate_pem: str,
-        ca_certificate_pem: Optional[str],
+        ca_certificate_pem: str | None,
         set_as_active: bool,
         status: str,
     ) -> FakeCertificate:
@@ -1966,8 +1966,8 @@ class IoTBackend(BaseBackend):
     def update_ca_certificate(
         self,
         certificate_id: str,
-        new_status: Optional[str],
-        config: Optional[dict[str, str]],
+        new_status: str | None,
+        config: dict[str, str] | None,
     ) -> None:
         """
         The newAutoRegistrationStatus and removeAutoRegistration-parameters are not yet implemented
@@ -2300,9 +2300,9 @@ class IoTBackend(BaseBackend):
 
     def list_thing_groups(
         self,
-        parent_group: Optional[str],
-        name_prefix_filter: Optional[str],
-        recursive: Optional[bool],
+        parent_group: str | None,
+        name_prefix_filter: str | None,
+        recursive: bool | None,
     ) -> list[FakeThingGroup]:
         if recursive is None:
             recursive = True
@@ -2364,7 +2364,7 @@ class IoTBackend(BaseBackend):
         return thing_group.version
 
     def _identify_thing_group(
-        self, thing_group_name: Optional[str], thing_group_arn: Optional[str]
+        self, thing_group_name: str | None, thing_group_arn: str | None
     ) -> FakeThingGroup:
         # identify thing group
         if thing_group_name is None and thing_group_arn is None:
@@ -2384,7 +2384,7 @@ class IoTBackend(BaseBackend):
         return thing_group
 
     def _identify_thing(
-        self, thing_name: Optional[str], thing_arn: Optional[str]
+        self, thing_name: str | None, thing_arn: str | None
     ) -> FakeThing:
         # identify thing
         if thing_name is None and thing_arn is None:
@@ -2406,9 +2406,9 @@ class IoTBackend(BaseBackend):
     def add_thing_to_thing_group(
         self,
         thing_group_name: str,
-        thing_group_arn: Optional[str],
+        thing_group_arn: str | None,
         thing_name: str,
-        thing_arn: Optional[str],
+        thing_arn: str | None,
     ) -> None:
         thing_group = self._identify_thing_group(thing_group_name, thing_group_arn)
         thing = self._identify_thing(thing_name, thing_arn)
@@ -2420,9 +2420,9 @@ class IoTBackend(BaseBackend):
     def remove_thing_from_thing_group(
         self,
         thing_group_name: str,
-        thing_group_arn: Optional[str],
+        thing_group_arn: str | None,
         thing_name: str,
-        thing_arn: Optional[str],
+        thing_arn: str | None,
     ) -> None:
         thing_group = self._identify_thing_group(thing_group_name, thing_group_arn)
         thing = self._identify_thing(thing_name, thing_arn)
@@ -2625,7 +2625,7 @@ class IoTBackend(BaseBackend):
 
     @paginate(PAGINATION_MODEL)  # type: ignore[misc]
     def list_job_executions_for_thing(
-        self, thing_name: str, status: Optional[str]
+        self, thing_name: str, status: str | None
     ) -> list[FakeJobExecution]:
         return [
             job_exec
@@ -2734,7 +2734,7 @@ class IoTBackend(BaseBackend):
         domain_configuration_name: str,
         authorizer_config: dict[str, Any],
         domain_configuration_status: str,
-        remove_authorizer_config: Optional[bool],
+        remove_authorizer_config: bool | None,
     ) -> FakeDomainConfiguration:
         if domain_configuration_name not in self.domain_configurations:
             raise ResourceNotFoundException("The specified resource does not exist.")
@@ -2802,8 +2802,8 @@ class IoTBackend(BaseBackend):
     def update_role_alias(
         self,
         role_alias_name: str,
-        role_arn: Optional[str] = None,
-        credential_duration_seconds: Optional[int] = None,
+        role_arn: str | None = None,
+        credential_duration_seconds: int | None = None,
     ) -> FakeRoleAlias:
         role_alias = self.describe_role_alias(role_alias_name=role_alias_name)
         if role_arn:
@@ -2839,7 +2839,7 @@ class IoTBackend(BaseBackend):
         abort_config: dict[str, list[dict[str, Any]]],
         job_execution_retry_config: dict[str, Any],
         timeout_config: dict[str, Any],
-    ) -> "FakeJobTemplate":
+    ) -> FakeJobTemplate:
         if job_template_id in self.jobs_templates:
             raise ConflictException(job_template_id)
 
@@ -2860,7 +2860,7 @@ class IoTBackend(BaseBackend):
         return job_template
 
     @paginate(PAGINATION_MODEL)  # type: ignore[misc]
-    def list_job_templates(self) -> list[dict[str, Union[str, datetime]]]:
+    def list_job_templates(self) -> list[dict[str, str | datetime]]:
         return [_.to_dict() for _ in self.jobs_templates.values()]
 
     def delete_job_template(self, job_template_id: str) -> None:
@@ -2876,7 +2876,7 @@ class IoTBackend(BaseBackend):
     def create_billing_group(
         self,
         billing_group_name: str,
-        billing_group_properties: Optional[dict[str, Any]],
+        billing_group_properties: dict[str, Any] | None,
     ) -> FakeBillingGroup:
         if billing_group_name in self.billing_groups:
             raise ResourceAlreadyExistsException(
@@ -2905,7 +2905,7 @@ class IoTBackend(BaseBackend):
 
     @paginate(PAGINATION_MODEL)
     def list_billing_groups(
-        self, name_prefix_filter: Optional[str] = None
+        self, name_prefix_filter: str | None = None
     ) -> list[dict[str, str]]:
         if name_prefix_filter:
             result = [
@@ -2931,10 +2931,10 @@ class IoTBackend(BaseBackend):
 
     def add_thing_to_billing_group(
         self,
-        billing_group_name: Optional[str] = None,
-        billing_group_arn: Optional[str] = None,
-        thing_name: Optional[str] = None,
-        thing_arn: Optional[str] = None,
+        billing_group_name: str | None = None,
+        billing_group_arn: str | None = None,
+        thing_name: str | None = None,
+        thing_arn: str | None = None,
     ) -> None:
         if billing_group_name:
             billing_group = self.describe_billing_group(billing_group_name)
@@ -2960,10 +2960,10 @@ class IoTBackend(BaseBackend):
 
     def remove_thing_from_billing_group(
         self,
-        billing_group_name: Optional[str] = None,
-        billing_group_arn: Optional[str] = None,
-        thing_name: Optional[str] = None,
-        thing_arn: Optional[str] = None,
+        billing_group_name: str | None = None,
+        billing_group_arn: str | None = None,
+        thing_name: str | None = None,
+        thing_arn: str | None = None,
     ) -> None:
         if billing_group_name:
             billing_group = self.describe_billing_group(billing_group_name)

--- a/moto/iotdata/models.py
+++ b/moto/iotdata/models.py
@@ -21,9 +21,9 @@ class FakeShadow(BaseModel):
 
     def __init__(
         self,
-        desired: Optional[str],
-        reported: Optional[str],
-        requested_payload: Optional[dict[str, Any]],
+        desired: str | None,
+        reported: str | None,
+        requested_payload: dict[str, Any] | None,
         version: int,
         deleted: bool = False,
     ):
@@ -43,7 +43,7 @@ class FakeShadow(BaseModel):
 
     @classmethod
     def create_from_previous_version(  # type: ignore[misc]
-        cls, previous_shadow: Optional["FakeShadow"], payload: Optional[dict[str, Any]]
+        cls, previous_shadow: Optional["FakeShadow"], payload: dict[str, Any] | None
     ) -> "FakeShadow":
         """
         set None to payload when you want to delete shadow
@@ -199,7 +199,7 @@ class IoTDataPlaneBackend(BaseBackend):
         return iot_backends[self.account_id][self.region_name]
 
     def update_thing_shadow(
-        self, thing_name: str, payload: str, shadow_name: Optional[str]
+        self, thing_name: str, payload: str, shadow_name: str | None
     ) -> FakeShadow:
         """
         spec of payload:
@@ -230,9 +230,7 @@ class IoTDataPlaneBackend(BaseBackend):
         thing.thing_shadows[shadow_name] = new_shadow
         return new_shadow
 
-    def get_thing_shadow(
-        self, thing_name: str, shadow_name: Optional[str]
-    ) -> FakeShadow:
+    def get_thing_shadow(self, thing_name: str, shadow_name: str | None) -> FakeShadow:
         thing = self.iot_backend.describe_thing(thing_name)
         thing_shadow = thing.thing_shadows.get(shadow_name)
 
@@ -241,7 +239,7 @@ class IoTDataPlaneBackend(BaseBackend):
         return thing_shadow
 
     def delete_thing_shadow(
-        self, thing_name: str, shadow_name: Optional[str]
+        self, thing_name: str, shadow_name: str | None
     ) -> FakeShadow:
         thing = self.iot_backend.describe_thing(thing_name)
         thing_shadow = thing.thing_shadows.get(shadow_name)

--- a/moto/ivs/models.py
+++ b/moto/ivs/models.py
@@ -1,6 +1,6 @@
 """IVSBackend class with methods for supported APIs."""
 
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.ivs.exceptions import ResourceNotFoundException
@@ -65,8 +65,8 @@ class IVSBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
     def list_channels(  # type: ignore[misc]
         self,
-        filter_by_name: Optional[str],
-        filter_by_recording_configuration_arn: Optional[str],
+        filter_by_name: str | None,
+        filter_by_recording_configuration_arn: str | None,
     ) -> list[dict[str, Any]]:
         if filter_by_name is not None:
             channels = [
@@ -102,13 +102,13 @@ class IVSBackend(BaseBackend):
     def update_channel(
         self,
         arn: str,
-        authorized: Optional[bool],
-        insecure_ingest: Optional[bool],
-        latency_mode: Optional[str],
-        name: Optional[str],
-        preset: Optional[str],
-        recording_configuration_arn: Optional[str],
-        channel_type: Optional[str],
+        authorized: bool | None,
+        insecure_ingest: bool | None,
+        latency_mode: str | None,
+        name: str | None,
+        preset: str | None,
+        recording_configuration_arn: str | None,
+        channel_type: str | None,
     ) -> dict[str, Any]:
         channel = self._find_channel(arn)
         if authorized is not None:

--- a/moto/kafka/models.py
+++ b/moto/kafka/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -19,23 +19,23 @@ class FakeKafkaCluster(BaseModel):
         account_id: str,
         region_name: str,
         cluster_type: str,
-        tags: Optional[dict[str, str]] = None,
-        broker_node_group_info: Optional[dict[str, Any]] = None,
-        kafka_version: Optional[str] = None,
-        number_of_broker_nodes: Optional[int] = None,
-        configuration_info: Optional[dict[str, Any]] = None,
-        serverless_config: Optional[dict[str, Any]] = None,
-        encryption_info: Optional[dict[str, Any]] = None,
+        tags: dict[str, str] | None = None,
+        broker_node_group_info: dict[str, Any] | None = None,
+        kafka_version: str | None = None,
+        number_of_broker_nodes: int | None = None,
+        configuration_info: dict[str, Any] | None = None,
+        serverless_config: dict[str, Any] | None = None,
+        encryption_info: dict[str, Any] | None = None,
         enhanced_monitoring: str = "DEFAULT",
-        open_monitoring: Optional[dict[str, Any]] = None,
-        logging_info: Optional[dict[str, Any]] = None,
+        open_monitoring: dict[str, Any] | None = None,
+        logging_info: dict[str, Any] | None = None,
         storage_mode: str = "LOCAL",
         current_version: str = "1.0",
-        client_authentication: Optional[dict[str, Any]] = None,
+        client_authentication: dict[str, Any] | None = None,
         state: str = "CREATING",
-        active_operation_arn: Optional[str] = None,
-        zookeeper_connect_string: Optional[str] = None,
-        zookeeper_connect_string_tls: Optional[str] = None,
+        active_operation_arn: str | None = None,
+        zookeeper_connect_string: str | None = None,
+        zookeeper_connect_string_tls: str | None = None,
     ):
         # General attributes
         self.cluster_id = str(uuid.uuid4())
@@ -87,9 +87,9 @@ class KafkaBackend(BaseBackend):
     def create_cluster_v2(
         self,
         cluster_name: str,
-        tags: Optional[dict[str, str]],
-        provisioned: Optional[dict[str, Any]],
-        serverless: Optional[dict[str, Any]],
+        tags: dict[str, str] | None,
+        provisioned: dict[str, Any] | None,
+        serverless: dict[str, Any] | None,
     ) -> tuple[str, str, str, str]:
         if provisioned:
             cluster_type = "PROVISIONED"
@@ -201,11 +201,11 @@ class KafkaBackend(BaseBackend):
 
     def list_clusters_v2(
         self,
-        cluster_name_filter: Optional[str],
-        cluster_type_filter: Optional[str],
-        max_results: Optional[int],
-        next_token: Optional[str],
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        cluster_name_filter: str | None,
+        cluster_type_filter: str | None,
+        max_results: int | None,
+        next_token: str | None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         cluster_info_list = []
         for cluster_arn in self.clusters.keys():
             cluster_info = self.describe_cluster_v2(cluster_arn)
@@ -216,16 +216,16 @@ class KafkaBackend(BaseBackend):
     def create_cluster(
         self,
         broker_node_group_info: dict[str, Any],
-        client_authentication: Optional[dict[str, Any]],
+        client_authentication: dict[str, Any] | None,
         cluster_name: str,
-        configuration_info: Optional[dict[str, Any]] = None,
-        encryption_info: Optional[dict[str, Any]] = None,
+        configuration_info: dict[str, Any] | None = None,
+        encryption_info: dict[str, Any] | None = None,
         enhanced_monitoring: str = "DEFAULT",
-        open_monitoring: Optional[dict[str, Any]] = None,
+        open_monitoring: dict[str, Any] | None = None,
         kafka_version: str = "2.8.1",
-        logging_info: Optional[dict[str, Any]] = None,
+        logging_info: dict[str, Any] | None = None,
         number_of_broker_nodes: int = 1,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
         storage_mode: str = "LOCAL",
     ) -> tuple[str, str, str]:
         new_cluster = FakeKafkaCluster(
@@ -293,9 +293,9 @@ class KafkaBackend(BaseBackend):
 
     def list_clusters(
         self,
-        cluster_name_filter: Optional[str],
-        max_results: Optional[int],
-        next_token: Optional[str],
+        cluster_name_filter: str | None,
+        max_results: int | None,
+        next_token: str | None,
     ) -> list[dict[str, Any]]:
         cluster_info_list = [
             {

--- a/moto/kinesis/exceptions.py
+++ b/moto/kinesis/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -51,13 +49,13 @@ class InvalidRetentionPeriod(InvalidArgumentError):
 
 
 class InvalidDecreaseRetention(InvalidArgumentError):
-    def __init__(self, name: Optional[str], requested: int, existing: int):
+    def __init__(self, name: str | None, requested: int, existing: int):
         msg = f"Requested retention period ({requested} hours) for stream {name} can not be longer than existing retention period ({existing} hours). Use IncreaseRetentionPeriod API."
         super().__init__(msg)
 
 
 class InvalidIncreaseRetention(InvalidArgumentError):
-    def __init__(self, name: Optional[str], requested: int, existing: int):
+    def __init__(self, name: str | None, requested: int, existing: int):
         msg = f"Requested retention period ({requested} hours) for stream {name} can not be shorter than existing retention period ({existing} hours). Use DecreaseRetentionPeriod API."
         super().__init__(msg)
 

--- a/moto/kinesis/models.py
+++ b/moto/kinesis/models.py
@@ -8,7 +8,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from gzip import GzipFile
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -96,8 +96,8 @@ class Shard(BaseModel):
         shard_id: int,
         starting_hash: int,
         ending_hash: int,
-        parent: Optional[str] = None,
-        adjacent_parent: Optional[str] = None,
+        parent: str | None = None,
+        adjacent_parent: str | None = None,
     ):
         self._shard_id = shard_id
         self.starting_hash = starting_hash
@@ -112,7 +112,7 @@ class Shard(BaseModel):
         return f"shardId-{str(self._shard_id).zfill(12)}"
 
     def get_records(
-        self, last_sequence_id: str, limit: Optional[int]
+        self, last_sequence_id: str, limit: int | None
     ) -> tuple[list[Record], int, int]:
         last_sequence_int = int(last_sequence_id)
         results = []
@@ -200,8 +200,8 @@ class Stream(CloudFormationModel):
         self,
         stream_name: str,
         shard_count: int,
-        stream_mode: Optional[dict[str, str]],
-        retention_period_hours: Optional[int],
+        stream_mode: dict[str, str] | None,
+        retention_period_hours: int | None,
         account_id: str,
         region_name: str,
     ):
@@ -213,7 +213,7 @@ class Stream(CloudFormationModel):
         self.shards: dict[str, Shard] = {}
         self.tags: dict[str, str] = {}
         self.status = "ACTIVE"
-        self.shard_count: Optional[int] = None
+        self.shard_count: int | None = None
         self.stream_mode = stream_mode or {"StreamMode": "PROVISIONED"}
         if self.stream_mode.get("StreamMode", "") == "ON_DEMAND":
             shard_count = 4
@@ -221,14 +221,14 @@ class Stream(CloudFormationModel):
         self.retention_period_hours = retention_period_hours or 24
         self.shard_level_metrics: list[str] = []
         self.encryption_type = "NONE"
-        self.key_id: Optional[str] = None
+        self.key_id: str | None = None
         self.consumers: list[Consumer] = []
         self.lambda_event_source_mappings: dict[str, EventSourceMapping] = {}
 
     def delete_consumer(self, consumer_arn: str) -> None:
         self.consumers = [c for c in self.consumers if c.consumer_arn != consumer_arn]
 
-    def get_consumer_by_arn(self, consumer_arn: str) -> Optional[Consumer]:
+    def get_consumer_by_arn(self, consumer_arn: str) -> Consumer | None:
         return next((c for c in self.consumers if c.consumer_arn == consumer_arn), None)
 
     def init_shards(self, shard_count: int) -> None:
@@ -386,7 +386,7 @@ class Stream(CloudFormationModel):
 
     def get_shard_for_key(
         self, partition_key: str, explicit_hash_key: str
-    ) -> Optional[Shard]:
+    ) -> Shard | None:
         if not isinstance(partition_key, str):
             raise InvalidArgumentError("partition_key")
         if len(partition_key) > 256:
@@ -432,7 +432,7 @@ class Stream(CloudFormationModel):
 
         return sequence_number, shard.shard_id
 
-    def to_json(self, shard_limit: Optional[int] = None) -> dict[str, Any]:
+    def to_json(self, shard_limit: int | None = None) -> dict[str, Any]:
         all_shards = list(self.shards.values())
         requested_shards = all_shards[0 : shard_limit or len(all_shards)]
         return {
@@ -600,8 +600,8 @@ class KinesisBackend(BaseBackend):
         self,
         stream_name: str,
         shard_count: int,
-        stream_mode: Optional[dict[str, str]] = None,
-        retention_period_hours: Optional[int] = None,
+        stream_mode: dict[str, str] | None = None,
+        retention_period_hours: int | None = None,
     ) -> Stream:
         if stream_name in self.streams:
             raise ResourceInUseError(stream_name)
@@ -617,7 +617,7 @@ class KinesisBackend(BaseBackend):
         return stream
 
     def describe_stream(
-        self, stream_arn: Optional[str], stream_name: Optional[str]
+        self, stream_arn: str | None, stream_name: str | None
     ) -> Stream:
         if stream_name and stream_name in self.streams:
             return self.streams[stream_name]
@@ -630,23 +630,21 @@ class KinesisBackend(BaseBackend):
         raise StreamNotFoundError(stream_name, self.account_id)  # type: ignore
 
     def describe_stream_summary(
-        self, stream_arn: Optional[str], stream_name: Optional[str]
+        self, stream_arn: str | None, stream_name: str | None
     ) -> Stream:
         return self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
 
     def list_streams(self) -> Iterable[Stream]:
         return self.streams.values()
 
-    def delete_stream(
-        self, stream_arn: Optional[str], stream_name: Optional[str]
-    ) -> Stream:
+    def delete_stream(self, stream_arn: str | None, stream_name: str | None) -> Stream:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         return self.streams.pop(stream.stream_name)
 
     def get_shard_iterator(
         self,
-        stream_arn: Optional[str],
-        stream_name: Optional[str],
+        stream_arn: str | None,
+        stream_name: str | None,
         shard_id: str,
         shard_iterator_type: str,
         starting_sequence_number: int,
@@ -671,7 +669,7 @@ class KinesisBackend(BaseBackend):
         return shard_iterator
 
     def get_records(
-        self, stream_arn: Optional[str], shard_iterator: str, limit: Optional[int]
+        self, stream_arn: str | None, shard_iterator: str, limit: int | None
     ) -> tuple[str, list[Record], int]:
         decomposed = decompose_shard_iterator(shard_iterator)
         stream_name, shard_id, last_sequence_id = decomposed
@@ -810,15 +808,15 @@ class KinesisBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_shards(
-        self, stream_arn: Optional[str], stream_name: Optional[str]
+        self, stream_arn: str | None, stream_name: str | None
     ) -> list[Shard]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         return sorted(stream.shards.values(), key=lambda x: x.shard_id)
 
     def increase_stream_retention_period(
         self,
-        stream_arn: Optional[str],
-        stream_name: Optional[str],
+        stream_arn: str | None,
+        stream_name: str | None,
         retention_period_hours: int,
     ) -> None:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
@@ -836,8 +834,8 @@ class KinesisBackend(BaseBackend):
 
     def decrease_stream_retention_period(
         self,
-        stream_arn: Optional[str],
-        stream_name: Optional[str],
+        stream_arn: str | None,
+        stream_name: str | None,
         retention_period_hours: int,
     ) -> None:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
@@ -857,8 +855,8 @@ class KinesisBackend(BaseBackend):
         self,
         stream_arn: str,
         stream_name: str,
-        exclusive_start_tag_key: Optional[str] = None,
-        limit: Optional[int] = None,
+        exclusive_start_tag_key: str | None = None,
+        limit: int | None = None,
     ) -> dict[str, Any]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
 
@@ -877,15 +875,15 @@ class KinesisBackend(BaseBackend):
 
     def add_tags_to_stream(
         self,
-        stream_arn: Optional[str],
-        stream_name: Optional[str],
+        stream_arn: str | None,
+        stream_name: str | None,
         tags: dict[str, str],
     ) -> None:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         stream.tags.update(tags)
 
     def remove_tags_from_stream(
-        self, stream_arn: Optional[str], stream_name: Optional[str], tag_keys: list[str]
+        self, stream_arn: str | None, stream_name: str | None, tag_keys: list[str]
     ) -> None:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
         for key in tag_keys:
@@ -894,8 +892,8 @@ class KinesisBackend(BaseBackend):
 
     def enable_enhanced_monitoring(
         self,
-        stream_arn: Optional[str],
-        stream_name: Optional[str],
+        stream_arn: str | None,
+        stream_name: str | None,
         shard_level_metrics: list[str],
     ) -> tuple[str, str, list[str], list[str]]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)
@@ -911,8 +909,8 @@ class KinesisBackend(BaseBackend):
 
     def disable_enhanced_monitoring(
         self,
-        stream_arn: Optional[str],
-        stream_name: Optional[str],
+        stream_arn: str | None,
+        stream_name: str | None,
         to_be_disabled: list[str],
     ) -> tuple[str, str, list[str], list[str]]:
         stream = self.describe_stream(stream_arn=stream_arn, stream_name=stream_name)

--- a/moto/kinesis/utils.py
+++ b/moto/kinesis/utils.py
@@ -1,6 +1,6 @@
 import base64
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from .exceptions import InvalidArgumentError
 
@@ -20,7 +20,7 @@ PAGINATION_MODEL = {
 
 
 def compose_new_shard_iterator(
-    stream_name: Optional[str],
+    stream_name: str | None,
     shard: Any,
     shard_iterator_type: str,
     starting_sequence_number: int,
@@ -42,7 +42,7 @@ def compose_new_shard_iterator(
 
 
 def compose_shard_iterator(
-    stream_name: Optional[str], shard: Any, last_sequence_id: int
+    stream_name: str | None, shard: Any, last_sequence_id: int
 ) -> str:
     return encode_method(
         f"{stream_name}:{shard.shard_id}:{last_sequence_id}".encode()

--- a/moto/kinesisanalyticsv2/models.py
+++ b/moto/kinesisanalyticsv2/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -18,12 +18,12 @@ class Application(BaseModel):
         account_id: str,
         region_name: str,
         application_name: str,
-        application_description: Optional[str],
+        application_description: str | None,
         runtime_environment: str,
         service_execution_role: str,
-        application_configuration: Optional[dict[str, Any]],
-        cloud_watch_logging_options: Optional[list[dict[str, str]]],
-        application_mode: Optional[str],
+        application_configuration: dict[str, Any] | None,
+        cloud_watch_logging_options: list[dict[str, str]] | None,
+        application_mode: str | None,
     ):
         self.account_id = account_id
         self.region_name = region_name
@@ -53,7 +53,7 @@ class Application(BaseModel):
         return f"arn:aws:kinesisanalytics:{self.region_name}:{self.account_id}:application/{self.application_name}"
 
     def _generate_logging_options(
-        self, cloud_watch_logging_options: Optional[list[dict[str, str]]]
+        self, cloud_watch_logging_options: list[dict[str, str]] | None
     ) -> list[dict[str, str]] | None:
         cloud_watch_logging_option_descriptions = []
         option_id = f"{str(random.randint(1, 100))}.1"
@@ -249,13 +249,13 @@ class KinesisAnalyticsV2Backend(BaseBackend):
     def create_application(
         self,
         application_name: str,
-        application_description: Optional[str],
+        application_description: str | None,
         runtime_environment: str,
         service_execution_role: str,
-        application_configuration: Optional[dict[str, Any]],
-        cloud_watch_logging_options: Optional[list[dict[str, str]]],
-        tags: Optional[list[dict[str, str]]],
-        application_mode: Optional[str],
+        application_configuration: dict[str, Any] | None,
+        cloud_watch_logging_options: list[dict[str, str]] | None,
+        tags: list[dict[str, str]] | None,
+        application_mode: str | None,
     ) -> dict[str, Any]:
         app = Application(
             account_id=self.account_id,

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import Iterable
 from copy import copy
 from datetime import datetime, timedelta
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -128,7 +128,7 @@ class Alias(CloudFormationModel):
 class Key(CloudFormationModel):
     def __init__(
         self,
-        policy: Optional[str],
+        policy: str | None,
         key_usage: str,
         key_spec: str,
         description: str,
@@ -157,7 +157,7 @@ class Key(CloudFormationModel):
                 "ReplicaKeys": [],
             }
         self.key_rotation_status = False
-        self.deletion_date: Optional[datetime] = None
+        self.deletion_date: datetime | None = None
         self.key_material = generate_master_key()
         self.origin = origin
         self.key_manager = "CUSTOMER"
@@ -239,7 +239,7 @@ class Key(CloudFormationModel):
         return self.id
 
     @property
-    def encryption_algorithms(self) -> Optional[list[str]]:
+    def encryption_algorithms(self) -> list[str] | None:
         if self.key_usage == "SIGN_VERIFY":
             return None
         elif self.key_spec == "SYMMETRIC_DEFAULT":
@@ -352,12 +352,12 @@ class KmsBackend(BaseBackend):
         }
     }
 
-    def __init__(self, region_name: str, account_id: Optional[str] = None):
+    def __init__(self, region_name: str, account_id: str | None = None):
         super().__init__(region_name=region_name, account_id=account_id)  # type: ignore
         self.keys: dict[str, Key] = {}
         self.tagger = TaggingService(key_name="TagKey", value_name="TagValue")
 
-    def _generate_default_keys(self, alias_name: str) -> Optional[str]:
+    def _generate_default_keys(self, alias_name: str) -> str | None:
         """Creates default kms keys"""
         if alias_name in RESERVED_ALIASES:
             key = self.create_key(
@@ -373,11 +373,11 @@ class KmsBackend(BaseBackend):
 
     def create_key(
         self,
-        policy: Optional[str],
+        policy: str | None,
         key_usage: str,
         key_spec: str,
         description: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
         multi_region: bool = False,
         origin: str = "AWS_KMS",
     ) -> Key:
@@ -529,12 +529,12 @@ class KmsBackend(BaseBackend):
             if alias_name in key.aliases:
                 key.aliases.pop(alias_name, None)
 
-    def list_aliases(self, key_id: Optional[str] = None) -> Iterable[Alias]:
+    def list_aliases(self, key_id: str | None = None) -> Iterable[Alias]:
         for key in self.keys.values():
             if not key_id or key.id == key_id:
                 yield from key.aliases.values()
 
-    def get_key_id_from_alias(self, alias_name: str) -> Optional[str]:
+    def get_key_id_from_alias(self, alias_name: str) -> str | None:
         for key in self.keys.values():
             if alias_name in key.aliases:
                 return key.id
@@ -601,7 +601,7 @@ class KmsBackend(BaseBackend):
         self,
         ciphertext_blob: bytes,
         encryption_context: dict[str, str],
-        key_id: Optional[str] = None,
+        key_id: str | None = None,
     ) -> tuple[bytes, str]:
         plaintext, actual_key_id = decrypt(
             master_keys=self.keys,
@@ -834,7 +834,7 @@ class KmsBackend(BaseBackend):
     @paginate(PAGINATION_MODEL)
     def list_key_rotations(
         self, key_id: str, limit: int, next_marker: str
-    ) -> list[dict[str, Union[str, float]]]:
+    ) -> list[dict[str, str | float]]:
         key: Key = self.keys[self.get_key_id(key_id)]
 
         return key.rotations

--- a/moto/lakeformation/models.py
+++ b/moto/lakeformation/models.py
@@ -129,7 +129,7 @@ class PermissionCatalog:
 
 
 class ListPermissionsResourceDatabase:
-    def __init__(self, catalog_id: Optional[str], name: str):
+    def __init__(self, catalog_id: str | None, name: str):
         self.name = name
         self.catalog_id = catalog_id
 
@@ -137,9 +137,9 @@ class ListPermissionsResourceDatabase:
 class ListPermissionsResourceTable:
     def __init__(
         self,
-        catalog_id: Optional[str],
+        catalog_id: str | None,
         database_name: str,
-        name: Optional[str],
+        name: str | None,
         table_wildcard: Optional[
             dict[str, str]
         ],  # Placeholder type, table_wildcard is an empty dict in docs
@@ -162,7 +162,7 @@ class ExcludedColumnNames:
 class ListPermissionsResourceTableWithColumns:
     def __init__(
         self,
-        catalog_id: Optional[str],
+        catalog_id: str | None,
         database_name: str,
         name: str,
         column_names: list[str],
@@ -176,7 +176,7 @@ class ListPermissionsResourceTableWithColumns:
 
 
 class ListPermissionsResourceDataLocation:
-    def __init__(self, catalog_id: Optional[str], resource_arn: str):
+    def __init__(self, catalog_id: str | None, resource_arn: str):
         self.catalog_id = catalog_id
         self.resource_arn = resource_arn
 
@@ -217,13 +217,13 @@ class ListPermissionsResource:
         catalog: Optional[
             dict[str, str]
         ],  # Placeholder type, catalog is an empty dict in docs
-        database: Optional[ListPermissionsResourceDatabase],
-        table: Optional[ListPermissionsResourceTable],
-        table_with_columns: Optional[ListPermissionsResourceTableWithColumns],
-        data_location: Optional[ListPermissionsResourceDataLocation],
-        data_cells_filter: Optional[ListPermissionsResourceDataCellsFilter],
-        lf_tag: Optional[ListPermissionsResourceLFTag],
-        lf_tag_policy: Optional[ListPermissionsResourceLFTagPolicy],
+        database: ListPermissionsResourceDatabase | None,
+        table: ListPermissionsResourceTable | None,
+        table_with_columns: ListPermissionsResourceTableWithColumns | None,
+        data_location: ListPermissionsResourceDataLocation | None,
+        data_cells_filter: ListPermissionsResourceDataCellsFilter | None,
+        lf_tag: ListPermissionsResourceLFTag | None,
+        lf_tag_policy: ListPermissionsResourceLFTagPolicy | None,
     ):
         if (
             catalog is None
@@ -349,9 +349,9 @@ class LakeFormationBackend(BaseBackend):
     def list_permissions(
         self,
         catalog_id: str,
-        principal: Optional[dict[str, str]] = None,
-        resource: Optional[ListPermissionsResource] = None,
-        resource_type: Optional[RessourceType] = None,
+        principal: dict[str, str] | None = None,
+        resource: ListPermissionsResource | None = None,
+        resource_type: RessourceType | None = None,
     ) -> list[dict[str, Any]]:
         """
         No pagination has been implemented yet.

--- a/moto/lexv2models/models.py
+++ b/moto/lexv2models/models.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 
@@ -19,10 +19,10 @@ class FakeBot:
         bot_name: str,
         description: str,
         role_arn: str,
-        data_privacy: Optional[dict[str, Any]],
+        data_privacy: dict[str, Any] | None,
         idle_session_ttl_in_seconds: int,
         bot_type: str,
-        bot_members: Optional[dict[str, Any]],
+        bot_members: dict[str, Any] | None,
     ):
         self.account_id = account_id
         self.region_name = region_name
@@ -57,9 +57,9 @@ class FakeBotAlias:
         bot_alias_name: str,
         description: str,
         bot_version: str,
-        bot_alias_locale_settings: Optional[dict[str, Any]],
-        conversation_log_settings: Optional[dict[str, Any]],
-        sentiment_analysis_settings: Optional[dict[str, Any]],
+        bot_alias_locale_settings: dict[str, Any] | None,
+        conversation_log_settings: dict[str, Any] | None,
+        sentiment_analysis_settings: dict[str, Any] | None,
         bot_id: str,
     ):
         self.account_id = account_id
@@ -107,12 +107,12 @@ class LexModelsV2Backend(BaseBackend):
         bot_name: str,
         description: str,
         role_arn: str,
-        data_privacy: Optional[dict[str, Any]],
+        data_privacy: dict[str, Any] | None,
         idle_session_ttl_in_seconds: int,
-        bot_tags: Optional[dict[str, str]],
-        test_bot_alias_tags: Optional[dict[str, str]],
+        bot_tags: dict[str, str] | None,
+        test_bot_alias_tags: dict[str, str] | None,
         bot_type: str,
-        bot_members: Optional[dict[str, Any]],
+        bot_members: dict[str, Any] | None,
     ) -> dict[str, Any]:
         bot = FakeBot(
             account_id=self.account_id,
@@ -183,10 +183,10 @@ class LexModelsV2Backend(BaseBackend):
         bot_name: str,
         description: str,
         role_arn: str,
-        data_privacy: Optional[dict[str, Any]],
+        data_privacy: dict[str, Any] | None,
         idle_session_ttl_in_seconds: int,
         bot_type: str,
-        bot_members: Optional[dict[str, Any]],
+        bot_members: dict[str, Any] | None,
     ) -> dict[str, Any]:
         bot = self.bots[bot_id]
 
@@ -239,11 +239,11 @@ class LexModelsV2Backend(BaseBackend):
         bot_alias_name: str,
         description: str,
         bot_version: str,
-        bot_alias_locale_settings: Optional[dict[str, Any]],
-        conversation_log_settings: Optional[dict[str, Any]],
-        sentiment_analysis_settings: Optional[dict[str, Any]],
+        bot_alias_locale_settings: dict[str, Any] | None,
+        conversation_log_settings: dict[str, Any] | None,
+        sentiment_analysis_settings: dict[str, Any] | None,
         bot_id: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> dict[str, Any]:
         bot_alias = FakeBotAlias(
             self.account_id,
@@ -301,9 +301,9 @@ class LexModelsV2Backend(BaseBackend):
         bot_alias_name: str,
         description: str,
         bot_version: str,
-        bot_alias_locale_settings: Optional[dict[str, Any]],
-        conversation_log_settings: Optional[dict[str, Any]],
-        sentiment_analysis_settings: Optional[dict[str, Any]],
+        bot_alias_locale_settings: dict[str, Any] | None,
+        conversation_log_settings: dict[str, Any] | None,
+        sentiment_analysis_settings: dict[str, Any] | None,
         bot_id: str,
     ) -> dict[str, Any]:
         ba = self.bot_aliases[bot_alias_id]
@@ -333,7 +333,7 @@ class LexModelsV2Backend(BaseBackend):
 
     def list_bot_aliases(
         self, bot_id: str, max_results: int
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], str | None]:
         bot_alias_summaries = [
             {
                 "botAliasId": ba.id,

--- a/moto/logs/exceptions.py
+++ b/moto/logs/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.exceptions import JsonRESTError
 
@@ -8,7 +8,7 @@ class LogsClientError(JsonRESTError):
 
 
 class ResourceNotFoundException(LogsClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 400
         super().__init__(
             "ResourceNotFoundException",
@@ -19,9 +19,9 @@ class ResourceNotFoundException(LogsClientError):
 class InvalidParameterException(LogsClientError):
     def __init__(
         self,
-        msg: Optional[str] = None,
-        constraint: Optional[str] = None,
-        parameter: Optional[str] = None,
+        msg: str | None = None,
+        constraint: str | None = None,
+        parameter: str | None = None,
         value: Any = None,
     ):
         self.code = 400

--- a/moto/logs/logs_query/query_parser.py
+++ b/moto/logs/logs_query/query_parser.py
@@ -1,11 +1,9 @@
-from typing import Optional
-
 from moto.utilities.tokenizer import GenericTokenizer
 
 
 class ParsedQuery:
     def __init__(self) -> None:
-        self.limit: Optional[int] = None
+        self.limit: int | None = None
         self.fields: list[str] = []
         self.sort: list[tuple[str, str]] = []
 

--- a/moto/logs/metric_filters.py
+++ b/moto/logs/metric_filters.py
@@ -1,9 +1,9 @@
-from typing import Any, Optional
+from typing import Any
 
 
 def find_metric_transformation_by_name(
     metric_transformations: list[dict[str, Any]], metric_name: str
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     for metric in metric_transformations:
         if metric["metricName"] == metric_name:
             return metric
@@ -12,7 +12,7 @@ def find_metric_transformation_by_name(
 
 def find_metric_transformation_by_namespace(
     metric_transformations: list[dict[str, Any]], metric_namespace: str
-) -> Optional[dict[str, Any]]:
+) -> dict[str, Any] | None:
     for metric in metric_transformations:
         if metric["metricNamespace"] == metric_namespace:
             return metric
@@ -41,10 +41,10 @@ class MetricFilters:
 
     def get_matching_filters(
         self,
-        prefix: Optional[str] = None,
-        log_group_name: Optional[str] = None,
-        metric_name: Optional[str] = None,
-        metric_namespace: Optional[str] = None,
+        prefix: str | None = None,
+        log_group_name: str | None = None,
+        metric_name: str | None = None,
+        metric_namespace: str | None = None,
     ) -> list[dict[str, Any]]:
         result: list[dict[str, Any]] = []
         for f in self.metric_filters:
@@ -76,7 +76,7 @@ class MetricFilters:
         return result
 
     def delete_filter(
-        self, filter_name: Optional[str] = None, log_group_name: Optional[str] = None
+        self, filter_name: str | None = None, log_group_name: str | None = None
     ) -> list[dict[str, Any]]:
         for f in self.metric_filters:
             if f["filterName"] == filter_name and f["logGroupName"] == log_group_name:

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Iterable
 from datetime import datetime, timedelta
 from gzip import compress as gzip_compress
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -37,7 +37,7 @@ class Destination(BaseModel):
         destination_name: str,
         role_arn: str,
         target_arn: str,
-        access_policy: Optional[str] = None,
+        access_policy: str | None = None,
     ):
         self.access_policy = access_policy
         self.arn = f"arn:{get_partition(region)}:logs:{region}:{account_id}:destination:{destination_name}"
@@ -136,7 +136,7 @@ class LogStream(BaseModel):
         self.creation_time = int(unix_time_millis())
         self.first_event_timestamp = None
         self.last_event_timestamp = None
-        self.last_ingestion_time: Optional[int] = None
+        self.last_ingestion_time: int | None = None
         self.log_stream_name = name
         self.stored_bytes = 0
         # I'm  guessing this is token needed for sequenceToken by put_events
@@ -257,9 +257,9 @@ class LogStream(BaseModel):
         start_time: str,
         end_time: str,
         limit: int,
-        next_token: Optional[str],
+        next_token: str | None,
         start_from_head: str,
-    ) -> tuple[list[dict[str, Any]], Optional[str], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], str | None, str | None]:
         if limit is None:
             limit = 10000
 
@@ -273,8 +273,8 @@ class LogStream(BaseModel):
             return True
 
         def get_index_and_direction_from_token(
-            token: Optional[str],
-        ) -> tuple[Optional[str], int]:
+            token: str | None,
+        ) -> tuple[str | None, int]:
             if token is not None:
                 try:
                     return token[0], int(token[2:])
@@ -471,8 +471,8 @@ class LogGroup(CloudFormationModel):
         log_stream_name_prefix: str,
         order_by: str,
         limit: int,
-        next_token: Optional[str] = None,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        next_token: str | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         # responses only log_stream_name, creation_time, arn, stored_bytes when no events are stored.
 
         log_streams = [
@@ -533,9 +533,9 @@ class LogGroup(CloudFormationModel):
         start_time: str,
         end_time: str,
         limit: int,
-        next_token: Optional[str],
+        next_token: str | None,
         start_from_head: str,
-    ) -> tuple[list[dict[str, Any]], Optional[str], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], str | None, str | None]:
         if log_stream_name not in self.streams:
             raise ResourceNotFoundException()
         stream = self.streams[log_stream_name]
@@ -553,11 +553,11 @@ class LogGroup(CloudFormationModel):
         log_stream_names: list[str],
         start_time: int,
         end_time: int,
-        limit: Optional[int],
-        next_token: Optional[str],
+        limit: int | None,
+        next_token: str | None,
         filter_pattern: str,
         interleaved: bool,
-    ) -> tuple[list[dict[str, Any]], Optional[str], list[dict[str, Any]]]:
+    ) -> tuple[list[dict[str, Any]], str | None, list[dict[str, Any]]]:
         if not limit:
             limit = 10000
         streams = [
@@ -624,7 +624,7 @@ class LogGroup(CloudFormationModel):
             log_group["kmsKeyId"] = self.kms_key_id
         return log_group
 
-    def set_retention_policy(self, retention_in_days: Optional[str]) -> None:
+    def set_retention_policy(self, retention_in_days: str | None) -> None:
         self.retention_in_days = retention_in_days
 
     def describe_subscription_filters(self) -> Iterable[SubscriptionFilter]:
@@ -777,10 +777,10 @@ class DeliveryDestination(BaseModel):
         account_id: str,
         region: str,
         name: str,
-        output_format: Optional[str],
+        output_format: str | None,
         delivery_destination_configuration: dict[str, str],
-        tags: Optional[dict[str, str]],
-        policy: Optional[str] = None,
+        tags: dict[str, str] | None,
+        policy: str | None = None,
     ):
         self.name = name
         self.output_format = output_format
@@ -819,7 +819,7 @@ class DeliverySource(BaseModel):
         name: str,
         resource_arn: str,
         log_type: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ):
         res_arns = []
         res_arns.append(resource_arn)
@@ -851,10 +851,10 @@ class Delivery(BaseModel):
         delivery_source_name: str,
         delivery_destination_arn: str,
         destination_type: str,
-        record_fields: Optional[list[str]],
-        field_delimiter: Optional[str],
-        s3_delivery_configuration: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        record_fields: list[str] | None,
+        field_delimiter: str | None,
+        s3_delivery_configuration: dict[str, Any] | None,
+        tags: dict[str, str] | None,
     ):
         self.id = mock_random.get_random_string(length=16)
         self.arn = f"arn:aws:logs:{region}:{account_id}:delivery:{self.id}"
@@ -974,7 +974,7 @@ class LogsBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_log_groups(
-        self, log_group_name_prefix: Optional[str] = None
+        self, log_group_name_prefix: str | None = None
     ) -> list[LogGroup]:
         groups = [
             group
@@ -1016,8 +1016,8 @@ class LogsBackend(BaseBackend):
         return
 
     def describe_destinations(
-        self, destination_name_prefix: str, limit: int, next_token: Optional[int] = None
-    ) -> tuple[list[dict[str, Any]], Optional[int]]:
+        self, destination_name_prefix: str, limit: int, next_token: int | None = None
+    ) -> tuple[list[dict[str, Any]], int | None]:
         if limit > 50:
             raise InvalidParameterException(
                 constraint="Member must have value less than or equal to 50",
@@ -1073,9 +1073,9 @@ class LogsBackend(BaseBackend):
         log_group_name: str,
         log_group_id: str,
         log_stream_name_prefix: str,
-        next_token: Optional[str],
+        next_token: str | None,
         order_by: str,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], str | None]:
         log_group = self._find_log_group(log_group_id, log_group_name=log_group_name)
         if limit > 50:
             raise InvalidParameterException(
@@ -1145,9 +1145,9 @@ class LogsBackend(BaseBackend):
         start_time: str,
         end_time: str,
         limit: int,
-        next_token: Optional[str],
+        next_token: str | None,
         start_from_head: str,
-    ) -> tuple[list[dict[str, Any]], Optional[str], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], str | None, str | None]:
         log_group = self._find_log_group(
             log_group_id=log_group_id, log_group_name=log_group_name
         )
@@ -1167,11 +1167,11 @@ class LogsBackend(BaseBackend):
         log_stream_names: list[str],
         start_time: int,
         end_time: int,
-        limit: Optional[int],
-        next_token: Optional[str],
+        limit: int | None,
+        next_token: str | None,
         filter_pattern: str,
         interleaved: bool,
-    ) -> tuple[list[dict[str, Any]], Optional[str], list[dict[str, Any]]]:
+    ) -> tuple[list[dict[str, Any]], str | None, list[dict[str, Any]]]:
         """
         The following filter patterns are currently supported: Single Terms, Multiple Terms, Exact Phrases.
         If the pattern is not supported, all events are returned.
@@ -1274,10 +1274,10 @@ class LogsBackend(BaseBackend):
 
     def describe_metric_filters(
         self,
-        prefix: Optional[str] = None,
-        log_group_name: Optional[str] = None,
-        metric_name: Optional[str] = None,
-        metric_namespace: Optional[str] = None,
+        prefix: str | None = None,
+        log_group_name: str | None = None,
+        metric_name: str | None = None,
+        metric_namespace: str | None = None,
     ) -> list[dict[str, Any]]:
         filters = self.filters.get_matching_filters(
             prefix, log_group_name, metric_name, metric_namespace
@@ -1285,7 +1285,7 @@ class LogsBackend(BaseBackend):
         return filters
 
     def delete_metric_filter(
-        self, filter_name: Optional[str] = None, log_group_name: Optional[str] = None
+        self, filter_name: str | None = None, log_group_name: str | None = None
     ) -> None:
         self.filters.delete_filter(filter_name, log_group_name)
 
@@ -1393,7 +1393,7 @@ class LogsBackend(BaseBackend):
         return query_id
 
     def describe_queries(
-        self, log_stream_name: str, status: Optional[str]
+        self, log_stream_name: str, status: str | None
     ) -> list[LogQuery]:
         """
         Pagination is not yet implemented
@@ -1507,9 +1507,9 @@ class LogsBackend(BaseBackend):
         self.tagger.untag_resource_using_names(arn, tag_keys)
 
     def _find_log_group(
-        self, log_group_id: Optional[str] = None, log_group_name: Optional[str] = None
+        self, log_group_id: str | None = None, log_group_name: str | None = None
     ) -> LogGroup:
-        log_group: Optional[LogGroup] = None
+        log_group: LogGroup | None = None
         if log_group_name:
             log_group = self.groups.get(log_group_name)
         elif log_group_id:
@@ -1531,9 +1531,9 @@ class LogsBackend(BaseBackend):
     def put_delivery_destination(
         self,
         name: str,
-        output_format: Optional[str],
+        output_format: str | None,
         delivery_destination_configuration: dict[str, str],
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> DeliveryDestination:
         if output_format and output_format not in [
             "w3c",
@@ -1676,10 +1676,10 @@ class LogsBackend(BaseBackend):
         self,
         delivery_source_name: str,
         delivery_destination_arn: str,
-        record_fields: Optional[list[str]],
-        field_delimiter: Optional[str],
-        s3_delivery_configuration: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        record_fields: list[str] | None,
+        field_delimiter: str | None,
+        s3_delivery_configuration: dict[str, Any] | None,
+        tags: dict[str, str] | None,
     ) -> Delivery:
         if delivery_source_name not in self.delivery_sources:
             raise ResourceNotFoundException(

--- a/moto/logs/responses.py
+++ b/moto/logs/responses.py
@@ -1,7 +1,7 @@
 import json
 import re
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.responses import BaseResponse
 
@@ -19,7 +19,7 @@ def validate_param(
     param_value: str,
     constraint: str,
     constraint_expression: Callable[[str], bool],
-    pattern: Optional[str] = None,
+    pattern: str | None = None,
 ) -> None:
     try:
         assert constraint_expression(param_value)
@@ -51,7 +51,7 @@ class LogsResponse(BaseResponse):
         param: str,
         constraint: str,
         constraint_expression: Callable[[str], bool],
-        pattern: Optional[str] = None,
+        pattern: str | None = None,
     ) -> Any:
         param_value = self._get_param(param)
         validate_param(param, param_value, constraint, constraint_expression, pattern)

--- a/moto/macie2/models.py
+++ b/moto/macie2/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -60,9 +60,9 @@ class MacieBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.invitations: dict[str, Invitation] = {}
         self.members: dict[str, Member] = {}
-        self.administrator_account: Optional[Member] = None
-        self.organization_admin_account_id: Optional[str] = None
-        self.macie_session: Optional[dict[str, Any]] = {
+        self.administrator_account: Member | None = None
+        self.organization_admin_account_id: str | None = None
+        self.macie_session: dict[str, Any] | None = {
             "createdAt": utcnow(),
             "findingPublishingFrequency": "FIFTEEN_MINUTES",
             "serviceRole": f"arn:aws:iam::{account_id}:role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie",
@@ -117,7 +117,7 @@ class MacieBackend(BaseBackend):
     def list_members(self) -> list[Member]:
         return list(self.members.values())
 
-    def get_administrator_account(self) -> Optional[Member]:
+    def get_administrator_account(self) -> Member | None:
         return self.administrator_account
 
     def delete_member(self, member_account_id: str) -> None:

--- a/moto/managedblockchain/models.py
+++ b/moto/managedblockchain/models.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -61,7 +61,7 @@ class ManagedBlockchainNetwork(BaseModel):
         voting_policy: dict[str, Any],
         member_configuration: dict[str, Any],
         region: str,
-        description: Optional[str] = None,
+        description: str | None = None,
     ):
         self.creationdate = utcnow()
         self.id = network_id
@@ -94,7 +94,7 @@ class ManagedBlockchainNetwork(BaseModel):
         return self.creationdate.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
 
     @property
-    def network_description(self) -> Optional[str]:
+    def network_description(self) -> str | None:
         return self.description
 
     @property
@@ -126,7 +126,7 @@ class ManagedBlockchainProposal(BaseModel):
         network_expiration: float,
         network_threshold: float,
         network_threshold_comp: str,
-        description: Optional[str] = None,
+        description: str | None = None,
     ):
         # In general, passing all values instead of creating
         # an apparatus to look them up
@@ -217,7 +217,7 @@ class ManagedBlockchainNetworkSummary(BaseModel):
         self,
         networkid: str,
         networkname: str,
-        networkdescription: Optional[str],
+        networkdescription: str | None,
         networkframework: str,
         networkframeworkversion: str,
         networkcreationdate: str,
@@ -241,7 +241,7 @@ class ManagedBlockchainInvitation(BaseModel):
         networkframeworkversion: str,
         networkcreationdate: str,
         region: str,
-        networkdescription: Optional[str] = None,
+        networkdescription: str | None = None,
     ):
         self.id = invitation_id
         self.network_summary = ManagedBlockchainNetworkSummary(
@@ -375,7 +375,7 @@ class ManagedBlockchainBackend(BaseBackend):
         frameworkconfiguration: dict[str, Any],
         voting_policy: dict[str, Any],
         member_configuration: dict[str, Any],
-        description: Optional[str] = None,
+        description: str | None = None,
     ) -> dict[str, str]:
         # Check framework
         if framework not in FRAMEWORKS:
@@ -434,7 +434,7 @@ class ManagedBlockchainBackend(BaseBackend):
         networkid: str,
         memberid: str,
         actions: dict[str, Any],
-        description: Optional[str] = None,
+        description: str | None = None,
     ) -> dict[str, str]:
         # Check if network exists
         if networkid not in self.networks:
@@ -829,7 +829,7 @@ class ManagedBlockchainBackend(BaseBackend):
         return {"NodeId": node_id}
 
     def list_nodes(
-        self, networkid: str, memberid: str, status: Optional[str] = None
+        self, networkid: str, memberid: str, status: str | None = None
     ) -> list[ManagedBlockchainNode]:
         if networkid not in self.networks:
             raise ResourceNotFoundException(

--- a/moto/managedblockchain/utils.py
+++ b/moto/managedblockchain/utils.py
@@ -1,7 +1,7 @@
 import json
 import re
 import string
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from moto.moto_api._internal import mock_random as random
@@ -83,7 +83,7 @@ def member_name_exist_in_network(
 
 
 def number_of_members_in_network(
-    members: dict[str, Any], networkid: str, member_status: Optional[str] = None
+    members: dict[str, Any], networkid: str, member_status: str | None = None
 ) -> int:
     return len(
         [
@@ -123,7 +123,7 @@ def get_node_id() -> str:
 
 
 def number_of_nodes_in_member(
-    nodes: dict[str, Any], memberid: str, node_status: Optional[str] = None
+    nodes: dict[str, Any], memberid: str, node_status: str | None = None
 ) -> int:
     return len(
         [

--- a/moto/mediaconnect/models.py
+++ b/moto/mediaconnect/models.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -20,10 +20,10 @@ class Flow(BaseModel):
         self.source_failover_config = kwargs.get("source_failover_config", {})
         self.sources = kwargs.get("sources", [])
         self.vpc_interfaces = kwargs.get("vpc_interfaces", [])
-        self.status: Optional[str] = (
+        self.status: str | None = (
             "STANDBY"  # one of 'STANDBY'|'ACTIVE'|'UPDATING'|'DELETING'|'STARTING'|'STOPPING'|'ERROR'
         )
-        self._previous_status: Optional[str] = None
+        self._previous_status: str | None = None
         self.description = "A Moto test flow"
         self.flow_arn = f"arn:{get_partition(region_name)}:mediaconnect:{region_name}:{account_id}:flow:{self.id}:{self.name}"
         self.egress_ip = "127.0.0.1"
@@ -33,7 +33,7 @@ class Flow(BaseModel):
                 self.source,
             ]
 
-    def to_dict(self, include: Optional[list[str]] = None) -> dict[str, Any]:
+    def to_dict(self, include: list[str] | None = None) -> dict[str, Any]:
         data = {
             "availabilityZone": self.availability_zone,
             "description": self.description,
@@ -77,7 +77,7 @@ class MediaConnectBackend(BaseBackend):
 
     def _add_source_details(
         self,
-        source: Optional[dict[str, Any]],
+        source: dict[str, Any] | None,
         flow_id: str,
         ingest_ip: str = "127.0.0.1",
     ) -> None:
@@ -90,7 +90,7 @@ class MediaConnectBackend(BaseBackend):
                 source["ingestIp"] = ingest_ip
 
     def _add_entitlement_details(
-        self, entitlement: Optional[dict[str, Any]], entitlement_id: str
+        self, entitlement: dict[str, Any] | None, entitlement_id: str
     ) -> None:
         if entitlement:
             entitlement["entitlementArn"] = (
@@ -127,7 +127,7 @@ class MediaConnectBackend(BaseBackend):
         source_failover_config: dict[str, Any],
         sources: list[dict[str, Any]],
         vpc_interfaces: list[dict[str, Any]],
-        maintenance: Optional[list[dict[str, Any]]] = None,
+        maintenance: list[dict[str, Any]] | None = None,
     ) -> Flow:
         flow = Flow(
             account_id=self.account_id,
@@ -146,7 +146,7 @@ class MediaConnectBackend(BaseBackend):
         self._flows[flow.flow_arn] = flow
         return flow
 
-    def list_flows(self, max_results: Optional[int]) -> list[dict[str, Any]]:
+    def list_flows(self, max_results: int | None) -> list[dict[str, Any]]:
         """
         Pagination is not yet implemented
         """
@@ -318,11 +318,11 @@ class MediaConnectBackend(BaseBackend):
         stream_id: str,
         vpc_interface_name: str,
         whitelist_cidr: str,
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         if flow_arn not in self._flows:
             raise NotFoundException(message=f"flow with arn={flow_arn} not found")
         flow = self._flows[flow_arn]
-        source: Optional[dict[str, Any]] = next(
+        source: dict[str, Any] | None = next(
             iter(
                 [source for source in flow.sources if source["sourceArn"] == source_arn]
             ),

--- a/moto/mediastore/exceptions.py
+++ b/moto/mediastore/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -8,7 +6,7 @@ class MediaStoreClientError(JsonRESTError):
 
 
 class ContainerNotFoundException(MediaStoreClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 400
         super().__init__(
             "ContainerNotFoundException",
@@ -17,7 +15,7 @@ class ContainerNotFoundException(MediaStoreClientError):
 
 
 class ResourceNotFoundException(MediaStoreClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 400
         super().__init__(
             "ResourceNotFoundException", msg or "The specified container does not exist"
@@ -25,7 +23,7 @@ class ResourceNotFoundException(MediaStoreClientError):
 
 
 class PolicyNotFoundException(MediaStoreClientError):
-    def __init__(self, msg: Optional[str] = None):
+    def __init__(self, msg: str | None = None):
         self.code = 400
         super().__init__(
             "PolicyNotFoundException",

--- a/moto/mediastore/models.py
+++ b/moto/mediastore/models.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import date
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -20,12 +20,12 @@ class Container(BaseModel):
         self.endpoint = kwargs.get("endpoint")
         self.status = kwargs.get("status")
         self.creation_time = kwargs.get("creation_time")
-        self.lifecycle_policy: Optional[str] = None
-        self.policy: Optional[str] = None
-        self.metric_policy: Optional[str] = None
+        self.lifecycle_policy: str | None = None
+        self.policy: str | None = None
+        self.metric_policy: str | None = None
         self.tags = kwargs.get("tags")
 
-    def to_dict(self, exclude: Optional[list[str]] = None) -> dict[str, Any]:
+    def to_dict(self, exclude: list[str] | None = None) -> dict[str, Any]:
         data = {
             "ARN": self.arn,
             "Name": self.name,
@@ -76,7 +76,7 @@ class MediaStoreBackend(BaseBackend):
         """
         return [c.to_dict() for c in self._containers.values()]
 
-    def list_tags_for_resource(self, name: str) -> Optional[dict[str, str]]:
+    def list_tags_for_resource(self, name: str) -> dict[str, str] | None:
         if name not in self._containers:
             raise ContainerNotFoundException()
         tags = self._containers[name].tags

--- a/moto/memorydb/models.py
+++ b/moto/memorydb/models.py
@@ -2,7 +2,7 @@
 
 import copy
 import random
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -147,19 +147,19 @@ class MemoryDBCluster(BaseModel):
 
     def update(
         self,
-        description: Optional[str],
-        security_group_ids: Optional[list[str]],
-        maintenance_window: Optional[str],
-        sns_topic_arn: Optional[str],
-        sns_topic_status: Optional[str],
-        parameter_group_name: Optional[str],
-        snapshot_window: Optional[str],
-        snapshot_retention_limit: Optional[int],
-        node_type: Optional[str],
-        engine_version: Optional[str],
-        replica_configuration: Optional[dict[str, int]],
-        shard_configuration: Optional[dict[str, int]],
-        acl_name: Optional[str],
+        description: str | None,
+        security_group_ids: list[str] | None,
+        maintenance_window: str | None,
+        sns_topic_arn: str | None,
+        sns_topic_status: str | None,
+        parameter_group_name: str | None,
+        snapshot_window: str | None,
+        snapshot_retention_limit: int | None,
+        node_type: str | None,
+        engine_version: str | None,
+        replica_configuration: dict[str, int] | None,
+        shard_configuration: dict[str, int] | None,
+        acl_name: str | None,
     ) -> None:
         if description is not None:
             self.description = description
@@ -236,7 +236,7 @@ class MemoryDBSubnetGroup(BaseModel):
         subnet_group_name: str,
         description: str,
         subnet_ids: list[str],
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.ec2_backend = ec2_backend
         self.subnet_group_name = subnet_group_name
@@ -277,9 +277,9 @@ class MemoryDBSnapshot(BaseModel):
         region_name: str,
         cluster: MemoryDBCluster,
         snapshot_name: str,
-        kms_key_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        source: Optional[str],
+        kms_key_id: str | None,
+        tags: list[dict[str, str]] | None,
+        source: str | None,
     ):
         self.cluster = copy.copy(cluster)
         self.cluster_name = self.cluster.cluster_name
@@ -438,7 +438,7 @@ class MemoryDBBackend(BaseBackend):
         subnet_group_name: str,
         description: str,
         subnet_ids: list[str],
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> MemoryDBSubnetGroup:
         if subnet_group_name in self.subnet_groups:
             raise SubnetGroupAlreadyExistsFault(
@@ -462,8 +462,8 @@ class MemoryDBBackend(BaseBackend):
         self,
         cluster_name: str,
         snapshot_name: str,
-        kms_key_id: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        kms_key_id: str | None = None,
+        tags: list[dict[str, str]] | None = None,
         source: str = "manual",
     ) -> MemoryDBSnapshot:
         if cluster_name not in self.clusters:
@@ -489,7 +489,7 @@ class MemoryDBBackend(BaseBackend):
         return snapshot
 
     def describe_clusters(
-        self, cluster_name: Optional[str] = None
+        self, cluster_name: str | None = None
     ) -> list[MemoryDBCluster]:
         if cluster_name:
             if cluster_name in self.clusters:
@@ -502,9 +502,9 @@ class MemoryDBBackend(BaseBackend):
 
     def describe_snapshots(
         self,
-        cluster_name: Optional[str] = None,
-        snapshot_name: Optional[str] = None,
-        source: Optional[str] = None,
+        cluster_name: str | None = None,
+        snapshot_name: str | None = None,
+        source: str | None = None,
     ) -> list[MemoryDBSnapshot]:
         sources = ["automated", "manual"] if source is None else [source]
 
@@ -610,19 +610,19 @@ class MemoryDBBackend(BaseBackend):
     def update_cluster(
         self,
         cluster_name: str,
-        description: Optional[str],
-        security_group_ids: Optional[list[str]],
-        maintenance_window: Optional[str],
-        sns_topic_arn: Optional[str],
-        sns_topic_status: Optional[str],
-        parameter_group_name: Optional[str],
-        snapshot_window: Optional[str],
-        snapshot_retention_limit: Optional[int],
-        node_type: Optional[str],
-        engine_version: Optional[str],
-        replica_configuration: Optional[dict[str, int]],
-        shard_configuration: Optional[dict[str, int]],
-        acl_name: Optional[str],
+        description: str | None,
+        security_group_ids: list[str] | None,
+        maintenance_window: str | None,
+        sns_topic_arn: str | None,
+        sns_topic_status: str | None,
+        parameter_group_name: str | None,
+        snapshot_window: str | None,
+        snapshot_retention_limit: int | None,
+        node_type: str | None,
+        engine_version: str | None,
+        replica_configuration: dict[str, int] | None,
+        shard_configuration: dict[str, int] | None,
+        acl_name: str | None,
     ) -> MemoryDBCluster:
         if cluster_name in self.clusters:
             cluster = self.clusters[cluster_name]
@@ -645,7 +645,7 @@ class MemoryDBBackend(BaseBackend):
         raise ClusterNotFoundFault(msg="Cluster not found.")
 
     def delete_cluster(
-        self, cluster_name: str, final_snapshot_name: Optional[str]
+        self, cluster_name: str, final_snapshot_name: str | None
     ) -> MemoryDBCluster:
         if cluster_name in self.clusters:
             cluster = self.clusters[cluster_name]

--- a/moto/moto_api/_internal/managed_state_model.py
+++ b/moto/moto_api/_internal/managed_state_model.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import Optional
 
 from moto.moto_api import state_manager
 
@@ -9,7 +8,7 @@ class ManagedState:
     Subclass this class to configure state-transitions
     """
 
-    def __init__(self, model_name: str, transitions: list[tuple[Optional[str], str]]):
+    def __init__(self, model_name: str, transitions: list[tuple[str | None, str]]):
         # Indicate the possible transitions for this model
         # Example: [(initializing,queued), (queued, starting), (starting, ready)]
         self._transitions = transitions
@@ -29,7 +28,7 @@ class ManagedState:
         self._tick += 1
 
     @property
-    def status(self) -> Optional[str]:
+    def status(self) -> str | None:
         """
         Transitions the status as appropriate before returning
         """
@@ -56,12 +55,12 @@ class ManagedState:
     def status(self, value: str) -> None:
         self._status = value
 
-    def _get_next_status(self, previous: Optional[str]) -> Optional[str]:
+    def _get_next_status(self, previous: str | None) -> str | None:
         return next(
             (nxt for prev, nxt in self._transitions if previous == prev), previous
         )
 
-    def _get_last_status(self, previous: Optional[str]) -> Optional[str]:
+    def _get_last_status(self, previous: str | None) -> str | None:
         next_state = self._get_next_status(previous)
         while next_state != previous:
             previous = next_state

--- a/moto/moto_api/_internal/models.py
+++ b/moto/moto_api/_internal/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -98,11 +98,11 @@ class MotoAPIBackend(BaseBackend):
 
     def set_rds_data_result(
         self,
-        records: Optional[list[list[dict[str, Any]]]],
-        column_metadata: Optional[list[dict[str, Any]]],
-        nr_of_records_updated: Optional[int],
-        generated_fields: Optional[list[dict[str, Any]]],
-        formatted_records: Optional[str],
+        records: list[list[dict[str, Any]]] | None,
+        column_metadata: list[dict[str, Any]] | None,
+        nr_of_records_updated: int | None,
+        generated_fields: list[dict[str, Any]] | None,
+        formatted_records: str | None,
         account_id: str,
         region: str,
     ) -> None:
@@ -132,7 +132,7 @@ class MotoAPIBackend(BaseBackend):
 
     def set_inspector2_findings_result(
         self,
-        results: Optional[list[list[dict[str, Any]]]],
+        results: list[list[dict[str, Any]]] | None,
         account_id: str,
         region: str,
     ) -> None:
@@ -143,7 +143,7 @@ class MotoAPIBackend(BaseBackend):
 
     def set_timestream_result(
         self,
-        query: Optional[str],
+        query: str | None,
         query_results: list[dict[str, Any]],
         account_id: str,
         region: str,

--- a/moto/moto_api/_internal/recorder/models.py
+++ b/moto/moto_api/_internal/recorder/models.py
@@ -2,7 +2,7 @@ import base64
 import io
 import json
 import os
-from typing import Any, Optional, Union
+from typing import Any
 from urllib.parse import urlparse
 
 import requests
@@ -15,7 +15,7 @@ class Recorder:
         self._os_enabled = bool(os.environ.get("MOTO_ENABLE_RECORDING", False))
         self._user_enabled = self._os_enabled
 
-    def _record_request(self, request: Any, body: Optional[bytes] = None) -> None:
+    def _record_request(self, request: Any, body: bytes | None = None) -> None:
         """
         Record the current request
         """
@@ -90,7 +90,7 @@ class Recorder:
     def stop_recording(self) -> None:
         self._user_enabled = False
 
-    def upload_recording(self, data: Union[str, bytes]) -> None:
+    def upload_recording(self, data: str | bytes) -> None:
         """
         Replaces the current log. Remember to replay the recording afterwards.
         """
@@ -108,7 +108,7 @@ class Recorder:
         with open(filepath) as file:
             return file.read()
 
-    def replay_recording(self, target_host: Optional[str] = None) -> None:
+    def replay_recording(self, target_host: str | None = None) -> None:
         """
         Replays the current log, i.e. replay all requests that were made after the recorder was started.
         Download the recording if you want to manually verify the correct requests will be replayed.

--- a/moto/moto_proxy/utils.py
+++ b/moto/moto_proxy/utils.py
@@ -1,12 +1,11 @@
 import io
-from typing import Optional
 
 import multipart
 
 
 def get_body_from_form_data(
     body: bytes, boundary: str
-) -> tuple[Optional[bytes], dict[str, str]]:
+) -> tuple[bytes | None, dict[str, str]]:
     body_stream = io.BytesIO(body)
     parser = multipart.MultipartParser(body_stream, boundary=boundary)
 

--- a/moto/moto_server/threaded_moto_server.py
+++ b/moto/moto_server/threaded_moto_server.py
@@ -1,5 +1,4 @@
 from threading import Event, Thread
-from typing import Optional
 
 from werkzeug.serving import BaseWSGIServer, make_server
 
@@ -12,9 +11,9 @@ class ThreadedMotoServer:
     ):
         self._port = port
 
-        self._thread: Optional[Thread] = None
+        self._thread: Thread | None = None
         self._ip_address = ip_address
-        self._server: Optional[BaseWSGIServer] = None
+        self._server: BaseWSGIServer | None = None
         self._server_ready_event = Event()
         self._verbose = verbose
 

--- a/moto/moto_server/werkzeug_app.py
+++ b/moto/moto_server/werkzeug_app.py
@@ -3,7 +3,7 @@ import os
 import os.path
 from collections.abc import Callable
 from threading import Lock
-from typing import Any, Optional
+from typing import Any
 
 try:
     from flask import Flask
@@ -67,7 +67,7 @@ class DomainDispatcherApplication:
         self.app_instances: dict[str, Flask] = {}
         self.backend_url_patterns = backend_index.backend_url_patterns
 
-    def get_backend_for_host(self, host: Optional[str]) -> Any:
+    def get_backend_for_host(self, host: str | None) -> Any:
         if host is None:
             return None
 
@@ -89,7 +89,7 @@ class DomainDispatcherApplication:
 
     def infer_service_region_host(
         self, environ: dict[str, Any], path: str
-    ) -> Optional[str]:
+    ) -> str | None:
         auth = environ.get("HTTP_AUTHORIZATION")
         target = environ.get("HTTP_X_AMZ_TARGET")
         service = None
@@ -237,7 +237,7 @@ class DomainDispatcherApplication:
                 self.app_instances[backend] = app
             return app
 
-    def _get_body(self, environ: dict[str, Any]) -> Optional[str]:
+    def _get_body(self, environ: dict[str, Any]) -> str | None:
         body = None
         try:
             # AWS requests use querystrings as the body (Action=x&Data=y&...)
@@ -256,8 +256,8 @@ class DomainDispatcherApplication:
         return body
 
     def get_service_from_body(
-        self, body: Optional[str], environ: dict[str, Any]
-    ) -> tuple[Optional[str], Optional[str]]:
+        self, body: str | None, environ: dict[str, Any]
+    ) -> tuple[str | None, str | None]:
         # Some services have the SDK Version in the body
         # If the version is unique, we can derive the service from it
         version = self.get_version_from_body(body)
@@ -267,14 +267,14 @@ class DomainDispatcherApplication:
             return SERVICE_BY_VERSION[version], region
         return None, None
 
-    def get_version_from_body(self, body: Optional[str]) -> Optional[str]:
+    def get_version_from_body(self, body: str | None) -> str | None:
         try:
             body_dict = dict(x.split("=") for x in body.split("&"))  # type: ignore
             return body_dict["Version"]
         except (AttributeError, KeyError, ValueError):
             return None
 
-    def get_action_from_body(self, body: Optional[str]) -> Optional[str]:
+    def get_action_from_body(self, body: str | None) -> str | None:
         try:
             # AWS requests use querystrings as the body (Action=x&Data=y&...)
             body_dict = dict(x.split("=") for x in body.split("&"))  # type: ignore
@@ -282,9 +282,7 @@ class DomainDispatcherApplication:
         except (AttributeError, KeyError, ValueError):
             return None
 
-    def get_service_from_path(
-        self, path_info: str
-    ) -> tuple[Optional[str], Optional[str]]:
+    def get_service_from_path(self, path_info: str) -> tuple[str | None, str | None]:
         # Moto sometimes needs to send a HTTP request to itself
         # In which case it will send a request to 'http://localhost/service_region/whatever'
         try:
@@ -296,7 +294,7 @@ class DomainDispatcherApplication:
     @staticmethod
     def get_service_from_unsigned_path(
         path_info: str,
-    ) -> tuple[Optional[str], Optional[str]]:
+    ) -> tuple[str | None, str | None]:
         # Must run before get_service_from_path, which would misparse the user pool ID
         # prefix (e.g., "us-east-1" from "us-east-1_abc123") as a service name.
         #

--- a/moto/mq/models.py
+++ b/moto/mq/models.py
@@ -1,6 +1,6 @@
 import base64
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 import xmltodict
 
@@ -26,7 +26,7 @@ class ConfigurationRevision(BaseModel):
         configuration_id: str,
         revision_id: str,
         description: str,
-        data: Optional[str] = None,
+        data: str | None = None,
     ):
         self.configuration_id = configuration_id
         self.created = utcnow()
@@ -117,17 +117,15 @@ class User(BaseModel):
         self,
         broker_id: str,
         username: str,
-        console_access: Optional[bool] = None,
-        groups: Optional[list[str]] = None,
+        console_access: bool | None = None,
+        groups: list[str] | None = None,
     ):
         self.broker_id = broker_id
         self.username = username
         self.console_access = console_access or False
         self.groups = groups or []
 
-    def update(
-        self, console_access: Optional[bool], groups: Optional[list[str]]
-    ) -> None:
+    def update(self, console_access: bool | None, groups: list[str] | None) -> None:
         if console_access is not None:
             self.console_access = console_access
         if groups:
@@ -144,13 +142,13 @@ class Broker(BaseModel):
         auto_minor_version_upgrade: bool,
         configuration: dict[str, Any],
         deployment_mode: str,
-        encryption_options: Optional[dict[str, Any]],
+        encryption_options: dict[str, Any] | None,
         engine_type: str,
         engine_version: str,
         host_instance_type: str,
-        ldap_server_metadata: Optional[dict[str, Any]],
+        ldap_server_metadata: dict[str, Any] | None,
         logs: dict[str, bool],
-        maintenance_window_start_time: Optional[dict[str, Any]],
+        maintenance_window_start_time: dict[str, Any] | None,
         publicly_accessible: bool,
         security_groups: list[str],
         storage_type: str,
@@ -245,15 +243,15 @@ class Broker(BaseModel):
 
     def update(
         self,
-        authentication_strategy: Optional[str],
-        auto_minor_version_upgrade: Optional[bool],
-        configuration: Optional[dict[str, Any]],
-        engine_version: Optional[str],
-        host_instance_type: Optional[str],
-        ldap_server_metadata: Optional[dict[str, Any]],
-        logs: Optional[dict[str, bool]],
-        maintenance_window_start_time: Optional[dict[str, str]],
-        security_groups: Optional[list[str]],
+        authentication_strategy: str | None,
+        auto_minor_version_upgrade: bool | None,
+        configuration: dict[str, Any] | None,
+        engine_version: str | None,
+        host_instance_type: str | None,
+        ldap_server_metadata: dict[str, Any] | None,
+        logs: dict[str, bool] | None,
+        maintenance_window_start_time: dict[str, str] | None,
+        security_groups: list[str] | None,
     ) -> None:
         if authentication_strategy:
             self.authentication_strategy = authentication_strategy
@@ -322,15 +320,15 @@ class MQBackend(BaseBackend):
         authentication_strategy: str,
         auto_minor_version_upgrade: bool,
         broker_name: str,
-        configuration: Optional[dict[str, Any]],
+        configuration: dict[str, Any] | None,
         deployment_mode: str,
-        encryption_options: Optional[dict[str, Any]],
+        encryption_options: dict[str, Any] | None,
         engine_type: str,
         engine_version: str,
         host_instance_type: str,
-        ldap_server_metadata: Optional[dict[str, Any]],
+        ldap_server_metadata: dict[str, Any] | None,
         logs: dict[str, bool],
-        maintenance_window_start_time: Optional[dict[str, Any]],
+        maintenance_window_start_time: dict[str, Any] | None,
         publicly_accessible: bool,
         security_groups: list[str],
         storage_type: str,

--- a/moto/networkfirewall/models.py
+++ b/moto/networkfirewall/models.py
@@ -1,6 +1,6 @@
 """NetworkFirewallBackend class with methods for supported APIs."""
 
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -126,7 +126,7 @@ class NetworkFirewallBackend(BaseBackend):
         return firewall
 
     def _get_firewall(
-        self, firewall_arn: Optional[str], firewall_name: Optional[str]
+        self, firewall_arn: str | None, firewall_name: str | None
     ) -> NetworkFirewallModel:
         if firewall_arn:
             if firewall_arn in self.firewalls:

--- a/moto/networkmanager/models.py
+++ b/moto/networkmanager/models.py
@@ -1,7 +1,7 @@
 """NetworkManagerBackend class with methods for supported APIs."""
 
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -50,8 +50,8 @@ class GlobalNetwork(BaseModel):
         self,
         account_id: str,
         partition: str,
-        description: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        description: str | None,
+        tags: list[dict[str, str]] | None,
     ):
         self.description = description
         self.tags = tags or []
@@ -79,8 +79,8 @@ class CoreNetwork(BaseModel):
         account_id: str,
         partition: str,
         global_network_id: str,
-        description: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        description: str | None,
+        tags: list[dict[str, str]] | None,
         policy_document: str,
         client_token: str,
     ):
@@ -116,9 +116,9 @@ class Site(BaseModel):
         account_id: str,
         partition: str,
         global_network_id: str,
-        description: Optional[str],
-        location: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
+        description: str | None,
+        location: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
     ):
         self.global_network_id = global_network_id
         self.description = description
@@ -150,12 +150,12 @@ class Link(BaseModel):
         account_id: str,
         partition: str,
         global_network_id: str,
-        description: Optional[str],
-        type: Optional[str],
+        description: str | None,
+        type: str | None,
         bandwidth: dict[str, int],
-        provider: Optional[str],
+        provider: str | None,
         site_id: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ):
         self.global_network_id = global_network_id
         self.description = description
@@ -193,15 +193,15 @@ class Device(BaseModel):
         account_id: str,
         partition: str,
         global_network_id: str,
-        aws_location: Optional[dict[str, str]],
-        description: Optional[str],
-        type: Optional[str],
-        vendor: Optional[str],
-        model: Optional[str],
-        serial_number: Optional[str],
-        location: Optional[dict[str, str]],
-        site_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        aws_location: dict[str, str] | None,
+        description: str | None,
+        type: str | None,
+        vendor: str | None,
+        model: str | None,
+        serial_number: str | None,
+        location: dict[str, str] | None,
+        site_id: str | None,
+        tags: list[dict[str, str]] | None,
     ):
         self.global_network_id = global_network_id
         self.aws_location = aws_location
@@ -279,8 +279,8 @@ class NetworkManagerBackend(BaseBackend):
 
     def create_global_network(
         self,
-        description: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        description: str | None,
+        tags: list[dict[str, str]] | None,
     ) -> GlobalNetwork:
         global_network = GlobalNetwork(
             description=description,
@@ -299,8 +299,8 @@ class NetworkManagerBackend(BaseBackend):
     def create_core_network(
         self,
         global_network_id: str,
-        description: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        description: str | None,
+        tags: list[dict[str, str]] | None,
         policy_document: str,
         client_token: str,
     ) -> CoreNetwork:
@@ -333,7 +333,7 @@ class NetworkManagerBackend(BaseBackend):
         resource = self._get_resource_from_arn(resource_arn)
         resource.tags.extend(tags)
 
-    def untag_resource(self, resource_arn: str, tag_keys: Optional[list[str]]) -> None:
+    def untag_resource(self, resource_arn: str, tag_keys: list[str] | None) -> None:
         resource = self._get_resource_from_arn(resource_arn)
         if tag_keys:
             resource.tags = [tag for tag in resource.tags if tag["Key"] not in tag_keys]
@@ -369,9 +369,9 @@ class NetworkManagerBackend(BaseBackend):
     def create_site(
         self,
         global_network_id: str,
-        description: Optional[str],
-        location: Optional[dict[str, str]],
-        tags: Optional[list[dict[str, str]]],
+        description: str | None,
+        location: dict[str, str] | None,
+        tags: list[dict[str, str]] | None,
     ) -> Site:
         # check if global network exists
         if global_network_id not in self.global_networks:
@@ -417,12 +417,12 @@ class NetworkManagerBackend(BaseBackend):
     def create_link(
         self,
         global_network_id: str,
-        description: Optional[str],
-        type: Optional[str],
+        description: str | None,
+        type: str | None,
         bandwidth: dict[str, Any],
-        provider: Optional[str],
+        provider: str | None,
         site_id: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ) -> Link:
         # check if global network exists
         if global_network_id not in self.global_networks:
@@ -475,15 +475,15 @@ class NetworkManagerBackend(BaseBackend):
     def create_device(
         self,
         global_network_id: str,
-        aws_location: Optional[dict[str, str]],
-        description: Optional[str],
-        type: Optional[str],
-        vendor: Optional[str],
-        model: Optional[str],
-        serial_number: Optional[str],
-        location: Optional[dict[str, str]],
-        site_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        aws_location: dict[str, str] | None,
+        description: str | None,
+        type: str | None,
+        vendor: str | None,
+        model: str | None,
+        serial_number: str | None,
+        location: dict[str, str] | None,
+        site_id: str | None,
+        tags: list[dict[str, str]] | None,
     ) -> Device:
         # check if global network exists
         if global_network_id not in self.global_networks:
@@ -507,7 +507,7 @@ class NetworkManagerBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def get_devices(
-        self, global_network_id: str, device_ids: list[str], site_id: Optional[str]
+        self, global_network_id: str, device_ids: list[str], site_id: str | None
     ) -> list[Device]:
         if global_network_id not in self.global_networks:
             raise ValidationError("Incorrect input.")

--- a/moto/opensearch/models.py
+++ b/moto/opensearch/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -86,8 +86,8 @@ class OpenSearchDomain(BaseModel):
         off_peak_window_options: dict[str, Any],
         software_update_options: dict[str, bool],
         is_es: bool,
-        elasticsearch_version: Optional[str],
-        elasticsearch_cluster_config: Optional[str],
+        elasticsearch_version: str | None,
+        elasticsearch_cluster_config: str | None,
     ):
         # Add creation_date attribute
         self.creation_date = unix_time(datetime.datetime.now())
@@ -140,8 +140,8 @@ class OpenSearchDomain(BaseModel):
                 self.cluster_config[key] = value
 
         if self.vpc_options is None:
-            self.endpoint: Optional[str] = f"{domain_name}.{region}.es.amazonaws.com"
-            self.endpoints: Optional[dict[str, str]] = None
+            self.endpoint: str | None = f"{domain_name}.{region}.es.amazonaws.com"
+            self.endpoints: dict[str, str] | None = None
         else:
             self.endpoint = None
             self.endpoints = {"vpc": f"{domain_name}.{region}.es.amazonaws.com"}
@@ -360,8 +360,8 @@ class OpenSearchServiceBackend(BaseBackend):
         off_peak_window_options: dict[str, Any],
         software_update_options: dict[str, Any],
         is_es: bool,
-        elasticsearch_version: Optional[str],
-        elasticsearch_cluster_config: Optional[str],
+        elasticsearch_version: str | None,
+        elasticsearch_cluster_config: str | None,
     ) -> OpenSearchDomain:
         domain = OpenSearchDomain(
             account_id=self.account_id,
@@ -392,9 +392,7 @@ class OpenSearchServiceBackend(BaseBackend):
             self.add_tags(domain.arn, tag_list)
         return domain
 
-    def get_compatible_versions(
-        self, domain_name: Optional[str]
-    ) -> list[dict[str, Any]]:
+    def get_compatible_versions(self, domain_name: str | None) -> list[dict[str, Any]]:
         if domain_name and domain_name not in self.domains:
             raise ResourceNotFoundException(domain_name)
         return compatible_versions

--- a/moto/organizations/models.py
+++ b/moto/organizations/models.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -418,7 +418,7 @@ class OrganizationsBackend(BaseBackend):
         self._reset()
 
     def _reset(self) -> None:
-        self.org: Optional[FakeOrganization] = None
+        self.org: FakeOrganization | None = None
         self.accounts: list[FakeAccount] = []
         self.ou: list[FakeOrganizationalUnit] = []
         self.policies: list[FakePolicy] = []
@@ -1068,7 +1068,7 @@ class OrganizationsBackendDict(BackendDict[OrganizationsBackend]):
         backend: Any,
         service_name: str,
         use_boto3_regions: bool = True,
-        additional_regions: Optional[list[str]] = None,
+        additional_regions: list[str] | None = None,
     ):
         super().__init__(backend, service_name, use_boto3_regions, additional_regions)
 

--- a/moto/organizations/utils.py
+++ b/moto/organizations/utils.py
@@ -1,7 +1,6 @@
 import re
 import string
 from re import Pattern
-from typing import Union
 
 from moto.moto_api._internal import mock_random as random
 
@@ -128,7 +127,7 @@ def make_random_policy_id() -> str:
     return "p-" + "".join(random.choice(CHARSET) for x in range(POLICY_ID_SIZE))
 
 
-def fullmatch(regex: Union[Pattern[str], str], s: str, flags: int = 0) -> bool:
+def fullmatch(regex: Pattern[str] | str, s: str, flags: int = 0) -> bool:
     """Emulate python-3.4 re.fullmatch()."""
     m = re.match(regex, s, flags=flags)
     if m and m.span()[1] == len(s):

--- a/moto/osis/exceptions.py
+++ b/moto/osis/exceptions.py
@@ -1,5 +1,4 @@
 import json
-from typing import Optional
 
 from moto.core.exceptions import JsonRESTError
 
@@ -18,9 +17,7 @@ class PipelineAlreadyExistsException(OpensearchIngestionExceptions):
 
 
 class PipelineInvalidStateException(OpensearchIngestionExceptions):
-    def __init__(
-        self, action: str, valid_states: list[str], current_state: Optional[str]
-    ):
+    def __init__(self, action: str, valid_states: list[str], current_state: str | None):
         super().__init__(
             "ConflictException",
             f"Only pipelines with one of the following statuses are eligible for {action}: {valid_states}. The current status is {current_state}.",

--- a/moto/osis/models.py
+++ b/moto/osis/models.py
@@ -2,7 +2,7 @@
 
 import json
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, ClassVar, Optional
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import yaml
 
@@ -56,15 +56,15 @@ class Pipeline(ManagedState, BaseModel):
         min_units: int,
         max_units: int,
         pipeline_configuration_body: str,
-        log_publishing_options: Optional[dict[str, Any]],
-        vpc_options: Optional[dict[str, Any]],
-        buffer_options: Optional[dict[str, Any]],
-        encryption_at_rest_options: Optional[dict[str, Any]],
+        log_publishing_options: dict[str, Any] | None,
+        vpc_options: dict[str, Any] | None,
+        buffer_options: dict[str, Any] | None,
+        encryption_at_rest_options: dict[str, Any] | None,
         ingest_endpoint_urls: list[str],
         serverless: bool,
-        vpc_endpoint_service: Optional[str],
-        vpc_endpoint: Optional[str],
-        vpc_id: Optional[str],
+        vpc_endpoint_service: str | None,
+        vpc_endpoint: str | None,
+        vpc_id: str | None,
         backend: "OpenSearchIngestionBackend",
     ):
         ManagedState.__init__(
@@ -115,7 +115,7 @@ class Pipeline(ManagedState, BaseModel):
     def _get_arn(self, name: str) -> str:
         return f"arn:{get_partition(self.region)}:osis:{self.region}:{self.account_id}:pipeline/{name}"
 
-    def _get_service_vpc_endpoints(self) -> Optional[list[dict[str, str]]]:
+    def _get_service_vpc_endpoints(self) -> list[dict[str, str]] | None:
         # ServiceVpcEndpoint.VpcEndpointId not implemented
         if self.serverless:
             return [{"ServiceName": "OPENSEARCH_SERVERLESS"}]
@@ -185,12 +185,12 @@ class Pipeline(ManagedState, BaseModel):
 
     def update(
         self,
-        min_units: Optional[int],
-        max_units: Optional[int],
-        pipeline_configuration_body: Optional[str],
-        log_publishing_options: Optional[dict[str, Any]],
-        buffer_options: Optional[dict[str, Any]],
-        encryption_at_rest_options: Optional[dict[str, Any]],
+        min_units: int | None,
+        max_units: int | None,
+        pipeline_configuration_body: str | None,
+        log_publishing_options: dict[str, Any] | None,
+        buffer_options: dict[str, Any] | None,
+        encryption_at_rest_options: dict[str, Any] | None,
     ) -> None:
         if min_units is not None:
             self.min_units = min_units
@@ -323,7 +323,7 @@ class OpenSearchIngestionBackend(BaseBackend):
 
     def _get_vpc_endpoint(
         self, vpc_id: str, vpc_options: dict[str, Any], service_name: str
-    ) -> Optional[str]:
+    ) -> str | None:
         if vpc_options.get("VpcEndpointManagement", "SERVICE") == "SERVICE":
             service_managed_endpoint = self.ec2_backend.create_vpc_endpoint(
                 vpc_id=vpc_id,
@@ -376,10 +376,10 @@ class OpenSearchIngestionBackend(BaseBackend):
         min_units: int,
         max_units: int,
         pipeline_configuration_body: str,
-        log_publishing_options: Optional[dict[str, Any]],
-        vpc_options: Optional[dict[str, Any]],
-        buffer_options: Optional[dict[str, bool]],
-        encryption_at_rest_options: Optional[dict[str, Any]],
+        log_publishing_options: dict[str, Any] | None,
+        vpc_options: dict[str, Any] | None,
+        buffer_options: dict[str, bool] | None,
+        encryption_at_rest_options: dict[str, Any] | None,
         tags: list[dict[str, str]],
     ) -> Pipeline:
         if pipeline_name in self.pipelines:
@@ -475,12 +475,12 @@ class OpenSearchIngestionBackend(BaseBackend):
     def update_pipeline(
         self,
         pipeline_name: str,
-        min_units: Optional[int],
-        max_units: Optional[int],
-        pipeline_configuration_body: Optional[str],
-        log_publishing_options: Optional[dict[str, Any]],
-        buffer_options: Optional[dict[str, Any]],
-        encryption_at_rest_options: Optional[dict[str, Any]],
+        min_units: int | None,
+        max_units: int | None,
+        pipeline_configuration_body: str | None,
+        log_publishing_options: dict[str, Any] | None,
+        buffer_options: dict[str, Any] | None,
+        encryption_at_rest_options: dict[str, Any] | None,
     ) -> Pipeline:
         if pipeline_name not in self.pipelines:
             raise PipelineNotFoundException(pipeline_name)

--- a/moto/packages/boto/ec2/blockdevicemapping.py
+++ b/moto/packages/boto/ec2/blockdevicemapping.py
@@ -21,7 +21,7 @@
 # IN THE SOFTWARE.
 #
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 
 class BlockDeviceType:
@@ -31,18 +31,18 @@ class BlockDeviceType:
 
     def __init__(
         self,
-        connection: Optional[str] = None,
-        ephemeral_name: Optional[str] = None,
-        no_device: Union[bool, str] = False,
-        volume_id: Optional[str] = None,
-        snapshot_id: Optional[str] = None,
-        status: Optional[str] = None,
-        attach_time: Optional[datetime] = None,
+        connection: str | None = None,
+        ephemeral_name: str | None = None,
+        no_device: bool | str = False,
+        volume_id: str | None = None,
+        snapshot_id: str | None = None,
+        status: str | None = None,
+        attach_time: datetime | None = None,
         delete_on_termination: bool = False,
-        size: Optional[int] = None,
-        volume_type: Optional[str] = None,
-        iops: Optional[str] = None,
-        encrypted: Optional[str] = None,
+        size: int | None = None,
+        volume_type: str | None = None,
+        iops: str | None = None,
+        encrypted: str | None = None,
     ):
         self.connection = connection
         self.ephemeral_name = ephemeral_name

--- a/moto/packages/boto/ec2/instance.py
+++ b/moto/packages/boto/ec2/instance.py
@@ -25,7 +25,7 @@
 Represents an EC2 Instance
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from moto.packages.boto.ec2.ec2object import EC2Object, TaggedEC2Object
 from moto.packages.boto.ec2.image import ProductCodes
@@ -47,10 +47,10 @@ class InstancePlacement:
         self.zone = zone
         self.group_name = group_name or ""
         self.tenancy = tenancy or "default"
-        self.host_id: Optional[str] = None
+        self.host_id: str | None = None
 
     @property
-    def availability_zone(self) -> Optional[str]:
+    def availability_zone(self) -> str | None:
         return self.zone
 
     def __repr__(self) -> Any:
@@ -157,8 +157,8 @@ class Instance(TaggedEC2Object):
         self.platform = None
         self.interfaces: Any = []
         self.hypervisor = "xen"
-        self.virtualization_type: Optional[str] = None
-        self.architecture: Optional[str] = None
+        self.virtualization_type: str | None = None
+        self.architecture: str | None = None
         self.instance_profile = None
         self._previous_state = None
         self._placement = InstancePlacement()

--- a/moto/panorama/models.py
+++ b/moto/panorama/models.py
@@ -2,7 +2,7 @@ import base64
 import json
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -71,10 +71,10 @@ class Device(BaseObject):
         self,
         account_id: str,
         region_name: str,
-        description: Optional[str],
+        description: str | None,
         name: str,
-        network_configuration: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        network_configuration: dict[str, Any] | None,
+        tags: dict[str, str] | None,
     ) -> None:
         # ManagedState is a class that helps us manage the state of a resource.
         # A Panorama Device has a lot of different states that has their own lifecycle.
@@ -215,7 +215,7 @@ class Device(BaseObject):
         }
 
     @property
-    def response_provision(self) -> dict[str, Union[str, bytes]]:
+    def response_provision(self) -> dict[str, str | bytes]:
         return {
             "Arn": self.arn,
             "Certificates": self.certificates,
@@ -349,7 +349,7 @@ class Node(BaseObject):
     def __init__(
         self,
         job_id: str,
-        job_tags: list[dict[str, Union[str, dict[str, str]]]],
+        job_tags: list[dict[str, str | dict[str, str]]],
         node_description: str,
         node_name: str,
         output_package_name: str,
@@ -401,10 +401,10 @@ class PanoramaBackend(BaseBackend):
 
     def provision_device(
         self,
-        description: Optional[str],
+        description: str | None,
         name: str,
-        networking_configuration: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        networking_configuration: dict[str, Any] | None,
+        tags: dict[str, str] | None,
     ) -> Device:
         device_obj = Device(
             account_id=self.account_id,
@@ -464,7 +464,7 @@ class PanoramaBackend(BaseBackend):
 
     def create_node_from_template_job(
         self,
-        job_tags: list[dict[str, Union[str, dict[str, str]]]],
+        job_tags: list[dict[str, str | dict[str, str]]],
         node_description: str,
         node_name: str,
         output_package_name: str,
@@ -512,7 +512,7 @@ class PanoramaBackend(BaseBackend):
 
     def create_application_instance(
         self,
-        application_instance_id_to_replace: Optional[str],
+        application_instance_id_to_replace: str | None,
         default_runtime_context_device: str,
         description: str,
         manifest_overrides_payload: dict[str, str],
@@ -564,8 +564,8 @@ class PanoramaBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_application_instances(
         self,
-        device_id: Optional[str],
-        status_filter: Optional[str],
+        device_id: str | None,
+        status_filter: str | None,
     ) -> list[ApplicationInstance]:
         filtered_application_instances = filter(
             lambda x: x.status == status_filter if status_filter else True,

--- a/moto/pinpoint/models.py
+++ b/moto/pinpoint/models.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -19,7 +19,7 @@ class App(BaseModel):
         self.name = name
         self.created = unix_time()
         self.settings = AppSettings()
-        self.event_stream: Optional[EventStream] = None
+        self.event_stream: EventStream | None = None
 
     def get_settings(self) -> "AppSettings":
         return self.settings

--- a/moto/pipes/exceptions.py
+++ b/moto/pipes/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions raised by the pipes service."""
 
 import json
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.exceptions import JsonRESTError
 
@@ -22,8 +22,8 @@ class ConflictException(JsonRESTError):
     def __init__(
         self,
         message: str,
-        resource_id: Optional[str] = None,
-        resource_type: Optional[str] = None,
+        resource_id: str | None = None,
+        resource_type: str | None = None,
     ):
         super().__init__("ConflictException", message)
         body: dict[str, Any] = {"message": self.message}
@@ -44,7 +44,7 @@ class NotFoundException(JsonRESTError):
 class InternalException(JsonRESTError):
     code = 500
 
-    def __init__(self, message: str, retry_after_seconds: Optional[int] = None):
+    def __init__(self, message: str, retry_after_seconds: int | None = None):
         super().__init__("InternalException", message)
         body: dict[str, Any] = {"message": self.message}
         if retry_after_seconds is not None:
@@ -58,10 +58,10 @@ class ServiceQuotaExceededException(JsonRESTError):
     def __init__(
         self,
         message: str,
-        quota_code: Optional[str] = None,
-        resource_id: Optional[str] = None,
-        resource_type: Optional[str] = None,
-        service_code: Optional[str] = None,
+        quota_code: str | None = None,
+        resource_id: str | None = None,
+        resource_type: str | None = None,
+        service_code: str | None = None,
     ):
         super().__init__("ServiceQuotaExceededException", message)
         body: dict[str, Any] = {"message": self.message}
@@ -82,9 +82,9 @@ class ThrottlingException(JsonRESTError):
     def __init__(
         self,
         message: str,
-        quota_code: Optional[str] = None,
-        retry_after_seconds: Optional[int] = None,
-        service_code: Optional[str] = None,
+        quota_code: str | None = None,
+        retry_after_seconds: int | None = None,
+        service_code: str | None = None,
     ):
         super().__init__("ThrottlingException", message)
         body: dict[str, Any] = {"message": self.message}

--- a/moto/pipes/models.py
+++ b/moto/pipes/models.py
@@ -1,7 +1,7 @@
 """EventBridgePipesBackend class with methods for supported APIs."""
 
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -32,7 +32,7 @@ class PipeStatus(str, Enum):
     DELETED = "DELETED"
 
     @classmethod
-    def status_transitions(self) -> list[tuple[Optional[str], str]]:
+    def status_transitions(self) -> list[tuple[str | None, str]]:
         return [
             (PipeStatus.CREATING.value, PipeStatus.RUNNING.value),
             (PipeStatus.STARTING.value, PipeStatus.RUNNING.value),
@@ -53,15 +53,15 @@ class Pipe(BaseModel, ManagedState):
         source: str,
         target: str,
         role_arn: str,
-        description: Optional[str] = None,
-        desired_state: Optional[str] = None,
-        source_parameters: Optional[dict[str, Any]] = None,
-        enrichment: Optional[str] = None,
-        enrichment_parameters: Optional[dict[str, Any]] = None,
-        target_parameters: Optional[dict[str, Any]] = None,
-        tags: Optional[dict[str, str]] = None,
-        log_configuration: Optional[dict[str, Any]] = None,
-        kms_key_identifier: Optional[str] = None,
+        description: str | None = None,
+        desired_state: str | None = None,
+        source_parameters: dict[str, Any] | None = None,
+        enrichment: str | None = None,
+        enrichment_parameters: dict[str, Any] | None = None,
+        target_parameters: dict[str, Any] | None = None,
+        tags: dict[str, str] | None = None,
+        log_configuration: dict[str, Any] | None = None,
+        kms_key_identifier: str | None = None,
     ):
         ManagedState.__init__(
             self, "pipes::pipe", transitions=PipeStatus.status_transitions()
@@ -88,7 +88,7 @@ class Pipe(BaseModel, ManagedState):
         self.state_reason = None
 
     @property
-    def current_state(self) -> Optional[str]:
+    def current_state(self) -> str | None:
         return self.status
 
     @property
@@ -107,18 +107,18 @@ class EventBridgePipesBackend(BaseBackend):
     def create_pipe(
         self,
         name: str,
-        description: Optional[str],
-        desired_state: Optional[str],
+        description: str | None,
+        desired_state: str | None,
         source: str,
-        source_parameters: Optional[dict[str, Any]],
-        enrichment: Optional[str],
-        enrichment_parameters: Optional[dict[str, Any]],
+        source_parameters: dict[str, Any] | None,
+        enrichment: str | None,
+        enrichment_parameters: dict[str, Any] | None,
         target: str,
-        target_parameters: Optional[dict[str, Any]],
+        target_parameters: dict[str, Any] | None,
         role_arn: str,
-        tags: Optional[dict[str, str]],
-        log_configuration: Optional[dict[str, Any]],
-        kms_key_identifier: Optional[str],
+        tags: dict[str, str] | None,
+        log_configuration: dict[str, Any] | None,
+        kms_key_identifier: str | None,
     ) -> Pipe:
         pipe = Pipe(
             name=name,
@@ -197,11 +197,11 @@ class EventBridgePipesBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_pipes(  # type: ignore[misc]
         self,
-        name_prefix: Optional[str],
-        desired_state: Optional[str],
-        current_state: Optional[str],
-        source_prefix: Optional[str],
-        target_prefix: Optional[str],
+        name_prefix: str | None,
+        desired_state: str | None,
+        current_state: str | None,
+        source_prefix: str | None,
+        target_prefix: str | None,
     ) -> list[dict[str, Any]]:
         """List pipes with optional filtering and pagination."""
         filtered_pipes = list(self.pipes.values())

--- a/moto/polly/models.py
+++ b/moto/polly/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Optional
+from typing import Any
 from xml.etree import ElementTree as ET
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -22,7 +22,7 @@ class Lexicon(BaseModel):
 
         self.update()
 
-    def update(self, content: Optional[str] = None) -> None:
+    def update(self, content: str | None = None) -> None:
         if content is not None:
             self.content = content
 

--- a/moto/polly/responses.py
+++ b/moto/polly/responses.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Any, Union
+from typing import Any
 from urllib.parse import urlsplit
 
 from moto.core.responses import BaseResponse
@@ -36,7 +36,7 @@ class PollyResponse(BaseResponse):
         return url_parts[1]
 
     # DescribeVoices
-    def voices(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def voices(self) -> str | tuple[str, dict[str, int]]:
         language_code = self._get_param("LanguageCode")
 
         if language_code is not None and language_code not in LANGUAGE_CODES:
@@ -51,7 +51,7 @@ class PollyResponse(BaseResponse):
 
         return json.dumps({"Voices": voices})
 
-    def lexicons(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def lexicons(self) -> str | tuple[str, dict[str, int]]:
         # Dish out requests based on methods
 
         # anything after the /v1/lexicons/
@@ -70,9 +70,7 @@ class PollyResponse(BaseResponse):
         return self._error("InvalidAction", "Bad route")
 
     # PutLexicon
-    def _put_lexicons(
-        self, lexicon_name: str
-    ) -> Union[str, tuple[str, dict[str, int]]]:
+    def _put_lexicons(self, lexicon_name: str) -> str | tuple[str, dict[str, int]]:
         if LEXICON_NAME_REGEX.match(lexicon_name) is None:
             return self._error(
                 "InvalidParameterValue", "Lexicon name must match [0-9A-Za-z]{1,20}"
@@ -92,7 +90,7 @@ class PollyResponse(BaseResponse):
         return json.dumps(result)
 
     # GetLexicon
-    def _get_lexicon(self, lexicon_name: str) -> Union[str, tuple[str, dict[str, int]]]:
+    def _get_lexicon(self, lexicon_name: str) -> str | tuple[str, dict[str, int]]:
         try:
             lexicon = self.polly_backend.get_lexicon(lexicon_name)
         except KeyError:
@@ -106,9 +104,7 @@ class PollyResponse(BaseResponse):
         return json.dumps(result)
 
     # DeleteLexicon
-    def _delete_lexicon(
-        self, lexicon_name: str
-    ) -> Union[str, tuple[str, dict[str, int]]]:
+    def _delete_lexicon(self, lexicon_name: str) -> str | tuple[str, dict[str, int]]:
         try:
             self.polly_backend.delete_lexicon(lexicon_name)
         except KeyError:

--- a/moto/quicksight/data_models.py
+++ b/moto/quicksight/data_models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random as random
@@ -75,7 +75,7 @@ class QuicksightGroup(BaseModel):
     def delete_member(self, user_name: str) -> None:
         self.members.pop(user_name, None)
 
-    def get_member(self, user_name: str) -> Union[QuicksightMembership, None]:
+    def get_member(self, user_name: str) -> QuicksightMembership | None:
         return self.members.get(user_name, None)
 
     def list_members(self) -> list[QuicksightMembership]:
@@ -190,9 +190,7 @@ class QuicksightDashboard(BaseModel):
 
 
 class QuicksightAccountSettings(BaseModel):
-    def __init__(
-        self, account_id: str, account_name: Optional[str] = "default"
-    ) -> None:
+    def __init__(self, account_id: str, account_name: str | None = "default") -> None:
         self.account_name = account_name
         self.account_id = account_id
         self.default_namespace = "default"
@@ -209,13 +207,13 @@ class QuickSightDataSource(BaseModel):
         region: str,
         data_source_id: str,
         name: str,
-        data_source_parameters: Optional[dict[str, dict[str, Any]]] = None,
-        alternate_data_source_parameters: Optional[list[dict[str, Any]]] = None,
-        ssl_properties: Optional[dict[str, Any]] = None,
-        status: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        data_source_type: Optional[str] = None,
-        vpc_connection_properties: Optional[dict[str, Any]] = None,
+        data_source_parameters: dict[str, dict[str, Any]] | None = None,
+        alternate_data_source_parameters: list[dict[str, Any]] | None = None,
+        ssl_properties: dict[str, Any] | None = None,
+        status: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        data_source_type: str | None = None,
+        vpc_connection_properties: dict[str, Any] | None = None,
     ) -> None:
         self.account_id = account_id
         self.region = region

--- a/moto/quicksight/models.py
+++ b/moto/quicksight/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.utilities.paginator import paginate
@@ -42,7 +42,7 @@ class QuickSightBackend(BaseBackend):
         self,
         data_set_id: str,
         name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> QuicksightDataSet:
         dataset = QuicksightDataSet(
             self.account_id, self.region_name, data_set_id, name=name
@@ -176,7 +176,7 @@ class QuickSightBackend(BaseBackend):
         aws_account_id: str,
         namespace: str,
         user_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> QuicksightUser:
         """
         The following parameters are not yet implemented:
@@ -326,10 +326,10 @@ class QuickSightBackend(BaseBackend):
         data_source_id: str,
         name: str,
         data_source_type: str,
-        data_source_parameters: Optional[dict[str, dict[str, Any]]] = None,
-        vpc_connection_properties: Optional[dict[str, Any]] = None,
-        ssl_properties: Optional[dict[str, Any]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        data_source_parameters: dict[str, dict[str, Any]] | None = None,
+        vpc_connection_properties: dict[str, Any] | None = None,
+        ssl_properties: dict[str, Any] | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> QuickSightDataSource:
         data_source = QuickSightDataSource(
             account_id=aws_account_id,
@@ -358,9 +358,9 @@ class QuickSightBackend(BaseBackend):
         aws_account_id: str,
         data_source_id: str,
         name: str,
-        data_source_parameters: Optional[dict[str, Any]] = None,
-        vpc_connection_properties: Optional[dict[str, Any]] = None,
-        ssl_properties: Optional[dict[str, Any]] = None,
+        data_source_parameters: dict[str, Any] | None = None,
+        vpc_connection_properties: dict[str, Any] | None = None,
+        ssl_properties: dict[str, Any] | None = None,
     ) -> QuickSightDataSource:
         data_source = self.data_sources.get(data_source_id)
 

--- a/moto/quicksight/utils.py
+++ b/moto/quicksight/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any
 
 from moto.core.common_models import BaseModel
 
@@ -121,7 +121,7 @@ class QuicksightSearchFilterFactory:
 
     @classmethod
     def validate_and_create_filter(
-        cls, model_type: type[BaseModel], input: Union[list[dict[str, str]], None]
+        cls, model_type: type[BaseModel], input: list[dict[str, str]] | None
     ) -> QuicksightSearchFilterList:
         if issubclass(model_type, QuicksightGroup):
             if input is None:

--- a/moto/ram/models.py
+++ b/moto/ram/models.py
@@ -1,7 +1,7 @@
 import re
 import string
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -155,7 +155,7 @@ class ResourceShare(BaseModel):
             "status": self.status,
         }
 
-    def update(self, allow_external_principals: bool, name: Optional[str]) -> None:
+    def update(self, allow_external_principals: bool, name: str | None) -> None:
         self.allow_external_principals = allow_external_principals
         self.last_updated_time = utcnow()
         self.name = name
@@ -187,8 +187,8 @@ class ManagedPermission(BaseModel):
         version: str = "1",
         default_version: bool = True,
         status: str = "ATTACHABLE",
-        creation_time: Optional[str] = None,
-        last_updated_time: Optional[str] = None,
+        creation_time: str | None = None,
+        last_updated_time: str | None = None,
         is_resource_type_default: bool = False,
         permission_type: str = "AWS_MANAGED",  # or "CUSTOMER_MANAGED",
     ):
@@ -276,7 +276,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
         return {"resourceShare": response}
 
-    def get_resource_shares(self, resource_owner: Optional[str]) -> dict[str, Any]:
+    def get_resource_shares(self, resource_owner: str | None) -> dict[str, Any]:
         if resource_owner not in ["SELF", "OTHER-ACCOUNTS"]:
             raise InvalidParameterException(
                 f"{resource_owner} is not a valid resource owner. "
@@ -294,9 +294,9 @@ class ResourceAccessManagerBackend(BaseBackend):
 
     def update_resource_share(
         self,
-        resource_share_arn: Optional[str],
+        resource_share_arn: str | None,
         allow_external_principals: bool,
-        name: Optional[str],
+        name: str | None,
     ) -> dict[str, Any]:
         resource = next(
             (
@@ -318,9 +318,7 @@ class ResourceAccessManagerBackend(BaseBackend):
 
         return {"resourceShare": response}
 
-    def delete_resource_share(
-        self, resource_share_arn: Optional[str]
-    ) -> dict[str, Any]:
+    def delete_resource_share(self, resource_share_arn: str | None) -> dict[str, Any]:
         resource = next(
             (
                 resource
@@ -347,11 +345,11 @@ class ResourceAccessManagerBackend(BaseBackend):
 
     def get_resource_share_associations(
         self,
-        association_type: Optional[str],
-        association_status: Optional[str],
+        association_type: str | None,
+        association_status: str | None,
         resource_share_arns: list[str],
-        resource_arn: Optional[str],
-        principal: Optional[str],
+        resource_arn: str | None,
+        principal: str | None,
     ) -> dict[str, Any]:
         if association_type not in ["PRINCIPAL", "RESOURCE"]:
             raise InvalidParameterException(

--- a/moto/ram/utils.py
+++ b/moto/ram/utils.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 
 class ManagedPermissionDict(TypedDict):
@@ -21,8 +21,8 @@ def format_ram_permission(
     version: str = "1",
     arn_prefix: str = "arn:aws:ram::aws:permission/",
     status: str = "ATTACHABLE",
-    creation_time: Optional[str] = None,
-    last_updated_time: Optional[str] = None,
+    creation_time: str | None = None,
+    last_updated_time: str | None = None,
     is_resource_type_default: bool = True,
     permission_type: str = "AWS_MANAGED",
     default_version: bool = True,

--- a/moto/rds/exceptions.py
+++ b/moto/rds/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import ServiceException
 
 
@@ -178,7 +176,7 @@ class InvalidDBClusterStateFault(RDSClientError):
 
 
 class DBClusterNotFoundError(RDSClientError):
-    def __init__(self, cluster_identifier: str, message: Optional[str] = None):
+    def __init__(self, cluster_identifier: str, message: str | None = None):
         if message is None:
             message = f"DBCluster {cluster_identifier} not found."
         super().__init__("DBClusterNotFoundFault", message)

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -18,9 +18,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
-    Optional,
     Protocol,
-    Union,
     overload,
 )
 
@@ -121,8 +119,8 @@ class SnapshotAttributesMixin:
     def modify_attribute(
         self,
         attribute_name: str,
-        values_to_add: Optional[list[str]],
-        values_to_remove: Optional[list[str]],
+        values_to_add: list[str] | None,
+        values_to_remove: list[str] | None,
     ) -> None:
         if not values_to_add:
             values_to_add = []
@@ -175,7 +173,7 @@ class TaggingMixin:
         return self._tags
 
     @tags.setter
-    def tags(self, value: Optional[list[dict[str, str]]]) -> None:
+    def tags(self, value: list[dict[str, str]] | None) -> None:
         if value is None:
             value = []
         # Tags may come in as XFormedDict and we want a regular dict.
@@ -238,7 +236,7 @@ class DBProxyTarget(RDSBaseModel):
         self,
         backend: RDSBackend,
         resource_id: str,
-        endpoint: Optional[str],
+        endpoint: str | None,
         type: str,
     ):
         super().__init__(backend)
@@ -317,9 +315,9 @@ class GlobalCluster(RDSBaseModel):
         backend: RDSBackend,
         global_cluster_identifier: str,
         engine: str,
-        engine_version: Optional[str],
-        storage_encrypted: Optional[bool],
-        deletion_protection: Optional[bool],
+        engine_version: str | None,
+        storage_encrypted: bool | None,
+        deletion_protection: bool | None,
     ):
         super().__init__(backend)
         self.global_cluster_identifier = global_cluster_identifier
@@ -431,7 +429,7 @@ class MasterUserSecret:
             self._status = "active"
         return status_to_return
 
-    def _create_secret(self, kms_key_id: Optional[str]) -> FakeSecret:
+    def _create_secret(self, kms_key_id: str | None) -> FakeSecret:
         secret = self.secretsmanager.create_managed_secret(
             service_name="rds",
             secret_id=self._generate_secret_name(),
@@ -468,12 +466,12 @@ class MasterUserSecret:
 class DomainMembership:
     def __init__(
         self,
-        domain: Optional[str] = None,
-        iam_role_name: Optional[str] = None,
-        domain_ou: Optional[str] = None,
-        domain_fqdn: Optional[str] = None,
-        auth_secret_arn: Optional[str] = None,
-        dns_ips: Optional[list[str]] = None,
+        domain: str | None = None,
+        iam_role_name: str | None = None,
+        domain_ou: str | None = None,
+        domain_fqdn: str | None = None,
+        auth_secret_arn: str | None = None,
+        dns_ips: list[str] | None = None,
     ):
         self.domain = domain.split(".")[0] if domain else None
         self.status = "active"
@@ -510,33 +508,33 @@ class DBCluster(RDSBaseModel):
         backend: RDSBackend,
         db_cluster_identifier: str,
         engine: str,
-        allocated_storage: Optional[int] = None,
+        allocated_storage: int | None = None,
         auto_minor_version_upgrade: bool = True,
-        engine_version: Optional[str] = None,
-        master_username: Optional[str] = None,
-        master_user_password: Optional[str] = None,
+        engine_version: str | None = None,
+        master_username: str | None = None,
+        master_user_password: str | None = None,
         backup_retention_period: int = 1,
-        domain: Optional[str] = None,
-        domain_iam_role_name: Optional[str] = None,
-        domain_ou: Optional[str] = None,
-        domain_fqdn: Optional[str] = None,
-        character_set_name: Optional[str] = None,
-        copy_tags_to_snapshot: Optional[bool] = False,
-        database_name: Optional[str] = None,
-        db_cluster_parameter_group_name: Optional[str] = None,
-        db_subnet_group_name: Optional[str] = None,
+        domain: str | None = None,
+        domain_iam_role_name: str | None = None,
+        domain_ou: str | None = None,
+        domain_fqdn: str | None = None,
+        character_set_name: str | None = None,
+        copy_tags_to_snapshot: bool | None = False,
+        database_name: str | None = None,
+        db_cluster_parameter_group_name: str | None = None,
+        db_subnet_group_name: str | None = None,
         license_model: str = "general-public-license",
-        port: Optional[int] = None,
+        port: int | None = None,
         preferred_backup_window: str = "01:37-02:07",
         preferred_maintenance_window: str = "wed:02:40-wed:03:10",
         publicly_accessible: bool = False,
         storage_encrypted: bool = False,
-        tags: Optional[list[dict[str, str]]] = None,
-        vpc_security_group_ids: Optional[list[str]] = None,
-        deletion_protection: Optional[bool] = False,
-        kms_key_id: Optional[str] = None,
-        manage_master_user_password: Optional[bool] = False,
-        master_user_secret_kms_key_id: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        vpc_security_group_ids: list[str] | None = None,
+        deletion_protection: bool | None = False,
+        kms_key_id: str | None = None,
+        manage_master_user_password: bool | None = False,
+        master_user_secret_kms_key_id: str | None = None,
         **kwargs: Any,
     ):
         super().__init__(backend)
@@ -751,7 +749,7 @@ class DBCluster(RDSBaseModel):
         return self._enable_http_endpoint
 
     @enable_http_endpoint.setter
-    def enable_http_endpoint(self, val: Optional[bool]) -> None:
+    def enable_http_endpoint(self, val: bool | None) -> None:
         # instead of raising an error on aws rds create-db-cluster commands with
         # incompatible configurations with enable_http_endpoint
         # (e.g. engine_mode is not set to "serverless"), the API
@@ -810,7 +808,7 @@ class DBCluster(RDSBaseModel):
         ]
 
     @property
-    def writer(self) -> Optional[DBInstanceClustered]:
+    def writer(self) -> DBInstanceClustered | None:
         return next(
             (
                 db_instance
@@ -873,9 +871,7 @@ class DBCluster(RDSBaseModel):
         return self._vpc_security_group_ids
 
     @vpc_security_group_ids.setter
-    def vpc_security_group_ids(
-        self, vpc_security_group_ids: Optional[list[str]]
-    ) -> None:
+    def vpc_security_group_ids(self, vpc_security_group_ids: list[str] | None) -> None:
         if vpc_security_group_ids is None:
             vpc_security_group_ids = []
         self._vpc_security_group_ids = vpc_security_group_ids
@@ -989,8 +985,8 @@ class DBClusterSnapshot(SnapshotAttributesMixin, RDSBaseModel):
         cluster: DBCluster,
         snapshot_id: str,
         snapshot_type: str = "manual",
-        tags: Optional[list[dict[str, str]]] = None,
-        kms_key_id: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        kms_key_id: str | None = None,
         **kwargs: Any,
     ):
         super().__init__(backend=backend, **kwargs)
@@ -1102,44 +1098,44 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         db_instance_identifier: str,
         db_instance_class: str,
         engine: str,
-        engine_version: Optional[str] = None,
-        port: Optional[int] = None,
-        allocated_storage: Optional[int] = None,
-        max_allocated_storage: Optional[int] = None,
+        engine_version: str | None = None,
+        port: int | None = None,
+        allocated_storage: int | None = None,
+        max_allocated_storage: int | None = None,
         backup_retention_period: int = 1,
-        character_set_name: Optional[str] = None,
+        character_set_name: str | None = None,
         auto_minor_version_upgrade: bool = True,
-        db_name: Optional[str] = None,
-        db_security_groups: Optional[list[str]] = None,
-        db_subnet_group_name: Optional[str] = None,
-        db_cluster_identifier: Optional[str] = None,
-        db_parameter_group_name: Optional[str] = None,
-        domain: Optional[str] = None,
-        domain_iam_role_name: Optional[str] = None,
-        domain_ou: Optional[str] = None,
-        domain_fqdn: Optional[str] = None,
+        db_name: str | None = None,
+        db_security_groups: list[str] | None = None,
+        db_subnet_group_name: str | None = None,
+        db_cluster_identifier: str | None = None,
+        db_parameter_group_name: str | None = None,
+        domain: str | None = None,
+        domain_iam_role_name: str | None = None,
+        domain_ou: str | None = None,
+        domain_fqdn: str | None = None,
         copy_tags_to_snapshot: bool = False,
-        iops: Optional[str] = None,
-        master_username: Optional[str] = None,
-        master_user_password: Optional[str] = None,
+        iops: str | None = None,
+        master_username: str | None = None,
+        master_user_password: str | None = None,
         multi_az: bool = False,
         license_model: str = "general-public-license",
         preferred_backup_window: str = "13:14-13:44",
         preferred_maintenance_window: str = "wed:06:38-wed:07:08",
-        publicly_accessible: Optional[bool] = None,
-        source_db_instance_identifier: Optional[str] = None,
-        storage_type: Optional[str] = None,
+        publicly_accessible: bool | None = None,
+        source_db_instance_identifier: str | None = None,
+        storage_type: str | None = None,
         storage_encrypted: bool = False,
-        tags: Optional[list[dict[str, str]]] = None,
-        vpc_security_group_ids: Optional[list[str]] = None,
+        tags: list[dict[str, str]] | None = None,
+        vpc_security_group_ids: list[str] | None = None,
         deletion_protection: bool = False,
-        option_group_name: Optional[str] = None,
-        enable_cloudwatch_logs_exports: Optional[list[str]] = None,
+        option_group_name: str | None = None,
+        enable_cloudwatch_logs_exports: list[str] | None = None,
         ca_certificate_identifier: str = "rds-ca-default",
-        availability_zone: Optional[str] = None,
-        manage_master_user_password: Optional[bool] = False,
-        master_user_secret_kms_key_id: Optional[str] = None,
-        storage_throughput: Optional[int] = None,
+        availability_zone: str | None = None,
+        manage_master_user_password: bool | None = False,
+        master_user_secret_kms_key_id: str | None = None,
+        storage_throughput: int | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(backend)
@@ -1266,11 +1262,11 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self._db_instance_identifier = value.lower()
 
     @property
-    def db_subnet_group_name(self) -> Optional[str]:
+    def db_subnet_group_name(self) -> str | None:
         raise NotImplementedError("write only property")
 
     @db_subnet_group_name.setter
-    def db_subnet_group_name(self, value: Optional[str]) -> None:
+    def db_subnet_group_name(self, value: str | None) -> None:
         self._db_subnet_group_name = value
         if self._db_subnet_group_name is not None:
             self.db_subnet_group = rds_backends[self.account_id][
@@ -1294,19 +1290,19 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self._backup_retention_period = value
 
     @property
-    def character_set_name(self) -> Optional[str]:
+    def character_set_name(self) -> str | None:
         return self._character_set_name
 
     @character_set_name.setter
-    def character_set_name(self, value: Optional[str]) -> None:
+    def character_set_name(self, value: str | None) -> None:
         self._character_set_name = value
 
     @property
-    def db_name(self) -> Optional[str]:
+    def db_name(self) -> str | None:
         return self._db_name
 
     @db_name.setter
-    def db_name(self, value: Optional[str]) -> None:
+    def db_name(self, value: str | None) -> None:
         self._db_name = value
 
     @property
@@ -1318,11 +1314,11 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self._engine_version = value
 
     @property
-    def kms_key_id(self) -> Optional[str]:
+    def kms_key_id(self) -> str | None:
         return self._kms_key_id
 
     @kms_key_id.setter
-    def kms_key_id(self, value: Optional[str]) -> None:
+    def kms_key_id(self, value: str | None) -> None:
         self._kms_key_id = value
 
     @property
@@ -1334,23 +1330,23 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         self._license_model = value
 
     @property
-    def master_username(self) -> Optional[str]:
+    def master_username(self) -> str | None:
         return self._master_username
 
     @master_username.setter
-    def master_username(self, value: Optional[str]) -> None:
+    def master_username(self, value: str | None) -> None:
         self._master_username = value
 
     @property
-    def master_user_password(self) -> Optional[str]:
+    def master_user_password(self) -> str | None:
         raise NotImplementedError("Password is not retrievable.")
 
     @master_user_password.setter
-    def master_user_password(self, value: Optional[str]) -> None:
+    def master_user_password(self, value: str | None) -> None:
         self._master_user_password = value
 
     @property
-    def max_allocated_storage(self) -> Optional[int]:
+    def max_allocated_storage(self) -> int | None:
         if self._max_allocated_storage > self.allocated_storage:
             return self._max_allocated_storage
         return None
@@ -1404,7 +1400,7 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         return self.arn
 
     @property
-    def physical_resource_id(self) -> Optional[str]:
+    def physical_resource_id(self) -> str | None:
         return self.db_instance_identifier
 
     @property
@@ -1505,11 +1501,11 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         return list(self.replicas)
 
     @property
-    def db_instance_port(self) -> Optional[int]:
+    def db_instance_port(self) -> int | None:
         return self.port
 
     @property
-    def read_replica_source_db_instance_identifier(self) -> Optional[str]:
+    def read_replica_source_db_instance_identifier(self) -> str | None:
         return self.source_db_instance_identifier
 
     @property
@@ -1517,12 +1513,12 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
         return self.enable_iam_database_authentication
 
     @property
-    def storage_throughput(self) -> Optional[int]:
+    def storage_throughput(self) -> int | None:
         return self._storage_throughput
 
     @storage_throughput.setter
-    def storage_throughput(self, value: Optional[int]) -> None:
-        self._storage_throughput: Optional[int]
+    def storage_throughput(self, value: int | None) -> None:
+        self._storage_throughput: int | None
         if value and self.storage_type == "gp3":
             self._storage_throughput = value
         else:
@@ -1544,9 +1540,9 @@ class DBInstance(EventMixin, CloudFormationModel, RDSBaseModel):
 
     def update(
         self,
-        manage_master_user_password: Optional[bool] = None,
-        master_user_secret_kms_key_id: Optional[str] = None,
-        rotate_master_user_password: Optional[bool] = None,
+        manage_master_user_password: bool | None = None,
+        master_user_secret_kms_key_id: str | None = None,
+        rotate_master_user_password: bool | None = None,
         **db_kwargs: dict[str, Any],
     ) -> None:
         if manage_master_user_password is True:
@@ -1746,11 +1742,11 @@ class DBInstanceClustered(DBInstance):
         raise NotImplementedError("Not valid for clustered db instances.")
 
     @property
-    def character_set_name(self) -> Optional[str]:
+    def character_set_name(self) -> str | None:
         return self.cluster.character_set_name
 
     @character_set_name.setter
-    def character_set_name(self, value: Optional[str]) -> None:
+    def character_set_name(self, value: str | None) -> None:
         raise NotImplementedError("Not valid for clustered db instances.")
 
     # TODO: Need to understand better how this works with Aurora instances.
@@ -1761,11 +1757,11 @@ class DBInstanceClustered(DBInstance):
     # So does that mean the cluster.database_name and the instance.db_name
     # can differ?
     @property
-    def db_name(self) -> Optional[str]:
+    def db_name(self) -> str | None:
         return self._db_name or self.cluster.database_name
 
     @db_name.setter
-    def db_name(self, value: Optional[str]) -> None:
+    def db_name(self, value: str | None) -> None:
         self._db_name = value
 
     @property
@@ -1777,11 +1773,11 @@ class DBInstanceClustered(DBInstance):
         raise NotImplementedError("Not valid for clustered db instances.")
 
     @property
-    def kms_key_id(self) -> Optional[str]:
+    def kms_key_id(self) -> str | None:
         return self.cluster.kms_key_id
 
     @kms_key_id.setter
-    def kms_key_id(self, value: Optional[str]) -> None:
+    def kms_key_id(self, value: str | None) -> None:
         raise NotImplementedError("Not valid for clustered db instances.")
 
     @property
@@ -1793,23 +1789,23 @@ class DBInstanceClustered(DBInstance):
         raise NotImplementedError("Not valid for clustered db instances.")
 
     @property
-    def master_username(self) -> Optional[str]:
+    def master_username(self) -> str | None:
         return self.cluster.master_username
 
     @master_username.setter
-    def master_username(self, value: Optional[str]) -> None:
+    def master_username(self, value: str | None) -> None:
         raise NotImplementedError("Not valid for clustered db instances.")
 
     @property
-    def master_user_password(self) -> Optional[str]:
+    def master_user_password(self) -> str | None:
         raise NotImplementedError("Password is not retrievable.")
 
     @master_user_password.setter
-    def master_user_password(self, value: Optional[str]) -> None:
+    def master_user_password(self, value: str | None) -> None:
         raise NotImplementedError("Not valid for clustered db instances.")
 
     @property
-    def max_allocated_storage(self) -> Optional[int]:
+    def max_allocated_storage(self) -> int | None:
         return None
 
     @max_allocated_storage.setter
@@ -1881,9 +1877,9 @@ class DBSnapshot(EventMixin, SnapshotAttributesMixin, RDSBaseModel):
         database: DBInstance,
         snapshot_id: str,
         snapshot_type: str = "manual",
-        tags: Optional[list[dict[str, str]]] = None,
-        original_created_at: Optional[datetime] = None,
-        kms_key_id: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        original_created_at: datetime | None = None,
+        kms_key_id: str | None = None,
         **kwargs: Any,
     ):
         super().__init__(backend=backend, **kwargs)
@@ -1943,7 +1939,7 @@ class ExportTask(RDSBaseModel):
     def __init__(
         self,
         backend: RDSBackend,
-        snapshot: Union[DBSnapshot, DBClusterSnapshot],
+        snapshot: DBSnapshot | DBClusterSnapshot,
         kwargs: dict[str, Any],
     ):
         super().__init__(backend)
@@ -2198,11 +2194,11 @@ class DBProxy(RDSBaseModel):
         auth: list[dict[str, str]],
         role_arn: str,
         vpc_subnet_ids: list[str],
-        vpc_security_group_ids: Optional[list[str]],
-        require_tls: Optional[bool] = False,
-        idle_client_timeout: Optional[int] = 1800,
-        debug_logging: Optional[bool] = False,
-        tags: Optional[list[dict[str, str]]] = None,
+        vpc_security_group_ids: list[str] | None,
+        require_tls: bool | None = False,
+        idle_client_timeout: int | None = 1800,
+        debug_logging: bool | None = False,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(backend)
         self.db_proxy_name = db_proxy_name
@@ -2304,10 +2300,10 @@ class DBShardGroup(RDSBaseModel):
         db_shard_group_identifier: str,
         db_cluster_identifier: str,
         max_acu: float,
-        compute_redundancy: Optional[int] = None,
-        min_acu: Optional[float] = None,
-        publicly_accessible: Optional[bool] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        compute_redundancy: int | None = None,
+        min_acu: float | None = None,
+        publicly_accessible: bool | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(backend)
         self.db_shard_group_identifier = db_shard_group_identifier
@@ -2355,7 +2351,7 @@ class RDSBackend(BaseBackend):
         self.security_groups: dict[str, DBSecurityGroup] = {}
         self.shard_groups: dict[str, DBShardGroup] = {}
         self.subnet_groups: MutableMapping[str, DBSubnetGroup] = CaseInsensitiveDict()
-        self._db_cluster_options: Optional[list[dict[str, Any]]] = None
+        self._db_cluster_options: list[dict[str, Any]] | None = None
         self.db_proxies: dict[str, DBProxy] = OrderedDict()
         self.events: list[Event] = []
         self.resource_map = {
@@ -2409,7 +2405,7 @@ class RDSBackend(BaseBackend):
         self,
         service: Literal["kms"],
         region: str,
-        account_id: Optional[str] = None,
+        account_id: str | None = None,
     ) -> KmsBackend: ...
 
     @overload
@@ -2417,7 +2413,7 @@ class RDSBackend(BaseBackend):
         self,
         service: Literal["rds"],
         region: str,
-        account_id: Optional[str] = None,
+        account_id: str | None = None,
     ) -> RDSBackend: ...
 
     @overload
@@ -2425,14 +2421,14 @@ class RDSBackend(BaseBackend):
         self,
         service: Literal["secretsmanager"],
         region: str,
-        account_id: Optional[str] = None,
+        account_id: str | None = None,
     ) -> SecretsManagerBackend: ...
 
     def get_backend(
         self,
         service: Literal["kms"] | Literal["rds"] | Literal["secretsmanager"],
         region: str,
-        account_id: Optional[str] = None,
+        account_id: str | None = None,
     ) -> KmsBackend | RDSBackend | SecretsManagerBackend:
         from moto.backends import get_backend as get_moto_backend
 
@@ -2568,9 +2564,9 @@ class RDSBackend(BaseBackend):
         db_instance_identifier: str,
         db_snapshot_identifier: str,
         snapshot_type: str = "manual",
-        tags: Optional[list[dict[str, str]]] = None,
-        original_created_at: Optional[datetime] = None,
-        kms_key_id: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        original_created_at: datetime | None = None,
+        kms_key_id: str | None = None,
     ) -> DBSnapshot:
         database = self.databases.get(db_instance_identifier)
         if not database:
@@ -2596,9 +2592,9 @@ class RDSBackend(BaseBackend):
         self,
         source_db_snapshot_identifier: str,
         target_db_snapshot_identifier: str,
-        kms_key_id: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        copy_tags: Optional[bool] = False,
+        kms_key_id: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        copy_tags: bool | None = False,
         **_: Any,
     ) -> DBSnapshot:
         if source_db_snapshot_identifier.startswith("arn:aws:rds:"):
@@ -2658,7 +2654,7 @@ class RDSBackend(BaseBackend):
         return replica
 
     def describe_db_instances(
-        self, db_instance_identifier: Optional[str] = None, filters: Any = None
+        self, db_instance_identifier: str | None = None, filters: Any = None
     ) -> list[DBInstance]:
         databases = self.databases
         if db_instance_identifier:
@@ -2673,10 +2669,10 @@ class RDSBackend(BaseBackend):
 
     def describe_db_snapshots(
         self,
-        db_instance_identifier: Optional[str],
-        db_snapshot_identifier: Optional[str] = None,
-        snapshot_type: Optional[str] = None,
-        filters: Optional[dict[str, Any]] = None,
+        db_instance_identifier: str | None,
+        db_snapshot_identifier: str | None = None,
+        snapshot_type: str | None = None,
+        filters: dict[str, Any] | None = None,
     ) -> list[DBSnapshot]:
         if snapshot_type == "shared":
             return self.get_shared_db_snapshots()  # type: ignore[return-value]
@@ -2845,7 +2841,7 @@ class RDSBackend(BaseBackend):
         db_cluster_identifier: str,
         source_db_cluster_identifier: str,
         restore_type: str = "full-copy",
-        restore_to_time: Optional[datetime] = None,
+        restore_to_time: datetime | None = None,
         use_latest_restorable_time: bool = False,
         **overrides: dict[str, Any],
     ) -> DBCluster:
@@ -2869,7 +2865,7 @@ class RDSBackend(BaseBackend):
     def failover_db_cluster(
         self,
         db_cluster_identifier: str,
-        target_db_instance_identifier: Optional[str] = None,
+        target_db_instance_identifier: str | None = None,
     ) -> DBCluster:
         target_instance = None
         if target_db_instance_identifier is not None:
@@ -2906,7 +2902,7 @@ class RDSBackend(BaseBackend):
         return cluster
 
     def stop_db_instance(
-        self, db_instance_identifier: str, db_snapshot_identifier: Optional[str] = None
+        self, db_instance_identifier: str, db_snapshot_identifier: str | None = None
     ) -> DBInstance:
         self._validate_db_identifier(db_instance_identifier)
         database = self.describe_db_instances(db_instance_identifier)[0]
@@ -2948,9 +2944,9 @@ class RDSBackend(BaseBackend):
     def delete_db_instance(
         self,
         db_instance_identifier: str,
-        final_db_snapshot_identifier: Optional[str] = None,
-        skip_final_snapshot: Optional[bool] = False,
-        delete_automated_backups: Optional[bool] = True,
+        final_db_snapshot_identifier: str | None = None,
+        skip_final_snapshot: bool | None = False,
+        delete_automated_backups: bool | None = True,
     ) -> DBInstance:
         self._validate_db_identifier(db_instance_identifier)
         if db_instance_identifier in self.databases:
@@ -3208,7 +3204,7 @@ class RDSBackend(BaseBackend):
 
     @staticmethod
     def describe_option_group_options(
-        engine_name: str, major_engine_version: Optional[str] = None
+        engine_name: str, major_engine_version: str | None = None
     ) -> list[dict[str, Any]]:
         filtered_options = []
         try:
@@ -3232,8 +3228,8 @@ class RDSBackend(BaseBackend):
     def modify_option_group(
         self,
         option_group_name: str,
-        options_to_include: Optional[list[dict[str, Any]]] = None,
-        options_to_remove: Optional[list[str]] = None,
+        options_to_include: list[dict[str, Any]] | None = None,
+        options_to_remove: list[str] | None = None,
     ) -> OptionGroup:
         if option_group_name not in self.option_groups:
             raise OptionGroupNotFoundFaultError(option_group_name)
@@ -3276,7 +3272,7 @@ class RDSBackend(BaseBackend):
         source_db_parameter_group_identifier: str,
         target_db_parameter_group_identifier: str,
         target_db_parameter_group_description: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> DBParameterGroup:
         if source_db_parameter_group_identifier.startswith("arn:aws:rds:"):
             source_db_parameter_group_identifier = (
@@ -3363,7 +3359,7 @@ class RDSBackend(BaseBackend):
         source_db_cluster_parameter_group_identifier: str,
         target_db_cluster_parameter_group_identifier: str,
         target_db_cluster_parameter_group_description: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> DBClusterParameterGroup:
         if source_db_cluster_parameter_group_identifier.startswith("arn:aws:rds:"):
             source_db_cluster_parameter_group_identifier = (
@@ -3526,7 +3522,7 @@ class RDSBackend(BaseBackend):
         db_cluster_identifier: str,
         db_cluster_snapshot_identifier: str,
         snapshot_type: str = "manual",
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> DBClusterSnapshot:
         if db_cluster_snapshot_identifier in self.cluster_snapshots:
             raise DBClusterSnapshotAlreadyExistsError(db_cluster_snapshot_identifier)
@@ -3548,9 +3544,9 @@ class RDSBackend(BaseBackend):
         self,
         source_db_cluster_snapshot_identifier: str,
         target_db_cluster_snapshot_identifier: str,
-        kms_key_id: Optional[str] = None,
+        kms_key_id: str | None = None,
         copy_tags: bool = False,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
         **_: Any,
     ) -> DBClusterSnapshot:
         if target_db_cluster_snapshot_identifier in self.cluster_snapshots:
@@ -3589,7 +3585,7 @@ class RDSBackend(BaseBackend):
         return self.cluster_snapshots.pop(db_snapshot_identifier)
 
     def describe_db_clusters(
-        self, db_cluster_identifier: Optional[str] = None, filters: Any = None
+        self, db_cluster_identifier: str | None = None, filters: Any = None
     ) -> list[DBCluster]:
         clusters = self.clusters
         if db_cluster_identifier:
@@ -3602,9 +3598,9 @@ class RDSBackend(BaseBackend):
 
     def describe_db_cluster_snapshots(
         self,
-        db_cluster_identifier: Optional[str],
+        db_cluster_identifier: str | None,
         db_snapshot_identifier: str,
-        snapshot_type: Optional[str] = None,
+        snapshot_type: str | None = None,
         filters: Any = None,
     ) -> list[DBClusterSnapshot]:
         if snapshot_type == "shared":
@@ -3635,7 +3631,7 @@ class RDSBackend(BaseBackend):
         return list(snapshots.values())
 
     def delete_db_cluster(
-        self, cluster_identifier: str, snapshot_name: Optional[str] = None
+        self, cluster_identifier: str, snapshot_name: str | None = None
     ) -> DBCluster:
         if cluster_identifier in self.clusters:
             cluster = self.clusters[cluster_identifier]
@@ -3714,7 +3710,7 @@ class RDSBackend(BaseBackend):
             raise DBClusterSnapshotNotFoundError(snapshot_id)
 
         if snapshot_type == "snapshot":
-            snapshot: Union[DBSnapshot, DBClusterSnapshot] = self.database_snapshots[
+            snapshot: DBSnapshot | DBClusterSnapshot = self.database_snapshots[
                 snapshot_id
             ]
         else:
@@ -3885,7 +3881,7 @@ class RDSBackend(BaseBackend):
         db_cluster_parameter_group_name: str,
         db_parameter_group_family: str,
         description: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ) -> DBClusterParameterGroup:
         if db_cluster_parameter_group_name in self.db_cluster_parameter_groups:
             raise DBParameterGroupAlreadyExistsError(db_cluster_parameter_group_name)
@@ -3928,11 +3924,11 @@ class RDSBackend(BaseBackend):
     def create_global_cluster(
         self,
         global_cluster_identifier: str,
-        source_db_cluster_identifier: Optional[str],
-        engine: Optional[str],
-        engine_version: Optional[str],
-        storage_encrypted: Optional[bool],
-        deletion_protection: Optional[bool],
+        source_db_cluster_identifier: str | None,
+        engine: str | None,
+        engine_version: str | None,
+        storage_encrypted: bool | None,
+        deletion_protection: bool | None,
     ) -> GlobalCluster:
         source_cluster = None
         if source_db_cluster_identifier is not None:
@@ -3978,7 +3974,7 @@ class RDSBackend(BaseBackend):
 
     def remove_from_global_cluster(
         self, global_cluster_identifier: str, db_cluster_identifier: str
-    ) -> Optional[GlobalCluster]:
+    ) -> GlobalCluster | None:
         try:
             global_cluster = self.global_clusters[global_cluster_identifier]
             cluster = self.describe_db_clusters(
@@ -4002,8 +3998,8 @@ class RDSBackend(BaseBackend):
         self,
         db_snapshot_identifier: str,
         attribute_name: str,
-        values_to_add: Optional[list[str]] = None,
-        values_to_remove: Optional[list[str]] = None,
+        values_to_add: list[str] | None = None,
+        values_to_remove: list[str] | None = None,
     ) -> dict[str, list[str]]:
         snapshot = self.describe_db_snapshots(
             db_instance_identifier=None, db_snapshot_identifier=db_snapshot_identifier
@@ -4028,8 +4024,8 @@ class RDSBackend(BaseBackend):
         self,
         db_cluster_snapshot_identifier: str,
         attribute_name: str,
-        values_to_add: Optional[list[str]] = None,
-        values_to_remove: Optional[list[str]] = None,
+        values_to_add: list[str] | None = None,
+        values_to_remove: list[str] | None = None,
     ) -> dict[str, list[str]]:
         snapshot = self.describe_db_cluster_snapshots(
             db_cluster_identifier=None,
@@ -4049,11 +4045,11 @@ class RDSBackend(BaseBackend):
         auth: list[dict[str, str]],
         role_arn: str,
         vpc_subnet_ids: list[str],
-        vpc_security_group_ids: Optional[list[str]],
-        require_tls: Optional[bool],
-        idle_client_timeout: Optional[int],
-        debug_logging: Optional[bool],
-        tags: Optional[list[dict[str, str]]],
+        vpc_security_group_ids: list[str] | None,
+        require_tls: bool | None,
+        idle_client_timeout: int | None,
+        debug_logging: bool | None,
+        tags: list[dict[str, str]] | None,
     ) -> DBProxy:
         self._validate_db_identifier(db_proxy_name)
         if db_proxy_name in self.db_proxies:
@@ -4078,8 +4074,8 @@ class RDSBackend(BaseBackend):
 
     def describe_db_proxies(
         self,
-        db_proxy_name: Optional[str],
-        filters: Optional[list[dict[str, Any]]] = None,
+        db_proxy_name: str | None,
+        filters: list[dict[str, Any]] | None = None,
     ) -> list[DBProxy]:
         """
         The filters-argument is not yet supported
@@ -4173,7 +4169,7 @@ class RDSBackend(BaseBackend):
 
     def describe_db_instance_automated_backups(
         self,
-        db_instance_identifier: Optional[str] = None,
+        db_instance_identifier: str | None = None,
         **_: Any,
     ) -> list[DBInstanceAutomatedBackup]:
         snapshots = list(self.database_snapshots.values())
@@ -4197,8 +4193,8 @@ class RDSBackend(BaseBackend):
 
     def describe_events(
         self,
-        source_identifier: Optional[str] = None,
-        source_type: Optional[str] = None,
+        source_identifier: str | None = None,
+        source_type: str | None = None,
         **_: Any,
     ) -> list[Event]:
         if source_identifier is not None and source_type is None:
@@ -4239,7 +4235,7 @@ class RDSBackend(BaseBackend):
 
     def describe_blue_green_deployments(
         self,
-        blue_green_deployment_identifier: Optional[str] = None,
+        blue_green_deployment_identifier: str | None = None,
         filters: Any = None,
     ) -> list[BlueGreenDeployment]:
         bg_deployments = self.blue_green_deployments
@@ -4263,7 +4259,7 @@ class RDSBackend(BaseBackend):
     def switchover_blue_green_deployment(
         self,
         blue_green_deployment_identifier: str,
-        switchover_timeout: Optional[int] = 300,
+        switchover_timeout: int | None = 300,
     ) -> BlueGreenDeployment:
         if blue_green_deployment_identifier not in self.blue_green_deployments:
             raise BlueGreenDeploymentNotFoundFault(blue_green_deployment_identifier)
@@ -4345,8 +4341,8 @@ class RDSBackend(BaseBackend):
 
     def describe_db_shard_groups(
         self,
-        db_shard_group_identifier: Optional[str],
-        filters: Optional[dict[str, list[str]]],
+        db_shard_group_identifier: str | None,
+        filters: dict[str, list[str]] | None,
     ) -> list[DBShardGroup]:
         shard_groups = self.shard_groups
         if db_shard_group_identifier:
@@ -4372,8 +4368,8 @@ class OptionGroup(RDSBaseModel):
         option_group_name: str,
         engine_name: str,
         major_engine_version: str,
-        option_group_description: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        option_group_description: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(backend)
         self.engine_name = engine_name
@@ -4430,8 +4426,8 @@ class DBParameterGroup(CloudFormationModel, RDSBaseModel):
         backend: RDSBackend,
         db_parameter_group_name: str,
         description: str,
-        db_parameter_group_family: Optional[str],
-        tags: Optional[list[dict[str, str]]] = None,
+        db_parameter_group_family: str | None,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(backend)
         self.name = db_parameter_group_name
@@ -4512,7 +4508,7 @@ class DBClusterParameterGroup(CloudFormationModel, RDSBaseModel):
         db_cluster_parameter_group_name: str,
         description: str,
         db_parameter_group_family: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(backend)
         self.name = db_cluster_parameter_group_name

--- a/moto/rds/utils.py
+++ b/moto/rds/utils.py
@@ -6,7 +6,7 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from botocore.utils import merge_dicts
 
@@ -95,7 +95,7 @@ def get_object_value(obj: Any, attr: str) -> Any:
 
 
 def merge_filters(
-    filters_to_update: Optional[dict[str, Any]], filters_to_merge: dict[str, Any]
+    filters_to_update: dict[str, Any] | None, filters_to_merge: dict[str, Any]
 ) -> dict[str, Any]:
     """Given two groups of filters, merge the second into the first.
 
@@ -262,7 +262,7 @@ def get_overlap_between_two_date_ranges(
 
 def valid_preferred_maintenance_window(
     maintenance_window: Any, backup_window: Any
-) -> Optional[str]:
+) -> str | None:
     """Determines validity of preferred_maintenance_window
 
     :param maintenance_windown:

--- a/moto/rdsdata/models.py
+++ b/moto/rdsdata/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 
@@ -6,11 +6,11 @@ from moto.core.base_backend import BackendDict, BaseBackend
 class QueryResults:
     def __init__(
         self,
-        records: Optional[list[list[dict[str, Any]]]] = None,
-        column_metadata: Optional[list[dict[str, Any]]] = None,
-        number_of_records_updated: Optional[int] = None,
-        generated_fields: Optional[list[dict[str, Any]]] = None,
-        formatted_records: Optional[str] = None,
+        records: list[list[dict[str, Any]]] | None = None,
+        column_metadata: list[dict[str, Any]] | None = None,
+        number_of_records_updated: int | None = None,
+        generated_fields: list[dict[str, Any]] | None = None,
+        formatted_records: str | None = None,
     ):
         self.records = records
         self.column_metadata = column_metadata

--- a/moto/redshift/exceptions.py
+++ b/moto/redshift/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import ServiceException
 
 
@@ -24,7 +22,7 @@ class ClusterSecurityGroupNotFoundError(RedshiftClientError):
     code = "ClusterSecurityGroupNotFound"
     message = "The cluster security group name does not refer to an existing cluster security group."
 
-    def __init__(self, group_identifier: Optional[str] = None):
+    def __init__(self, group_identifier: str | None = None):
         if group_identifier:
             super().__init__(f"Security group {group_identifier} not found.")
 
@@ -83,9 +81,9 @@ class InvalidParameterValueError(RedshiftClientError):
 class ResourceNotFoundFaultError(RedshiftClientError):
     def __init__(
         self,
-        resource_type: Optional[str] = None,
-        resource_name: Optional[str] = None,
-        message: Optional[str] = None,
+        resource_type: str | None = None,
+        resource_name: str | None = None,
+        message: str | None = None,
     ):
         if resource_type and not resource_name:
             msg = f"resource of type '{resource_type}' not found."

--- a/moto/redshift/models.py
+++ b/moto/redshift/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from collections.abc import Iterable
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -39,7 +39,7 @@ class TaggableResourceMixin:
     resource_type = ""
 
     def __init__(
-        self, account_id: str, region_name: str, tags: Optional[list[dict[str, Any]]]
+        self, account_id: str, region_name: str, tags: list[dict[str, Any]] | None
     ):
         self.account_id = account_id
         self.region = region_name
@@ -90,11 +90,11 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         publicly_accessible: bool,
         encrypted: bool,
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
-        iam_roles_arn: Optional[list[str]] = None,
-        enhanced_vpc_routing: Optional[bool] = False,
+        tags: list[dict[str, str]] | None = None,
+        iam_roles_arn: list[str] | None = None,
+        enhanced_vpc_routing: bool | None = False,
         restored_from_snapshot: bool = False,
-        kms_key_id: Optional[str] = None,
+        kms_key_id: str | None = None,
     ):
         super().__init__(redshift_backend.account_id, region_name, tags)
         self.redshift_backend = redshift_backend
@@ -153,7 +153,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         self.iam_roles_arn = iam_roles_arn or []
         self.restored_from_snapshot = restored_from_snapshot
         self.kms_key_id = kms_key_id
-        self.cluster_snapshot_copy_status: Optional[dict[str, Any]] = None
+        self.cluster_snapshot_copy_status: dict[str, Any] | None = None
         self.total_storage_capacity = 0
         self.logging_details = {
             "LoggingEnabled": "false",  # Lower case is required in response so we use string to simplify
@@ -324,7 +324,7 @@ class Cluster(TaggableResourceMixin, CloudFormationModel):
         return self.total_storage_capacity
 
     @property
-    def restore_status(self) -> Optional[dict[str, Any]]:
+    def restore_status(self) -> dict[str, Any] | None:
         if not self.restored_from_snapshot:
             return None
         status = {
@@ -356,7 +356,7 @@ class SubnetGroup(TaggableResourceMixin, CloudFormationModel):
         description: str,
         subnet_ids: list[str],
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(ec2_backend.account_id, region_name, tags)
         self.ec2_backend = ec2_backend
@@ -429,7 +429,7 @@ class SecurityGroup(TaggableResourceMixin, BaseModel):
         description: str,
         account_id: str,
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(account_id, region_name, tags)
         self.cluster_security_group_name = cluster_security_group_name
@@ -453,7 +453,7 @@ class ParameterGroup(TaggableResourceMixin, CloudFormationModel):
         description: str,
         account_id: str,
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         super().__init__(account_id, region_name, tags)
         self.name = cluster_parameter_group_name
@@ -503,8 +503,8 @@ class Snapshot(TaggableResourceMixin, BaseModel):
         snapshot_identifier: str,
         account_id: str,
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
-        iam_roles_arn: Optional[list[str]] = None,
+        tags: list[dict[str, str]] | None = None,
+        iam_roles_arn: list[str] | None = None,
         snapshot_type: str = "manual",
     ):
         super().__init__(account_id, region_name, tags)
@@ -650,8 +650,8 @@ class RedshiftBackend(BaseBackend):
 
     def describe_clusters(
         self,
-        cluster_identifier: Optional[str] = None,
-        tag_keys: Optional[list[str]] = None,
+        cluster_identifier: str | None = None,
+        tag_keys: list[str] | None = None,
     ) -> list[Cluster]:
         if cluster_identifier:
             if cluster_identifier in self.clusters:
@@ -745,7 +745,7 @@ class RedshiftBackend(BaseBackend):
         description: str,
         subnet_ids: list[str],
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> SubnetGroup:
         subnet_group = SubnetGroup(
             self.ec2_backend,
@@ -759,7 +759,7 @@ class RedshiftBackend(BaseBackend):
         return subnet_group
 
     def describe_cluster_subnet_groups(
-        self, subnet_identifier: Optional[str] = None
+        self, subnet_identifier: str | None = None
     ) -> list[SubnetGroup]:
         if subnet_identifier:
             if subnet_identifier in self.subnet_groups:
@@ -776,7 +776,7 @@ class RedshiftBackend(BaseBackend):
         self,
         cluster_security_group_name: str,
         description: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> SecurityGroup:
         security_group = SecurityGroup(
             cluster_security_group_name,
@@ -789,7 +789,7 @@ class RedshiftBackend(BaseBackend):
         return security_group
 
     def describe_cluster_security_groups(
-        self, security_group_name: Optional[str] = None
+        self, security_group_name: str | None = None
     ) -> list[SecurityGroup]:
         if security_group_name:
             if security_group_name in self.security_groups:
@@ -822,7 +822,7 @@ class RedshiftBackend(BaseBackend):
         group_family: str,
         description: str,
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> ParameterGroup:
         parameter_group = ParameterGroup(
             cluster_parameter_group_name,
@@ -837,7 +837,7 @@ class RedshiftBackend(BaseBackend):
         return parameter_group
 
     def describe_cluster_parameter_groups(
-        self, parameter_group_name: Optional[str] = None
+        self, parameter_group_name: str | None = None
     ) -> list[ParameterGroup]:
         if parameter_group_name:
             if parameter_group_name in self.parameter_groups:
@@ -878,7 +878,7 @@ class RedshiftBackend(BaseBackend):
         cluster_identifier: str,
         snapshot_identifier: str,
         region_name: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
         snapshot_type: str = "manual",
     ) -> Snapshot:
         cluster = self.clusters.get(cluster_identifier)
@@ -899,9 +899,9 @@ class RedshiftBackend(BaseBackend):
 
     def describe_cluster_snapshots(
         self,
-        cluster_identifier: Optional[str] = None,
-        snapshot_identifier: Optional[str] = None,
-        snapshot_type: Optional[str] = None,
+        cluster_identifier: str | None = None,
+        snapshot_identifier: str | None = None,
+        snapshot_type: str | None = None,
     ) -> list[Snapshot]:
         snapshot_types = (
             ["automated", "manual"] if snapshot_type is None else [snapshot_type]

--- a/moto/redshiftdata/models.py
+++ b/moto/redshiftdata/models.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import Iterable, Iterator
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import iso_8601_datetime_without_milliseconds
@@ -65,7 +65,7 @@ class StatementResult(Iterable[tuple[str, Any]]):
         column_metadata: list[dict[str, Any]],
         records: list[list[dict[str, Any]]],
         total_number_rows: int,
-        next_token: Optional[str] = None,
+        next_token: str | None = None,
     ):
         self.column_metadata = column_metadata
         self.records = records
@@ -82,7 +82,7 @@ class StatementResult(Iterable[tuple[str, Any]]):
 class ColumnMetadata(Iterable[tuple[str, Any]]):
     def __init__(
         self,
-        column_default: Optional[str],
+        column_default: str | None,
         is_case_sensitive: bool,
         is_signed: bool,
         name: str,

--- a/moto/resiliencehub/models.py
+++ b/moto/resiliencehub/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -121,7 +121,7 @@ class Resource:
 
 
 class AppVersion(BaseModel):
-    def __init__(self, app_arn: str, version_name: Optional[str], identifier: int):
+    def __init__(self, app_arn: str, version_name: str | None, identifier: int):
         self.app_arn = app_arn
         self.eks_sources: list[dict[str, Any]] = []
         self.source_arns: list[str] = []

--- a/moto/resourcegroups/models.py
+++ b/moto/resourcegroups/models.py
@@ -1,7 +1,7 @@
 import json
 import re
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -18,9 +18,9 @@ class FakeResourceGroup(BaseModel):
         region_name: str,
         name: str,
         resource_query: dict[str, str],
-        description: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        configuration: Optional[list[dict[str, Any]]] = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
+        configuration: list[dict[str, Any]] | None = None,
     ):
         self.errors: list[str] = []
         description = description or ""
@@ -211,9 +211,9 @@ class FakeTagSyncTask(BaseModel):
         group_arn: str,
         group_name: str,
         role_arn: str,
-        tag_key: Optional[str] = None,
-        tag_value: Optional[str] = None,
-        resource_query: Optional[dict[str, str]] = None,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+        resource_query: dict[str, str] | None = None,
     ):
         self.group_arn = group_arn
         self.group_name = group_name
@@ -374,9 +374,9 @@ class ResourceGroupsBackend(BaseBackend):
         self,
         name: str,
         resource_query: dict[str, str],
-        description: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        configuration: Optional[list[dict[str, Any]]] = None,
+        description: str | None = None,
+        tags: dict[str, str] | None = None,
+        configuration: list[dict[str, Any]] | None = None,
     ) -> FakeResourceGroup:
         tags = tags or {}
         group = FakeResourceGroup(
@@ -437,7 +437,7 @@ class ResourceGroupsBackend(BaseBackend):
             del group.tags[key]
 
     def update_group(
-        self, group_name: str, description: Optional[str] = None
+        self, group_name: str, description: str | None = None
     ) -> FakeResourceGroup:
         if description:
             self.groups.by_name[group_name].description = description
@@ -450,9 +450,7 @@ class ResourceGroupsBackend(BaseBackend):
         self.groups.by_name[group_name].resource_query = resource_query
         return self.groups.by_name[group_name]
 
-    def get_group_configuration(
-        self, group_name: str
-    ) -> Optional[list[dict[str, Any]]]:
+    def get_group_configuration(self, group_name: str) -> list[dict[str, Any]] | None:
         group = self.groups.by_name[group_name]
         return group.configuration
 
@@ -464,8 +462,8 @@ class ResourceGroupsBackend(BaseBackend):
 
     def list_tag_sync_tasks(
         self,
-        filters: Optional[list[dict[str, str]]] = None,
-        max_results: Optional[int] = None,
+        filters: list[dict[str, str]] | None = None,
+        max_results: int | None = None,
     ) -> list[dict[str, Any]]:
         tag_sync_tasks = []
         for task in self.tag_sync_tasks.values():
@@ -476,9 +474,9 @@ class ResourceGroupsBackend(BaseBackend):
         self,
         group: str,
         role_arn: str,
-        tag_key: Optional[str] = None,
-        tag_value: Optional[str] = None,
-        resource_query: Optional[dict[str, str]] = None,
+        tag_key: str | None = None,
+        tag_value: str | None = None,
+        resource_query: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         group_arn, group_name = None, None
         group_arn_regex = r"arn:aws(-[a-z]+)*:resource-groups:[a-z]{2}(-[a-z]+)+-\d{1}:[0-9]{12}:group/([a-zA-Z0-9_\.-]{1,300}|[a-zA-Z0-9_\.-]{1,150}/[a-z0-9]{26})"

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,5 +1,5 @@
 from collections.abc import Iterator
-from typing import Any, Optional
+from typing import Any
 
 from moto.acm.models import AWSCertificateManagerBackend, acm_backends
 from moto.appsync.models import AppSyncBackend, appsync_backends
@@ -209,21 +209,21 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return dynamodb_backends[self.account_id][self.region_name]
 
     @property
-    def workspaces_backend(self) -> Optional[WorkSpacesBackend]:
+    def workspaces_backend(self) -> WorkSpacesBackend | None:
         # Workspaces service has limited region availability
         if self.region_name in workspaces_backends[self.account_id].regions:
             return workspaces_backends[self.account_id][self.region_name]
         return None
 
     @property
-    def workspacesweb_backends(self) -> Optional[WorkSpacesWebBackend]:
+    def workspacesweb_backends(self) -> WorkSpacesWebBackend | None:
         # WorkspacesWeb service has limited region availability
         if self.region_name in workspacesweb_backends[self.account_id].regions:
             return workspacesweb_backends[self.account_id][self.region_name]
         return None
 
     @property
-    def comprehend_backend(self) -> Optional[ComprehendBackend]:
+    def comprehend_backend(self) -> ComprehendBackend | None:
         # aws Comprehend has limited region availability
         if self.region_name in comprehend_backends[self.account_id].regions:
             return comprehend_backends[self.account_id][self.region_name]
@@ -238,13 +238,13 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return sagemaker_backends[self.account_id][self.region_name]
 
     @property
-    def lexv2_backend(self) -> Optional[LexModelsV2Backend]:
+    def lexv2_backend(self) -> LexModelsV2Backend | None:
         if self.region_name in lexv2models_backends[self.account_id].regions:
             return lexv2models_backends[self.account_id][self.region_name]
         return None
 
     @property
-    def clouddirectory_backend(self) -> Optional[CloudDirectoryBackend]:
+    def clouddirectory_backend(self) -> CloudDirectoryBackend | None:
         if self.region_name in clouddirectory_backends[self.account_id].regions:
             return clouddirectory_backends[self.account_id][self.region_name]
         return None
@@ -262,14 +262,14 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return cloudwatch_backends[self.account_id][self.region_name]
 
     @property
-    def connectcampaigns_backend(self) -> Optional[ConnectCampaignServiceBackend]:
+    def connectcampaigns_backend(self) -> ConnectCampaignServiceBackend | None:
         # Connect Campaigns service has limited region availability
         if self.region_name in connectcampaigns_backends[self.account_id].regions:
             return connectcampaigns_backends[self.account_id][self.region_name]
         return None
 
     @property
-    def quicksight_backend(self) -> Optional[QuickSightBackend]:
+    def quicksight_backend(self) -> QuickSightBackend | None:
         if self.region_name in quicksight_backends[self.account_id].regions:
             return quicksight_backends[self.account_id][self.region_name]
         return None
@@ -288,8 +288,8 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
     def _get_resources_generator(
         self,
-        tag_filters: Optional[list[dict[str, Any]]] = None,
-        resource_type_filters: Optional[list[str]] = None,
+        tag_filters: list[dict[str, Any]] | None = None,
+        resource_type_filters: list[str] | None = None,
     ) -> Iterator[dict[str, Any]]:
         # Look at
         # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
@@ -1581,12 +1581,12 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
     def get_resources(
         self,
-        pagination_token: Optional[str] = None,
+        pagination_token: str | None = None,
         resources_per_page: int = 50,
         tags_per_page: int = 100,
-        tag_filters: Optional[list[dict[str, Any]]] = None,
-        resource_type_filters: Optional[list[str]] = None,
-    ) -> tuple[Optional[str], list[dict[str, Any]]]:
+        tag_filters: list[dict[str, Any]] | None = None,
+        resource_type_filters: list[str] | None = None,
+    ) -> tuple[str | None, list[dict[str, Any]]]:
         # Simple range checking
         if 100 >= tags_per_page >= 500:
             raise RESTError(
@@ -1650,8 +1650,8 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return new_token, result
 
     def get_tag_keys(
-        self, pagination_token: Optional[str] = None
-    ) -> tuple[Optional[str], list[str]]:
+        self, pagination_token: str | None = None
+    ) -> tuple[str | None, list[str]]:
         if pagination_token:
             if pagination_token not in self._pages:
                 raise RESTError(
@@ -1697,8 +1697,8 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return new_token, result
 
     def get_tag_values(
-        self, pagination_token: Optional[str], key: str
-    ) -> tuple[Optional[str], list[str]]:
+        self, pagination_token: str | None, key: str
+    ) -> tuple[str | None, list[str]]:
         if pagination_token:
             if pagination_token not in self._pages:
                 raise RESTError(

--- a/moto/route53/exceptions.py
+++ b/moto/route53/exceptions.py
@@ -1,7 +1,5 @@
 """Exceptions raised by the Route53 service."""
 
-from typing import Optional
-
 from moto.core.exceptions import ServiceException
 
 
@@ -14,7 +12,7 @@ class Route53ClientError(ServiceException):
 class ConflictingDomainExists(Route53ClientError):
     """Domain already exists."""
 
-    def __init__(self, domain_name: str, delegation_set_id: Optional[str]) -> None:
+    def __init__(self, domain_name: str, delegation_set_id: str | None) -> None:
         message = (
             f"Cannot create hosted zone with DelegationSetId DelegationSetId:{delegation_set_id} as the DNSName"
             f"{domain_name} conflicts with existing ones sharing the delegation set"

--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -6,7 +6,7 @@ import re
 import string
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -45,7 +45,7 @@ class HostedZoneIdentifier(ResourceIdentifier):
     service = "route53"
     resource = "hosted_zone"
 
-    def __init__(self, account_id: str, name: str, delegation_set_id: Optional[str]):
+    def __init__(self, account_id: str, name: str, delegation_set_id: str | None):
         # the region is left blank as route53 is a global service
         super().__init__(
             account_id=account_id,
@@ -79,8 +79,8 @@ class DelegationSet(BaseModel):
     def __init__(
         self,
         caller_reference: str,
-        name_servers: Optional[list[str]],
-        delegation_set_id: Optional[str],
+        name_servers: list[str] | None,
+        delegation_set_id: str | None,
     ):
         self.caller_reference = caller_reference
         self.name_servers = name_servers or [
@@ -117,8 +117,8 @@ class HealthCheck(CloudFormationModel):
         self.disabled = health_check_args.get("disabled") or False
         self.enable_sni = health_check_args.get("enable_sni") or False
         self.caller_reference = caller_reference
-        self.children: Optional[list[str]] = None
-        self.regions: Optional[list[str]] = None
+        self.children: list[str] | None = None
+        self.regions: list[str] | None = None
         self.health_check_version = 1
 
     def set_children(self, children: list[str]) -> None:
@@ -208,7 +208,7 @@ class RecordSet(CloudFormationModel):
         self.multi_value_answer = kwargs.get("MultiValueAnswer")
 
     @property
-    def resource_records(self) -> Optional[list[dict[str, Any]]]:
+    def resource_records(self) -> list[dict[str, Any]] | None:
         records = None
         if self.records:
             records = [{"Value": value} for value in self.records]
@@ -348,8 +348,8 @@ class FakeZone(CloudFormationModel):
         id_: str,
         private_zone: bool,
         caller_reference: str,
-        comment: Optional[str] = None,
-        delegation_set: Optional[DelegationSet] = None,
+        comment: str | None = None,
+        delegation_set: DelegationSet | None = None,
     ):
         self.name = name
         self.resource_id = id_
@@ -410,9 +410,7 @@ class FakeZone(CloudFormationModel):
             if record_set.set_identifier != set_identifier
         ]
 
-    def add_vpc(
-        self, vpc_id: Optional[str], vpc_region: Optional[str]
-    ) -> dict[str, Any]:
+    def add_vpc(self, vpc_id: str | None, vpc_region: str | None) -> dict[str, Any]:
         vpc = {}
         if vpc_id is not None:
             vpc["vpc_id"] = vpc_id
@@ -541,7 +539,7 @@ class Route53Backend(BaseBackend):
         self.delegation_sets: dict[str, DelegationSet] = {}
 
     def _has_prev_conflicting_domain(
-        self, name: str, delegation_set_id: Optional[str]
+        self, name: str, delegation_set_id: str | None
     ) -> bool:
         """Check if a conflicting domain exists in the backend"""
         if not delegation_set_id:
@@ -562,11 +560,11 @@ class Route53Backend(BaseBackend):
         self,
         name: str,
         private_zone: bool,
-        caller_reference: Optional[str] = None,
-        vpcid: Optional[str] = None,
-        vpcregion: Optional[str] = None,
-        comment: Optional[str] = None,
-        delegation_set_id: Optional[str] = None,
+        caller_reference: str | None = None,
+        vpcid: str | None = None,
+        vpcregion: str | None = None,
+        comment: str | None = None,
+        delegation_set_id: str | None = None,
     ) -> FakeZone:
         if self._has_prev_conflicting_domain(name, delegation_set_id):
             raise ConflictingDomainExists(name, delegation_set_id)
@@ -676,7 +674,7 @@ class Route53Backend(BaseBackend):
 
     def list_resource_record_sets(
         self, zone_id: str, start_type: str, start_name: str, max_items: int
-    ) -> tuple[list[RecordSet], Optional[str], Optional[str], bool]:
+    ) -> tuple[list[RecordSet], str | None, str | None, bool]:
         """
         The StartRecordIdentifier-parameter is not yet implemented
         """
@@ -764,8 +762,8 @@ class Route53Backend(BaseBackend):
         return list(self.zones.values())
 
     def list_hosted_zones_by_name(
-        self, dnsname: Optional[str]
-    ) -> tuple[Optional[str], list[FakeZone]]:
+        self, dnsname: str | None
+    ) -> tuple[str | None, list[FakeZone]]:
         if dnsname:
             if dnsname[-1] != ".":
                 dnsname += "."
@@ -813,13 +811,13 @@ class Route53Backend(BaseBackend):
     def get_hosted_zone_count(self) -> int:
         return len(self.zones.values())
 
-    def get_hosted_zone_by_name(self, name: str) -> Optional[FakeZone]:
+    def get_hosted_zone_by_name(self, name: str) -> FakeZone | None:
         for zone in self.zones.values():
             if zone.name == name:
                 return zone
         return None
 
-    def delete_hosted_zone(self, id_: str) -> Optional[FakeZone]:
+    def delete_hosted_zone(self, id_: str) -> FakeZone | None:
         # Verify it exists
         zone = self.get_hosted_zone(id_)
         if len(zone.rrsets) > 0:
@@ -960,7 +958,7 @@ class Route53Backend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_query_logging_configs(
-        self, hosted_zone_id: Optional[str] = None
+        self, hosted_zone_id: str | None = None
     ) -> list[QueryLoggingConfig]:
         """Return a list of query logging configs."""
         if hosted_zone_id:
@@ -977,10 +975,10 @@ class Route53Backend(BaseBackend):
     def create_reusable_delegation_set(
         self,
         caller_reference: str,
-        delegation_set_id: Optional[str] = None,
-        hosted_zone_id: Optional[str] = None,
+        delegation_set_id: str | None = None,
+        hosted_zone_id: str | None = None,
     ) -> DelegationSet:
-        name_servers: Optional[list[str]] = None
+        name_servers: list[str] | None = None
         if hosted_zone_id:
             hosted_zone = self.get_hosted_zone(hosted_zone_id)
             name_servers = hosted_zone.delegation_set.name_servers  # type: ignore

--- a/moto/route53domains/models.py
+++ b/moto/route53domains/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.route53 import route53_backends
@@ -154,8 +154,8 @@ class Route53DomainsBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_domains(
         self,
-        filter_conditions: Optional[list[dict[str, Any]]] = None,
-        sort_condition: Optional[dict[str, Any]] = None,
+        filter_conditions: list[dict[str, Any]] | None = None,
+        sort_condition: dict[str, Any] | None = None,
     ) -> list[Route53Domain]:
         try:
             filters: list[DomainsFilter] = (
@@ -163,7 +163,7 @@ class Route53DomainsBackend(BaseBackend):
                 if filter_conditions
                 else []
             )
-            sort: Optional[DomainsSortCondition] = (
+            sort: DomainsSortCondition | None = (
                 DomainsSortCondition.validate_dict(sort_condition)
                 if sort_condition
                 else None
@@ -200,11 +200,11 @@ class Route53DomainsBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_operations(
         self,
-        submitted_since_timestamp: Optional[int] = None,
-        statuses: Optional[list[str]] = None,
-        types: Optional[list[str]] = None,
-        sort_by: Optional[str] = None,
-        sort_order: Optional[str] = None,
+        submitted_since_timestamp: int | None = None,
+        statuses: list[str] | None = None,
+        types: list[str] | None = None,
+        sort_by: str | None = None,
+        sort_order: str | None = None,
     ) -> list[Route53DomainsOperation]:
         input_errors: list[str] = []
         statuses = statuses or []

--- a/moto/route53domains/validators.py
+++ b/moto/route53domains/validators.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
@@ -644,8 +644,8 @@ class Route53DomainsOperation(BaseModel):
         type_: str,
         submitted_date: datetime,
         last_updated_date: datetime,
-        message: Optional[str] = None,
-        status_flag: Optional[str] = None,
+        message: str | None = None,
+        status_flag: str | None = None,
     ):
         self.id = id_
         self.domain_name = domain_name
@@ -662,8 +662,8 @@ class Route53DomainsOperation(BaseModel):
         domain_name: str,
         status: str,
         type_: str,
-        message: Optional[str] = None,
-        status_flag: Optional[str] = None,
+        message: str | None = None,
+        status_flag: str | None = None,
     ):
         id_ = str(mock_random.uuid4())
         submitted_date = datetime.now(timezone.utc)
@@ -700,20 +700,20 @@ class Route53DomainsOperation(BaseModel):
 class Route53DomainsContactDetail(BaseModel):
     def __init__(
         self,
-        address_line_1: Optional[str] = None,
-        address_line_2: Optional[str] = None,
-        city: Optional[str] = None,
-        contact_type: Optional[str] = None,
-        country_code: Optional[str] = None,
-        email: Optional[str] = None,
-        extra_params: Optional[list[dict[str, Any]]] = None,
-        fax: Optional[str] = None,
-        first_name: Optional[str] = None,
-        last_name: Optional[str] = None,
-        organization_name: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        state: Optional[str] = None,
-        zip_code: Optional[str] = None,
+        address_line_1: str | None = None,
+        address_line_2: str | None = None,
+        city: str | None = None,
+        contact_type: str | None = None,
+        country_code: str | None = None,
+        email: str | None = None,
+        extra_params: list[dict[str, Any]] | None = None,
+        fax: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        organization_name: str | None = None,
+        phone_number: str | None = None,
+        state: str | None = None,
+        zip_code: str | None = None,
     ):
         super().__init__()
         self.address_line_1 = address_line_1
@@ -734,20 +734,20 @@ class Route53DomainsContactDetail(BaseModel):
     @classmethod
     def validate(  # type: ignore[misc, no-untyped-def]
         cls,
-        address_line_1: Optional[str] = None,
-        address_line_2: Optional[str] = None,
-        city: Optional[str] = None,
-        contact_type: Optional[str] = None,
-        country_code: Optional[str] = None,
-        email: Optional[str] = None,
-        extra_params: Optional[list[dict[str, Any]]] = None,
-        fax: Optional[str] = None,
-        first_name: Optional[str] = None,
-        last_name: Optional[str] = None,
-        organization_name: Optional[str] = None,
-        phone_number: Optional[str] = None,
-        state: Optional[str] = None,
-        zip_code: Optional[str] = None,
+        address_line_1: str | None = None,
+        address_line_2: str | None = None,
+        city: str | None = None,
+        contact_type: str | None = None,
+        country_code: str | None = None,
+        email: str | None = None,
+        extra_params: list[dict[str, Any]] | None = None,
+        fax: str | None = None,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        organization_name: str | None = None,
+        phone_number: str | None = None,
+        state: str | None = None,
+        zip_code: str | None = None,
     ):
         input_errors: list[str] = []
 
@@ -831,7 +831,7 @@ class Route53DomainsContactDetail(BaseModel):
 
     @staticmethod
     def __validate_str_len(
-        value: Optional[str], field_name: str, max_len: int, input_errors: list[str]
+        value: str | None, field_name: str, max_len: int, input_errors: list[str]
     ) -> None:
         if value and len(value) > max_len:
             input_errors.append(f"Length of {field_name} is more than {max_len}")
@@ -863,7 +863,7 @@ class NameServer:
         self.glue_ips = glue_ips
 
     @classmethod
-    def validate(cls, name: str, glue_ips: Optional[list[str]] = None):  # type: ignore[misc,no-untyped-def]
+    def validate(cls, name: str, glue_ips: list[str] | None = None):  # type: ignore[misc,no-untyped-def]
         glue_ips = glue_ips or []
         input_errors: list[str] = []
 
@@ -961,21 +961,21 @@ class Route53Domain(BaseModel):
         admin_contact: Route53DomainsContactDetail,
         registrant_contact: Route53DomainsContactDetail,
         tech_contact: Route53DomainsContactDetail,
-        nameservers: Optional[list[dict[str, Any]]] = None,
+        nameservers: list[dict[str, Any]] | None = None,
         auto_renew: bool = True,
         admin_privacy: bool = True,
         registrant_privacy: bool = True,
         tech_privacy: bool = True,
-        registrar_name: Optional[str] = None,
-        whois_server: Optional[str] = None,
-        registrar_url: Optional[str] = None,
-        abuse_contact_email: Optional[str] = None,
-        abuse_contact_phone: Optional[str] = None,
-        registry_domain_id: Optional[str] = None,
-        expiration_date: Optional[datetime] = None,
-        reseller: Optional[str] = None,
-        dns_sec_keys: Optional[list[dict[str, Any]]] = None,
-        extra_params: Optional[list[dict[str, Any]]] = None,
+        registrar_name: str | None = None,
+        whois_server: str | None = None,
+        registrar_url: str | None = None,
+        abuse_contact_email: str | None = None,
+        abuse_contact_phone: str | None = None,
+        registry_domain_id: str | None = None,
+        expiration_date: datetime | None = None,
+        reseller: str | None = None,
+        dns_sec_keys: list[dict[str, Any]] | None = None,
+        extra_params: list[dict[str, Any]] | None = None,
     ):
         input_errors: list[str] = []
 

--- a/moto/route53resolver/models.py
+++ b/moto/route53resolver/models.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from datetime import datetime, timezone
 from ipaddress import IPv4Address, ip_address, ip_network
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -99,8 +99,8 @@ class ResolverRule(BaseModel):
         creator_request_id: str,
         rule_type: str,
         domain_name: str,
-        target_ips: Optional[list[dict[str, Any]]],
-        resolver_endpoint_id: Optional[str],
+        target_ips: list[dict[str, Any]] | None,
+        resolver_endpoint_id: str | None,
         name: str,
     ):
         self.account_id = account_id
@@ -1076,7 +1076,7 @@ class Route53ResolverBackend(BaseBackend):
         name: str,
         destination_arn: str,
         creator_request_id: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> ResolverQueryLogConfig:
         if tags:
             errmsg = self.tagger.validate_tags(

--- a/moto/route53resolver/validations.py
+++ b/moto/route53resolver/validations.py
@@ -4,7 +4,7 @@ Note that ValidationExceptions are accumulative.
 """
 
 import re
-from typing import Any, Optional
+from typing import Any
 
 from moto.route53resolver.exceptions import RRValidationException
 
@@ -45,14 +45,14 @@ def validate_args(validators: list[tuple[str, Any]]) -> None:
         raise RRValidationException(err_msgs)
 
 
-def validate_creator_request_id(value: Optional[str]) -> str:
+def validate_creator_request_id(value: str | None) -> str:
     """Raise exception if the creator_request_id has invalid length."""
     if value and len(value) > 255:
         return "have length less than or equal to 255"
     return ""
 
 
-def validate_direction(value: Optional[str]) -> str:
+def validate_direction(value: str | None) -> str:
     """Raise exception if direction not one of the allowed values."""
     if value and value not in ["INBOUND", "OUTBOUND"]:
         return "satisfy enum value set: [INBOUND, OUTBOUND]"
@@ -66,7 +66,7 @@ def validate_domain_name(value: str) -> str:
     return ""
 
 
-def validate_endpoint_id(value: Optional[str]) -> str:
+def validate_endpoint_id(value: str | None) -> str:
     """Raise exception if resolver endpoint id has invalid length."""
     if value and len(value) > 64:
         return "have length less than or equal to 64"
@@ -80,14 +80,14 @@ def validate_ip_addresses(value: str) -> str:
     return ""
 
 
-def validate_max_results(value: Optional[int]) -> str:
+def validate_max_results(value: int | None) -> str:
     """Raise exception if number of endpoints or IPs is too large."""
     if value and value > 100:
         return "have length less than or equal to 100"
     return ""
 
 
-def validate_name(value: Optional[str]) -> str:
+def validate_name(value: str | None) -> str:
     """Raise exception if name fails to match constraints."""
     if value:
         if len(value) > 64:
@@ -98,21 +98,21 @@ def validate_name(value: Optional[str]) -> str:
     return ""
 
 
-def validate_rule_association_id(value: Optional[str]) -> str:
+def validate_rule_association_id(value: str | None) -> str:
     """Raise exception if resolver rule association id has invalid length."""
     if value and len(value) > 64:
         return "have length less than or equal to 64"
     return ""
 
 
-def validate_rule_id(value: Optional[str]) -> str:
+def validate_rule_id(value: str | None) -> str:
     """Raise exception if resolver rule id has invalid length."""
     if value and len(value) > 64:
         return "have length less than or equal to 64"
     return ""
 
 
-def validate_rule_type(value: Optional[str]) -> str:
+def validate_rule_type(value: str | None) -> str:
     """Raise exception if rule_type not one of the allowed values."""
     if value and value not in ["FORWARD", "SYSTEM", "RECURSIVE"]:
         return "satisfy enum value set: [FORWARD, SYSTEM, RECURSIVE]"
@@ -139,7 +139,7 @@ def validate_subnets(value: list[dict[str, Any]]) -> str:
     return ""
 
 
-def validate_target_port(value: Optional[dict[str, int]]) -> str:
+def validate_target_port(value: dict[str, int] | None) -> str:
     """Raise exception if target port fails to match length constraint."""
     if value and value["Port"] > 65535:
         return "have value less than or equal to 65535"

--- a/moto/s3/config.py
+++ b/moto/s3/config.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import ConfigQueryModel
 from moto.core.exceptions import InvalidNextTokenException
@@ -12,14 +12,14 @@ class S3ConfigQuery(ConfigQueryModel[S3Backend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[list[str]],
-        resource_name: Optional[str],
+        resource_ids: list[str] | None,
+        resource_name: str | None,
         limit: int,
-        next_token: Optional[str],
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-        aggregator: Optional[dict[str, Any]] = None,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        next_token: str | None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+        aggregator: dict[str, Any] | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         # The resource_region only matters for aggregated queries as you can filter on bucket regions for them.
         # For other resource types, you would need to iterate appropriately for the backend_region.
 
@@ -101,10 +101,10 @@ class S3ConfigQuery(ConfigQueryModel[S3Backend]):
         account_id: str,
         partition: str,
         resource_id: str,
-        resource_name: Optional[str] = None,
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        resource_name: str | None = None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+    ) -> dict[str, Any] | None:
         # Get the bucket:
         bucket = self.backends[account_id][partition].buckets.get(resource_id)
 

--- a/moto/s3/exceptions.py
+++ b/moto/s3/exceptions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from werkzeug.exceptions import RequestedRangeNotSatisfiable
 
@@ -62,7 +62,7 @@ class MissingBucket(BucketError):
 class MissingKey(S3ClientError):
     code = "NoSuchKey"
 
-    def __init__(self, key: Optional[str] = None):
+    def __init__(self, key: str | None = None):
         super().__init__("The specified key does not exist.")
         self.key = key
 
@@ -70,9 +70,7 @@ class MissingKey(S3ClientError):
 class MissingVersion(S3ClientError):
     code = "NoSuchVersion"
 
-    def __init__(
-        self, key: Optional[str] = None, version_id: Optional[str] = None
-    ) -> None:
+    def __init__(self, key: str | None = None, version_id: str | None = None) -> None:
         super().__init__("The specified version does not exist.")
         self.key = key
         self.version_id = version_id
@@ -244,7 +242,7 @@ class InvalidNotificationEvent(S3ClientError):
 
 
 class InvalidStorageClass(S3ClientError):
-    def __init__(self, storage: Optional[str]):
+    def __init__(self, storage: str | None):
         super().__init__(
             "InvalidStorageClass", "The storage class you specified is not valid"
         )
@@ -398,7 +396,7 @@ class InvalidBucketState(S3ClientError):
 class InvalidObjectState(S3ClientError):
     code = "InvalidObjectState"
 
-    def __init__(self, storage_class: Optional[str]):
+    def __init__(self, storage_class: str | None):
         super().__init__("The operation is not valid for the object's storage class")
         self.storage_class = storage_class
 
@@ -471,9 +469,7 @@ class HeadOnDeleteMarker(Exception):
 class MethodNotAllowed(S3ClientError):
     code = "MethodNotAllowed"
 
-    def __init__(
-        self, method: Optional[str] = None, resource_type: Optional[str] = None
-    ):
+    def __init__(self, method: str | None = None, resource_type: str | None = None):
         super().__init__("The specified method is not allowed against this resource.")
         self.method = method
         self.resource_type = resource_type

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import bz2
 import codecs
@@ -17,7 +19,7 @@ from collections.abc import Iterator
 from enum import Enum
 from importlib import reload
 from io import BytesIO
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 from moto.cloudwatch.models import MetricDatum
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -99,7 +101,7 @@ class TransitionDefaultMinimumObjectSize(Enum):
 
 
 class FakeDeleteMarker(BaseModel):
-    def __init__(self, key: "FakeKey"):
+    def __init__(self, key: FakeKey):
         self.key = key
         self.name = key.name
         self.last_modified = utcnow()
@@ -121,22 +123,22 @@ class FakeKey(BaseModel, ManagedState):
         value: bytes,
         account_id: str,
         region_name: str,
-        storage: Optional[str] = "STANDARD",
-        etag: Optional[str] = None,
+        storage: str | None = "STANDARD",
+        etag: str | None = None,
         is_versioned: bool = False,
-        version_id: Optional[str] = None,
-        max_buffer_size: Optional[int] = None,
-        multipart: Optional["FakeMultipart"] = None,
-        bucket_name: Optional[str] = None,
-        encryption: Optional[str] = None,
-        kms_key_id: Optional[str] = None,
+        version_id: str | None = None,
+        max_buffer_size: int | None = None,
+        multipart: FakeMultipart | None = None,
+        bucket_name: str | None = None,
+        encryption: str | None = None,
+        kms_key_id: str | None = None,
         bucket_key_enabled: Any = None,
-        lock_mode: Optional[str] = None,
-        lock_legal_status: Optional[str] = None,
-        lock_until: Optional[str] = None,
-        checksum_value: Optional[str] = None,
-        checksum_type: Optional[str] = None,
-        checksum_parts: Optional[int] = None,
+        lock_mode: str | None = None,
+        lock_legal_status: str | None = None,
+        lock_until: str | None = None,
+        checksum_value: str | None = None,
+        checksum_type: str | None = None,
+        checksum_parts: int | None = None,
     ):
         ManagedState.__init__(
             self,
@@ -151,12 +153,12 @@ class FakeKey(BaseModel, ManagedState):
         self.region_name = region_name
         self.partition = get_partition(region_name)
         self.last_modified = utcnow()
-        self.acl: Optional[FakeAcl] = get_canned_acl("private")
-        self.website_redirect_location: Optional[str] = None
-        self.checksum_algorithm: Optional[str] = None
-        self._storage_class: Optional[str] = storage if storage else "STANDARD"
+        self.acl: FakeAcl | None = get_canned_acl("private")
+        self.website_redirect_location: str | None = None
+        self.checksum_algorithm: str | None = None
+        self._storage_class: str | None = storage if storage else "STANDARD"
         self._metadata = LowercaseDict()
-        self._expiry: Optional[datetime.datetime] = None
+        self._expiry: datetime.datetime | None = None
         self._etag = etag
         self._version_id = version_id
         self._is_versioned = is_versioned
@@ -185,7 +187,7 @@ class FakeKey(BaseModel, ManagedState):
         # Default metadata values
         self._metadata["Content-Type"] = "binary/octet-stream"
 
-    def safe_name(self, encoding_type: Optional[str] = None) -> str:
+    def safe_name(self, encoding_type: str | None = None) -> str:
         if encoding_type == "url":
             return urllib.parse.quote(self.name)
         return self.name
@@ -220,7 +222,7 @@ class FakeKey(BaseModel, ManagedState):
         self.contentsize = len(new_value)
 
     @property
-    def status(self) -> Optional[str]:
+    def status(self) -> str | None:
         previous = self._status
         new_status = super().status
         if previous != "RESTORED" and new_status == "RESTORED":
@@ -251,15 +253,15 @@ class FakeKey(BaseModel, ManagedState):
                 metadata["Content-Encoding"] = encoding
         self._metadata.update(metadata)
 
-    def set_storage_class(self, storage: Optional[str]) -> None:
+    def set_storage_class(self, storage: str | None) -> None:
         if storage is not None and storage not in STORAGE_CLASS:
             raise InvalidStorageClass(storage=storage)
         self._storage_class = storage
 
-    def set_expiry(self, expiry: Optional[datetime.datetime]) -> None:
+    def set_expiry(self, expiry: datetime.datetime | None) -> None:
         self._expiry = expiry
 
-    def set_acl(self, acl: Optional["FakeAcl"]) -> None:
+    def set_acl(self, acl: FakeAcl | None) -> None:
         self.acl = acl
 
     def restore(self, days: int) -> None:
@@ -358,11 +360,11 @@ class FakeKey(BaseModel, ManagedState):
         return self.contentsize
 
     @property
-    def storage_class(self) -> Optional[str]:
+    def storage_class(self) -> str | None:
         return self._storage_class
 
     @property
-    def expiry_date(self) -> Optional[str]:
+    def expiry_date(self) -> str | None:
         if self._expiry is not None:
             return self._expiry.strftime("%a, %d %b %Y %H:%M:%S GMT")
         return None
@@ -443,11 +445,11 @@ class FakeMultipart(BaseModel):
         metadata: CaseInsensitiveDict,  # type: ignore
         account_id: str,
         region_name: str,
-        storage: Optional[str] = None,
-        tags: Optional[dict[str, str]] = None,
-        acl: Optional["FakeAcl"] = None,
-        sse_encryption: Optional[str] = None,
-        kms_key_id: Optional[str] = None,
+        storage: str | None = None,
+        tags: dict[str, str] | None = None,
+        acl: FakeAcl | None = None,
+        sse_encryption: str | None = None,
+        kms_key_id: str | None = None,
     ):
         self.key_name = key_name
         self.metadata = metadata
@@ -467,9 +469,9 @@ class FakeMultipart(BaseModel):
 
     def complete(
         self, body: Iterator[tuple[int, str]]
-    ) -> tuple[bytearray, str, Optional[tuple[str, str, int]]]:
-        checksum_algo: Optional[str] = self.metadata.get("x-amz-checksum-algorithm")
-        checksum_type: Optional[str] = self.metadata.get("x-amz-checksum-type")
+    ) -> tuple[bytearray, str, tuple[str, str, int] | None]:
+        checksum_algo: str | None = self.metadata.get("x-amz-checksum-algorithm")
+        checksum_type: str | None = self.metadata.get("x-amz-checksum-type")
         decode_hex = codecs.getdecoder("hex_codec")
         total = bytearray()
         md5s = bytearray()
@@ -532,7 +534,7 @@ class FakeMultipart(BaseModel):
 
 
 class MultipartChecksumBuilder:
-    def __init__(self, checksum_algorithm: Optional[str], checksum_type: Optional[str]):
+    def __init__(self, checksum_algorithm: str | None, checksum_type: str | None):
         self.complete_object = bytearray()
         self.checksum = bytearray()
 
@@ -558,7 +560,7 @@ class MultipartChecksumBuilder:
 
         self.part_count += 1
 
-    def build(self) -> Optional[tuple[str, str, int]]:
+    def build(self) -> tuple[str, str, int] | None:
         if self.checksum_type == "COMPOSITE":
             return (
                 self.checksum_type,
@@ -631,7 +633,7 @@ class FakeGrant(BaseModel):
 
 
 class FakeAcl(BaseModel):
-    def __init__(self, grants: Optional[list[FakeGrant]] = None):
+    def __init__(self, grants: list[FakeGrant] | None = None):
         self.grants = grants or []
 
     @property
@@ -721,14 +723,14 @@ def get_canned_acl(acl: str) -> FakeAcl:
 
 
 class LifecycleFilter(BaseModel):
-    tag_key: Optional[str]
-    tag_value: Optional[str]
+    tag_key: str | None
+    tag_value: str | None
 
     def __init__(
         self,
-        prefix: Optional[str] = None,
-        tag: Optional[tuple[str, str]] = None,
-        and_filter: Optional["LifecycleAndFilter"] = None,
+        prefix: str | None = None,
+        tag: tuple[str, str] | None = None,
+        and_filter: LifecycleAndFilter | None = None,
     ):
         self.prefix = prefix
         (self.tag_key, self.tag_value) = tag if tag else (None, None)
@@ -758,9 +760,7 @@ class LifecycleFilter(BaseModel):
 
 
 class LifecycleAndFilter(BaseModel):
-    def __init__(
-        self, prefix: Optional[str] = None, tags: Optional[dict[str, str]] = None
-    ):
+    def __init__(self, prefix: str | None = None, tags: dict[str, str] | None = None):
         self.prefix = prefix
         self.tags = tags or {}
 
@@ -781,9 +781,9 @@ class LifecycleAndFilter(BaseModel):
 class LifecycleTransition(BaseModel):
     def __init__(
         self,
-        date: Optional[str] = None,
-        days: Optional[int] = None,
-        storage_class: Optional[str] = None,
+        date: str | None = None,
+        days: int | None = None,
+        storage_class: str | None = None,
     ):
         self.date = date
         self.days = days
@@ -802,7 +802,7 @@ class LifecycleTransition(BaseModel):
 
 class LifeCycleNoncurrentVersionTransition(BaseModel):
     def __init__(
-        self, days: int, storage_class: str, newer_versions: Optional[int] = None
+        self, days: int, storage_class: str, newer_versions: int | None = None
     ):
         self.newer_versions = newer_versions
         self.days = days
@@ -822,19 +822,19 @@ class LifeCycleNoncurrentVersionTransition(BaseModel):
 class LifecycleRule(BaseModel):
     def __init__(
         self,
-        rule_id: Optional[str] = None,
-        prefix: Optional[str] = None,
-        lc_filter: Optional[LifecycleFilter] = None,
-        status: Optional[str] = None,
-        expiration_days: Optional[str] = None,
-        expiration_date: Optional[str] = None,
-        transitions: Optional[list[LifecycleTransition]] = None,
-        expired_object_delete_marker: Optional[str] = None,
-        nve_noncurrent_days: Optional[str] = None,
+        rule_id: str | None = None,
+        prefix: str | None = None,
+        lc_filter: LifecycleFilter | None = None,
+        status: str | None = None,
+        expiration_days: str | None = None,
+        expiration_date: str | None = None,
+        transitions: list[LifecycleTransition] | None = None,
+        expired_object_delete_marker: str | None = None,
+        nve_noncurrent_days: str | None = None,
         noncurrent_version_transitions: Optional[
             list[LifeCycleNoncurrentVersionTransition]
         ] = None,
-        aimu_days: Optional[str] = None,
+        aimu_days: str | None = None,
     ):
         self.id = rule_id
         self.prefix = prefix
@@ -931,8 +931,8 @@ class Notification(BaseModel):
         self,
         arn: str,
         events: list[str],
-        filters: Optional[dict[str, Any]] = None,
-        notification_id: Optional[str] = None,
+        filters: dict[str, Any] | None = None,
+        notification_id: str | None = None,
     ):
         self.id = notification_id or "".join(
             random.choice(string.ascii_letters + string.digits) for _ in range(50)
@@ -996,10 +996,10 @@ class Notification(BaseModel):
 class NotificationConfiguration(BaseModel):
     def __init__(
         self,
-        topic: Optional[list[dict[str, Any]]] = None,
-        queue: Optional[list[dict[str, Any]]] = None,
-        cloud_function: Optional[list[dict[str, Any]]] = None,
-        event_bridge: Optional[dict[str, Any]] = None,
+        topic: list[dict[str, Any]] | None = None,
+        queue: list[dict[str, Any]] | None = None,
+        cloud_function: list[dict[str, Any]] | None = None,
+        event_bridge: dict[str, Any] | None = None,
     ):
         self.topic = (
             [
@@ -1071,10 +1071,10 @@ class NotificationConfiguration(BaseModel):
 class PublicAccessBlock(BaseModel):
     def __init__(
         self,
-        block_public_acls: Optional[Union[str, bool]],
-        ignore_public_acls: Optional[Union[str, bool]],
-        block_public_policy: Optional[Union[str, bool]],
-        restrict_public_buckets: Optional[Union[str, bool]],
+        block_public_acls: str | int | None,
+        ignore_public_acls: str | int | None,
+        block_public_policy: str | int | None,
+        restrict_public_buckets: str | int | None,
     ):
         self.block_public_acls = ensure_boolean(block_public_acls)
         self.ignore_public_acls = ensure_boolean(ignore_public_acls)
@@ -1103,7 +1103,7 @@ class FakeBucket(CloudFormationModel):
         name: str,
         account_id: str,
         region_name: str,
-        bucket_namespace: Optional[str] = None,
+        bucket_namespace: str | None = None,
     ):
         self.name = name
         self.account_id = account_id
@@ -1112,24 +1112,24 @@ class FakeBucket(CloudFormationModel):
         self.partition = get_partition(region_name)
         self.keys = _VersionedKeyStore()
         self.multiparts = MultipartDict()
-        self.versioning_status: Optional[str] = None
+        self.versioning_status: str | None = None
         self.rules: list[LifecycleRule] = []
-        self.policy: Optional[bytes] = None
-        self.website_configuration: Optional[bytes] = None
-        self.acl: Optional[FakeAcl] = get_canned_acl("private")
+        self.policy: bytes | None = None
+        self.website_configuration: bytes | None = None
+        self.acl: FakeAcl | None = get_canned_acl("private")
         self.cors: list[CorsRule] = []
         self.logging: dict[str, Any] = {}
-        self.notification_configuration: Optional[NotificationConfiguration] = None
-        self.accelerate_configuration: Optional[str] = None
+        self.notification_configuration: NotificationConfiguration | None = None
+        self.accelerate_configuration: str | None = None
         self.payer = "BucketOwner"
         self.creation_date = datetime.datetime.now(tz=datetime.timezone.utc)
-        self.public_access_block: Optional[PublicAccessBlock] = None
-        self.encryption: Optional[dict[str, Any]] = None
+        self.public_access_block: PublicAccessBlock | None = None
+        self.encryption: dict[str, Any] | None = None
         self.object_lock_enabled = False
-        self.default_lock_mode: Optional[str] = ""
-        self.default_lock_days: Optional[int] = 0
-        self.default_lock_years: Optional[int] = 0
-        self.ownership_rule: Optional[dict[str, Any]] = None
+        self.default_lock_mode: str | None = ""
+        self.default_lock_days: int | None = 0
+        self.default_lock_years: int | None = 0
+        self.ownership_rule: dict[str, Any] | None = None
         self.inventory_configs: dict[str, FakeBucketInventoryConfiguration] = {}
         s3_backends.bucket_accounts[name] = (self.partition, account_id)
 
@@ -1353,7 +1353,7 @@ class FakeBucket(CloudFormationModel):
 
     @staticmethod
     def _log_permissions_enabled_policy(
-        target_bucket: "FakeBucket", target_prefix: Optional[str]
+        target_bucket: FakeBucket, target_prefix: str | None
     ) -> bool:
         target_bucket_policy = target_bucket.policy
         if target_bucket_policy:
@@ -1382,7 +1382,7 @@ class FakeBucket(CloudFormationModel):
         return False
 
     @staticmethod
-    def _log_permissions_enabled_acl(target_bucket: "FakeBucket") -> bool:
+    def _log_permissions_enabled_acl(target_bucket: FakeBucket) -> bool:
         write = read_acp = False
         for grant in target_bucket.acl.grants:  # type: ignore
             # Must be granted to: http://acs.amazonaws.com/groups/s3/LogDelivery
@@ -1404,7 +1404,7 @@ class FakeBucket(CloudFormationModel):
         return write and read_acp
 
     def set_logging(
-        self, logging_config: Optional[dict[str, Any]], bucket_backend: "S3Backend"
+        self, logging_config: dict[str, Any] | None, bucket_backend: S3Backend
     ) -> None:
         if not logging_config:
             self.logging = {}
@@ -1438,7 +1438,7 @@ class FakeBucket(CloudFormationModel):
         self.logging = logging_config
 
     def set_notification_configuration(
-        self, notification_config: Optional[dict[str, Any]]
+        self, notification_config: dict[str, Any] | None
     ) -> None:
         if not notification_config:
             self.notification_configuration = None
@@ -1493,7 +1493,7 @@ class FakeBucket(CloudFormationModel):
             return self.website_url
         raise UnformattedGetAttTemplateException()
 
-    def set_acl(self, acl: Optional[FakeAcl]) -> None:
+    def set_acl(self, acl: FakeAcl | None) -> None:
         self.acl = acl
 
     @property
@@ -1537,7 +1537,7 @@ class FakeBucket(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "FakeBucket":
+    ) -> FakeBucket:
         partition = get_partition(region_name)
         backend = s3_backends[account_id][partition]
         bucket = backend.create_bucket(resource_name, region_name)
@@ -1563,7 +1563,7 @@ class FakeBucket(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "FakeBucket":
+    ) -> FakeBucket:
         properties = cloudformation_json["Properties"]
         backend = s3_backends[account_id][get_partition(region_name)]
         # BucketName is not mandatory - a random name will be autogenerated if not supplied
@@ -1721,8 +1721,8 @@ class FakeBucketInventoryConfiguration(BaseModel):
         destination: dict[str, Any],
         is_enabled: bool,
         schedule: dict[str, Any],
-        filters: Optional[dict[str, Any]] = None,
-        optional_fields: Optional[list[str]] = None,
+        filters: dict[str, Any] | None = None,
+        optional_fields: list[str] | None = None,
     ):
         self.id = id
         self.destination = destination
@@ -1941,7 +1941,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         region_name: str,
-        bucket_namespace: Optional[str] = None,
+        bucket_namespace: str | None = None,
     ) -> FakeBucket:
         if bucket_name in s3_backends.bucket_accounts.keys():
             raise BucketAlreadyExists(bucket=bucket_name)
@@ -1985,9 +1985,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def list_buckets(
         self,
-        prefix: Optional[str],
-        bucket_region: Optional[str],
-        max_buckets: Optional[str],
+        prefix: str | None,
+        bucket_region: str | None,
+        max_buckets: str | None,
     ) -> list[FakeBucket]:
         buckets = self.buckets
         if prefix:
@@ -2025,7 +2025,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def head_bucket(self, bucket_name: str) -> FakeBucket:
         return self.get_bucket(bucket_name)
 
-    def delete_bucket(self, bucket_name: str) -> Optional[FakeBucket]:
+    def delete_bucket(self, bucket_name: str) -> FakeBucket | None:
         bucket = self.get_bucket(bucket_name)
         if bucket.keys:
             # Can't delete a bucket with keys
@@ -2034,7 +2034,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             s3_backends.bucket_accounts.pop(bucket_name, None)
             return self.buckets.pop(bucket_name)
 
-    def delete_table_storage_bucket(self, bucket_name: str) -> Optional[FakeBucket]:
+    def delete_table_storage_bucket(self, bucket_name: str) -> FakeBucket | None:
         bucket = self.get_bucket(bucket_name)
         assert isinstance(bucket, FakeTableStorageBucket)
         # table storage buckets can be deleted while not empty
@@ -2047,29 +2047,29 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         s3_backends.bucket_accounts.pop(bucket_name, None)
         return self.table_buckets.pop(bucket_name)
 
-    def get_bucket_accelerate_configuration(self, bucket_name: str) -> Optional[str]:
+    def get_bucket_accelerate_configuration(self, bucket_name: str) -> str | None:
         bucket = self.get_bucket(bucket_name)
         return bucket.accelerate_configuration
 
     def put_bucket_versioning(self, bucket_name: str, status: str) -> None:
         self.get_bucket(bucket_name).versioning_status = status
 
-    def get_bucket_versioning(self, bucket_name: str) -> Optional[str]:
+    def get_bucket_versioning(self, bucket_name: str) -> str | None:
         return self.get_bucket(bucket_name).versioning_status
 
-    def get_bucket_encryption(self, bucket_name: str) -> Optional[dict[str, Any]]:
+    def get_bucket_encryption(self, bucket_name: str) -> dict[str, Any] | None:
         return self.get_bucket(bucket_name).encryption
 
     def list_object_versions(
         self,
         bucket_name: str,
-        delimiter: Optional[str] = None,
-        key_marker: Optional[str] = None,
-        max_keys: Optional[int] = 1000,
+        delimiter: str | None = None,
+        key_marker: str | None = None,
+        max_keys: int | None = 1000,
         prefix: str = "",
-        version_id_marker: Optional[str] = None,
+        version_id_marker: str | None = None,
     ) -> tuple[
-        list[FakeKey], list[str], list[FakeDeleteMarker], Optional[str], Optional[str]
+        list[FakeKey], list[str], list[FakeDeleteMarker], str | None, str | None
     ]:
         """
         The default value for the MaxKeys-argument is 100. This can be configured with an environment variable:
@@ -2081,8 +2081,8 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         common_prefixes: set[str] = set()
         requested_versions: list[FakeKey] = []
         delete_markers: list[FakeDeleteMarker] = []
-        next_key_marker: Optional[str] = None
-        next_version_id_marker: Optional[str] = None
+        next_key_marker: str | None = None
+        next_version_id_marker: str | None = None
         all_versions = list(
             itertools.chain(
                 *(
@@ -2096,7 +2096,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         last_name = None
 
         skip_versions = True
-        last_item_added: Union[None, FakeKey, FakeDeleteMarker] = None
+        last_item_added: None | FakeKey | FakeDeleteMarker = None
         for version in all_versions:
             name = version.name
             # guaranteed to be sorted - so the first key with this name will be the latest
@@ -2182,7 +2182,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             next_version_id_marker,
         )
 
-    def get_bucket_policy(self, bucket_name: str) -> Optional[bytes]:
+    def get_bucket_policy(self, bucket_name: str) -> bytes | None:
         return self.get_bucket(bucket_name).policy
 
     def put_bucket_policy(self, bucket_name: str, policy: bytes) -> None:
@@ -2207,9 +2207,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def delete_bucket_encryption(self, bucket_name: str) -> None:
         self.get_bucket(bucket_name).encryption = None
 
-    def get_bucket_ownership_controls(
-        self, bucket_name: str
-    ) -> Optional[dict[str, Any]]:
+    def get_bucket_ownership_controls(self, bucket_name: str) -> dict[str, Any] | None:
         return self.get_bucket(bucket_name).ownership_rule
 
     def put_bucket_ownership_controls(
@@ -2220,7 +2218,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def delete_bucket_ownership_controls(self, bucket_name: str) -> None:
         self.get_bucket(bucket_name).ownership_rule = None
 
-    def get_bucket_replication(self, bucket_name: str) -> Optional[dict[str, Any]]:
+    def get_bucket_replication(self, bucket_name: str) -> dict[str, Any] | None:
         bucket = self.get_bucket(bucket_name)
         return getattr(bucket, "replication", None)
 
@@ -2266,7 +2264,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket = self.get_bucket(bucket_name)
         bucket.website_configuration = website_configuration
 
-    def get_bucket_website_configuration(self, bucket_name: str) -> Optional[bytes]:
+    def get_bucket_website_configuration(self, bucket_name: str) -> bytes | None:
         bucket = self.get_bucket(bucket_name)
         return bucket.website_configuration
 
@@ -2287,19 +2285,19 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket_name: str,
         key_name: str,
         value: bytes,
-        storage: Optional[str] = None,
-        etag: Optional[str] = None,
-        multipart: Optional[FakeMultipart] = None,
-        encryption: Optional[str] = None,
-        kms_key_id: Optional[str] = None,
+        storage: str | None = None,
+        etag: str | None = None,
+        multipart: FakeMultipart | None = None,
+        encryption: str | None = None,
+        kms_key_id: str | None = None,
         bucket_key_enabled: Any = None,
-        lock_mode: Optional[str] = None,
-        lock_legal_status: Optional[str] = None,
-        lock_until: Optional[str] = None,
-        checksum_value: Optional[str] = None,
+        lock_mode: str | None = None,
+        lock_legal_status: str | None = None,
+        lock_until: str | None = None,
+        checksum_value: str | None = None,
         # arguments to handle notification
-        request_method: Optional[str] = "PUT",
-        disable_notification: Optional[bool] = False,
+        request_method: str | None = "PUT",
+        disable_notification: bool | None = False,
     ) -> FakeKey:
         if storage is not None and storage not in STORAGE_CLASS:
             raise InvalidStorageClass(storage=storage)
@@ -2372,8 +2370,8 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         key_name: str,
-        acl: Optional[FakeAcl],
-        disable_notification: Optional[bool] = False,
+        acl: FakeAcl | None,
+        disable_notification: bool | None = False,
     ) -> None:
         key = self.get_object(bucket_name, key_name)
         # TODO: Support the XML-based ACL format
@@ -2396,7 +2394,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         key_name: str,
-        version_id: Optional[str],
+        version_id: str | None,
         legal_hold_status: dict[str, Any],
     ) -> None:
         key = self.get_object(bucket_name, key_name, version_id=version_id)
@@ -2406,8 +2404,8 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         key_name: str,
-        version_id: Optional[str],
-        retention: tuple[Optional[str], Optional[str]],
+        version_id: str | None,
+        retention: tuple[str | None, str | None],
     ) -> None:
         key = self.get_object(bucket_name, key_name, version_id=version_id)
         key.lock_mode = retention[0]  # type: ignore
@@ -2443,10 +2441,10 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         key_name: str,
-        version_id: Optional[str] = None,
-        part_number: Optional[str] = None,
+        version_id: str | None = None,
+        part_number: str | None = None,
         return_delete_marker: bool = False,
-    ) -> Optional[FakeKey]:
+    ) -> FakeKey | None:
         bucket = self.get_bucket(bucket_name)
 
         key = None
@@ -2476,9 +2474,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         key_name: str,
-        version_id: Optional[str] = None,
-        part_number: Optional[str] = None,
-    ) -> Optional[FakeKey]:
+        version_id: str | None = None,
+        part_number: str | None = None,
+    ) -> FakeKey | None:
         obj = self.get_object(
             bucket_name, key_name, version_id, part_number, return_delete_marker=True
         )
@@ -2486,15 +2484,15 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             raise HeadOnDeleteMarker(obj)
         return obj
 
-    def get_object_acl(self, key: FakeKey) -> Optional[FakeAcl]:
+    def get_object_acl(self, key: FakeKey) -> FakeAcl | None:
         return key.acl
 
-    def get_object_legal_hold(self, key: FakeKey) -> Optional[str]:
+    def get_object_legal_hold(self, key: FakeKey) -> str | None:
         return key.lock_legal_status
 
     def get_object_lock_configuration(
         self, bucket_name: str
-    ) -> tuple[bool, Optional[str], Optional[int], Optional[int]]:
+    ) -> tuple[bool, str | None, int | None, int | None]:
         bucket = self.get_bucket(bucket_name)
         if not bucket.object_lock_enabled:
             raise ObjectLockConfigurationNotFoundError
@@ -2511,7 +2509,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def put_object_tagging(
         self,
         key: FakeKey,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> FakeKey:
         # get bucket for eventbridge notification
         # we can assume that the key has its bucket
@@ -2553,9 +2551,9 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         lock_enabled: bool,
-        mode: Optional[str] = None,
-        days: Optional[int] = None,
-        years: Optional[int] = None,
+        mode: str | None = None,
+        days: int | None = None,
+        years: int | None = None,
     ) -> None:
         bucket = self.get_bucket(bucket_name)
         if not bucket.is_versioned:
@@ -2637,7 +2635,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket.set_accelerate_configuration(accelerate_configuration)
 
     def put_public_access_block(
-        self, bucket_name: str, pub_block_config: Optional[dict[str, Any]]
+        self, bucket_name: str, pub_block_config: dict[str, Any] | None
     ) -> None:
         bucket = self.get_bucket(bucket_name)
 
@@ -2685,7 +2683,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         metadata: CaseInsensitiveDict,  # type: ignore
         storage_type: str,
         tags: dict[str, str],
-        acl: Optional[FakeAcl],
+        acl: FakeAcl | None,
         sse_encryption: str,
         kms_key_id: str,
     ) -> FakeMultipart:
@@ -2707,7 +2705,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def complete_multipart_upload(
         self, bucket_name: str, multipart_id: str, body: Iterator[tuple[int, str]]
-    ) -> Optional[FakeKey]:
+    ) -> FakeKey | None:
         bucket = self.get_bucket(bucket_name)
         multipart = bucket.multiparts[multipart_id]
         value, etag, checksum_details = multipart.complete(body)
@@ -2772,7 +2770,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         part_id: int,
         src_bucket_name: str,
         src_key_name: str,
-        src_version_id: Optional[str],
+        src_version_id: str | None,
         start_byte: int,
         end_byte: int,
     ) -> FakeKey:
@@ -2789,11 +2787,11 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def list_objects(
         self,
         bucket: FakeBucket,
-        prefix: Optional[str],
-        delimiter: Optional[str],
-        marker: Optional[str],
-        max_keys: Optional[int],
-    ) -> tuple[set[FakeKey], set[str], bool, Optional[str]]:
+        prefix: str | None,
+        delimiter: str | None,
+        marker: str | None,
+        max_keys: int | None,
+    ) -> tuple[set[FakeKey], set[str], bool, str | None]:
         """
         The default value for the MaxKeys-argument is 100. This can be configured with an environment variable:
 
@@ -2846,12 +2844,12 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     def list_objects_v2(
         self,
         bucket: FakeBucket,
-        prefix: Optional[str],
-        delimiter: Optional[str],
-        continuation_token: Optional[str],
-        start_after: Optional[str],
+        prefix: str | None,
+        delimiter: str | None,
+        continuation_token: str | None,
+        start_after: str | None,
         max_keys: int,
-    ) -> tuple[set[Union[FakeKey, str]], bool, Optional[str]]:
+    ) -> tuple[set[FakeKey | str], bool, str | None]:
         """
         The default value for the MaxKeys-argument is 100. This can be configured with an environment variable:
 
@@ -2906,7 +2904,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         return result_keys, is_truncated, next_continuation_token
 
     @staticmethod
-    def _get_name(key: Union[str, FakeKey]) -> str:
+    def _get_name(key: str | FakeKey) -> str:
         if isinstance(key, FakeKey):
             return key.name
         else:
@@ -2919,7 +2917,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         return delete_marker
 
     def delete_object_tagging(
-        self, bucket_name: str, key_name: str, version_id: Optional[str] = None
+        self, bucket_name: str, key_name: str, version_id: str | None = None
     ) -> None:
         key = self.get_object(bucket_name, key_name, version_id=version_id)
         bucket = self.get_bucket(bucket_name)
@@ -2937,7 +2935,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         self,
         bucket_name: str,
         key_name: str,
-        version_id: Optional[str] = None,
+        version_id: str | None = None,
         bypass: bool = False,
     ) -> tuple[bool, dict[str, Any]]:
         bucket = self.get_bucket(bucket_name)
@@ -3012,7 +3010,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         bucket_name: str,
         objects: list[dict[str, Any]],
         bypass_retention: bool = False,
-    ) -> tuple[list[tuple[str, Optional[str], Optional[str]]], list[str]]:
+    ) -> tuple[list[tuple[str, str | None, str | None]], list[str]]:
         deleted = []
         errors = []
         for object_ in objects:
@@ -3044,17 +3042,17 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         src_key: FakeKey,
         dest_bucket_name: str,
         dest_key_name: str,
-        storage: Optional[str] = None,
-        encryption: Optional[str] = None,
-        kms_key_id: Optional[str] = None,
+        storage: str | None = None,
+        encryption: str | None = None,
+        kms_key_id: str | None = None,
         bucket_key_enabled: Any = None,
-        mdirective: Optional[str] = None,
-        metadata: Optional[Any] = None,
-        website_redirect_location: Optional[str] = None,
-        lock_mode: Optional[str] = None,
-        lock_legal_status: Optional[str] = None,
-        lock_until: Optional[str] = None,
-        provided_version_id: Optional[str] = None,
+        mdirective: str | None = None,
+        metadata: Any | None = None,
+        website_redirect_location: str | None = None,
+        lock_mode: str | None = None,
+        lock_legal_status: str | None = None,
+        lock_until: str | None = None,
+        provided_version_id: str | None = None,
     ) -> None:
         bucket = self.get_bucket(dest_bucket_name)
         if src_key.name == dest_key_name and src_key.bucket_name == dest_bucket_name:
@@ -3115,11 +3113,11 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             new_key,
         )
 
-    def put_bucket_acl(self, bucket_name: str, acl: Optional[FakeAcl]) -> None:
+    def put_bucket_acl(self, bucket_name: str, acl: FakeAcl | None) -> None:
         bucket = self.get_bucket(bucket_name)
         bucket.set_acl(acl)
 
-    def get_bucket_acl(self, bucket_name: str) -> Optional[FakeAcl]:
+    def get_bucket_acl(self, bucket_name: str) -> FakeAcl | None:
         bucket = self.get_bucket(bucket_name)
         return bucket.acl
 
@@ -3148,7 +3146,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
 
     def get_bucket_notification_configuration(
         self, bucket_name: str
-    ) -> Optional[NotificationConfiguration]:
+    ) -> NotificationConfiguration | None:
         bucket = self.get_bucket(bucket_name)
         return bucket.notification_configuration
 
@@ -3220,7 +3218,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
             ], bytes_scanned
 
     def restore_object(
-        self, bucket_name: str, key_name: str, days: Optional[str], type_: Optional[str]
+        self, bucket_name: str, key_name: str, days: str | None, type_: str | None
     ) -> bool:
         key = self.get_object(bucket_name, key_name)
         if not key:
@@ -3260,7 +3258,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         return
 
     def get_bucket_inventory_configuration(
-        self, bucket_name: str, id: str, expected_bucket_owner: Optional[str] = None
+        self, bucket_name: str, id: str, expected_bucket_owner: str | None = None
     ) -> FakeBucketInventoryConfiguration:
         bucket = self.get_bucket(bucket_name)
 
@@ -3289,7 +3287,7 @@ class S3BackendDict(BackendDict[S3Backend]):
         backend: Any,
         service_name: str,
         use_boto3_regions: bool = True,
-        additional_regions: Optional[list[str]] = None,
+        additional_regions: list[str] | None = None,
     ):
         super().__init__(backend, service_name, use_boto3_regions, additional_regions)
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -2,7 +2,7 @@ import io
 import re
 import urllib.parse
 from collections.abc import Iterator
-from typing import Any, Optional, Union
+from typing import Any
 from urllib.parse import parse_qs, unquote, urlencode, urlparse, urlunparse
 from xml.dom import minidom
 from xml.parsers.expat import ExpatError
@@ -392,9 +392,7 @@ class S3Response(BaseResponse):
         return self._send_response(response)
 
     @classmethod
-    def _send_response(
-        cls, response: Union[TYPE_RESPONSE, str, bytes]
-    ) -> TYPE_RESPONSE:  # type: ignore
+    def _send_response(cls, response: TYPE_RESPONSE | str | bytes) -> TYPE_RESPONSE:  # type: ignore
         if isinstance(response, (str, bytes)):
             status_code = 200
             headers: dict[str, str] = {}
@@ -412,9 +410,7 @@ class S3Response(BaseResponse):
 
         return status_code, headers, body
 
-    def _bucket_response(
-        self, request: Any, full_url: str
-    ) -> Union[str, TYPE_RESPONSE]:
+    def _bucket_response(self, request: Any, full_url: str) -> str | TYPE_RESPONSE:
         querystring = self._get_querystring(request, full_url)
         method = request.method
         bucket_name = self.parse_bucket_name_from_url(request, full_url)
@@ -492,7 +488,7 @@ class S3Response(BaseResponse):
         if they are re-defining the same headers.
         """
 
-        def _to_string(header: Union[list[str], str]) -> str:
+        def _to_string(header: list[str] | str) -> str:
             # We allow list and strs in header values. Transform lists in comma-separated strings
             if isinstance(header, list):
                 return ", ".join(header)
@@ -579,7 +575,7 @@ class S3Response(BaseResponse):
                 return response_headers
             bucket = self.backend.get_bucket(self.bucket_name)
 
-            def _to_string(header: Union[list[str], str]) -> str:
+            def _to_string(header: list[str] | str) -> str:
                 # We allow list and strs in header values. Transform lists in comma-separated strings
                 if isinstance(header, list):
                     return ", ".join(header)
@@ -613,7 +609,7 @@ class S3Response(BaseResponse):
 
     def _bucket_response_get(
         self, bucket_name: str, querystring: dict[str, Any]
-    ) -> Union[str, TYPE_RESPONSE]:
+    ) -> str | TYPE_RESPONSE:
         self._set_action("BUCKET", "GET", querystring)
         self._authenticate_and_authorize_s3_action(bucket_name=bucket_name)
 
@@ -945,7 +941,7 @@ class S3Response(BaseResponse):
                 result_folders.append(key)
         return result_keys, result_folders
 
-    def _get_location_constraint(self) -> Optional[str]:
+    def _get_location_constraint(self) -> str | None:
         try:
             if self.body:
                 return xmltodict.parse(self.body)["CreateBucketConfiguration"][
@@ -966,7 +962,7 @@ class S3Response(BaseResponse):
         request: Any,
         bucket_name: str,
         querystring: dict[str, Any],
-    ) -> Union[str, TYPE_RESPONSE]:
+    ) -> str | TYPE_RESPONSE:
         if querystring and not request.headers.get("Content-Length"):
             return 411, {}, "Content-Length required"
 
@@ -1168,7 +1164,7 @@ class S3Response(BaseResponse):
         self.data["Action"] = "GetBucketAcl"
         return self.serialized(ActionResult(self._acl_to_dict(acl)))
 
-    def get_bucket_cors(self) -> Union[str, TYPE_RESPONSE]:
+    def get_bucket_cors(self) -> str | TYPE_RESPONSE:
         self.data["Action"] = "GetBucketCors"
         cors = self.backend.get_bucket_cors(self.bucket_name)
         if len(cors) == 0:
@@ -1186,7 +1182,7 @@ class S3Response(BaseResponse):
         ]
         return self.serialized(ActionResult({"CORSRules": cors_rules}))
 
-    def get_bucket_encryption(self) -> Union[str, TYPE_RESPONSE]:
+    def get_bucket_encryption(self) -> str | TYPE_RESPONSE:
         self.data["Action"] = "GetBucketEncryption"
         encryption = self.backend.get_bucket_encryption(self.bucket_name)
         if not encryption:
@@ -1306,7 +1302,7 @@ class S3Response(BaseResponse):
         return self.serialized(ActionResult(result))
 
     def get_bucket_location(self) -> TYPE_RESPONSE:
-        location: Optional[str] = self.backend.get_bucket_location(self.bucket_name)
+        location: str | None = self.backend.get_bucket_location(self.bucket_name)
 
         # us-east-1 is different - returns a None location
         if location == DEFAULT_REGION_NAME:
@@ -1374,7 +1370,7 @@ class S3Response(BaseResponse):
         self.data["Action"] = "GetBucketNotificationConfiguration"
         return self.serialized(ActionResult(result))
 
-    def get_bucket_ownership_controls(self) -> Union[str, TYPE_RESPONSE]:
+    def get_bucket_ownership_controls(self) -> str | TYPE_RESPONSE:
         self.data["Action"] = "GetBucketOwnershipControls"
         ownership_rule = self.backend.get_bucket_ownership_controls(self.bucket_name)
         if not ownership_rule:
@@ -1389,13 +1385,13 @@ class S3Response(BaseResponse):
             )
         )
 
-    def get_bucket_policy(self) -> Union[str, TYPE_RESPONSE]:
+    def get_bucket_policy(self) -> str | TYPE_RESPONSE:
         policy = self.backend.get_bucket_policy(self.bucket_name)
         if not policy:
             raise NoSuchBucketPolicy(bucket_name=self.bucket_name)
         return 200, {}, policy
 
-    def get_bucket_replication(self) -> Union[str, TYPE_RESPONSE]:
+    def get_bucket_replication(self) -> str | TYPE_RESPONSE:
         self.data["Action"] = "GetBucketReplication"
         replication = self.backend.get_bucket_replication(self.bucket_name)
         if not replication:
@@ -1422,7 +1418,7 @@ class S3Response(BaseResponse):
             )
         )
 
-    def get_bucket_tags(self) -> Union[str, TYPE_RESPONSE]:
+    def get_bucket_tags(self) -> str | TYPE_RESPONSE:
         self.data["Action"] = "GetBucketTagging"
         tags = self.backend.get_bucket_tagging(self.bucket_name)["Tags"]
         # "Special Error" if no tags:
@@ -1827,7 +1823,7 @@ class S3Response(BaseResponse):
             line = body_io.readline()
         return bytes(new_body)
 
-    def _handle_encoded_body(self, body: Union[io.BufferedIOBase, bytes]) -> bytes:
+    def _handle_encoded_body(self, body: io.BufferedIOBase | bytes) -> bytes:
         decoded_body = b""
         if not body:
             return decoded_body
@@ -2302,9 +2298,7 @@ class S3Response(BaseResponse):
         response_headers.pop("content-length", None)
         return 200, response_headers, ""
 
-    def _get_checksum(
-        self, response_headers: dict[str, Any]
-    ) -> tuple[str, Optional[str]]:
+    def _get_checksum(self, response_headers: dict[str, Any]) -> tuple[str, str | None]:
         checksum_algorithm = self.headers.get("x-amz-sdk-checksum-algorithm", "")
         checksum_header = f"x-amz-checksum-{checksum_algorithm.lower()}"
         checksum_value = self.headers.get(checksum_header)
@@ -2451,7 +2445,7 @@ class S3Response(BaseResponse):
 
     def _get_lock_details(
         self, bucket: "FakeBucket", lock_enabled: bool
-    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    ) -> tuple[str | None, str | None, str | None]:
         lock_mode = self.headers.get("x-amz-object-lock-mode")
         lock_until = self.headers.get("x-amz-object-lock-retain-until-date")
         legal_hold = self.headers.get("x-amz-object-lock-legal-hold")
@@ -2713,7 +2707,7 @@ class S3Response(BaseResponse):
 
         return response_dict
 
-    def _acl_from_body(self) -> Optional[FakeAcl]:
+    def _acl_from_body(self) -> FakeAcl | None:
         parsed_xml = xmltodict.parse(self.body)
         if not parsed_xml.get("AccessControlPolicy"):
             raise MalformedACLError()
@@ -2781,7 +2775,7 @@ class S3Response(BaseResponse):
 
         return grants
 
-    def _acl_from_headers(self, headers: dict[str, str]) -> Optional[FakeAcl]:
+    def _acl_from_headers(self, headers: dict[str, str]) -> FakeAcl | None:
         canned_acl = headers.get("x-amz-acl", "")
 
         grants = []
@@ -2867,7 +2861,7 @@ class S3Response(BaseResponse):
 
         return [parsed_xml["CORSConfiguration"]["CORSRule"]]
 
-    def _mode_until_from_body(self) -> tuple[Optional[str], Optional[str]]:
+    def _mode_until_from_body(self) -> tuple[str | None, str | None]:
         parsed_xml = xmltodict.parse(self.body)
         return (
             parsed_xml.get("Retention", None).get("Mode", None),
@@ -3152,7 +3146,7 @@ class S3Response(BaseResponse):
                 and existing.multipart.id == multipart_id
             ):
                 # Operation is idempotent
-                key: Optional[FakeKey] = existing
+                key: FakeKey | None = existing
             else:
                 if self.headers.get("If-None-Match") == "*" and existing is not None:
                     raise PreconditionFailed("If-None-Match")

--- a/moto/s3/select_object_content.py
+++ b/moto/s3/select_object_content.py
@@ -1,6 +1,6 @@
 import binascii
 import struct
-from typing import Any, Optional
+from typing import Any
 
 
 def parse_query(text_input: str, query: str) -> tuple[list[dict[str, Any]], int]:
@@ -16,7 +16,7 @@ def _create_header(key: bytes, value: bytes) -> bytes:
 
 
 def _create_message(
-    content_type: Optional[bytes], event_type: bytes, payload: bytes
+    content_type: bytes | None, event_type: bytes, payload: bytes
 ) -> bytes:
     headers = _create_header(b":message-type", b"event")
     headers += _create_header(b":event-type", event_type)

--- a/moto/s3/utils.py
+++ b/moto/s3/utils.py
@@ -5,7 +5,7 @@ import logging
 import re
 import sys
 from collections.abc import Iterator
-from typing import Any, Optional, Union
+from typing import Any
 from urllib.parse import urlparse
 
 from requests.structures import CaseInsensitiveDict
@@ -50,7 +50,7 @@ STORAGE_CLASS = [
 LOGGING_SERVICE_PRINCIPAL = "logging.s3.amazonaws.com"
 
 
-def bucket_name_from_url(url: str) -> Optional[str]:  # type: ignore
+def bucket_name_from_url(url: str) -> str | None:  # type: ignore
     if S3_IGNORE_SUBDOMAIN_BUCKETNAME:
         return None
     domain = urlparse(url).netloc
@@ -71,7 +71,7 @@ def bucket_name_from_url(url: str) -> Optional[str]:  # type: ignore
 
 
 # 'owi-common-cf', 'snippets/test.json' = bucket_and_name_from_url('s3://owi-common-cf/snippets/test.json')
-def bucket_and_name_from_url(url: str) -> Union[tuple[str, str], tuple[None, None]]:
+def bucket_and_name_from_url(url: str) -> tuple[str, str] | tuple[None, None]:
     prefix = "s3://"
     if url.startswith(prefix):
         bucket_name = url[len(prefix) : url.index("/", len(prefix))]

--- a/moto/s3bucket_path/utils.py
+++ b/moto/s3bucket_path/utils.py
@@ -1,8 +1,7 @@
-from typing import Optional
 from urllib.parse import urlparse
 
 
-def bucket_name_from_url(url: str) -> Optional[str]:
+def bucket_name_from_url(url: str) -> str | None:
     path = urlparse(url).path.lstrip("/")
 
     parts = path.lstrip("/").split("/")

--- a/moto/s3control/config.py
+++ b/moto/s3control/config.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any
 
 from boto3 import Session
 
@@ -15,14 +15,14 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[list[str]],
-        resource_name: Optional[str],
+        resource_ids: list[str] | None,
+        resource_name: str | None,
         limit: int,
-        next_token: Optional[str],
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
+        next_token: str | None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
         aggregator: Any = None,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], str | None]:
         # For the Account Public Access Block, they are the same for all regions. The resource ID is the AWS account ID
         # There is no resource name -- it should be a blank string "" if provided.
 
@@ -100,10 +100,10 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
         account_id: str,
         partition: str,
         resource_id: str,
-        resource_name: Optional[str] = None,
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        resource_name: str | None = None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+    ) -> dict[str, Any] | None:
         # Do we even have this defined?
         backend = self.backends[account_id][partition]
         if not backend.public_access_block:
@@ -118,7 +118,7 @@ class S3AccountPublicAccessBlockConfigQuery(ConfigQueryModel[S3ControlBackend]):
         # Is the resource ID correct?:
         if account_id == resource_id:
             if backend_region:
-                pab_region: Optional[str] = backend_region
+                pab_region: str | None = backend_region
 
             # Invalid region?
             elif resource_region not in regions:

--- a/moto/s3control/models.py
+++ b/moto/s3control/models.py
@@ -1,7 +1,7 @@
 import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -63,7 +63,7 @@ class AccessPoint(BaseModel):
         self.bucket = bucket
         self.created = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")
         self.arn = f"arn:{get_partition(region_name)}:s3:us-east-1:{account_id}:accesspoint/{name}"
-        self.policy: Optional[str] = None
+        self.policy: str | None = None
         self.network_origin = "VPC" if vpc_configuration else "Internet"
         self.vpc_id = (vpc_configuration or {}).get("VpcId")
         pubc = public_access_block_configuration or {}
@@ -102,7 +102,7 @@ class MultiRegionAccessPoint(BaseModel):
         }
         self.regions = regions
         self.status = "READY"
-        self.policy: Optional[str] = None
+        self.policy: str | None = None
 
     def set_policy(self, policy: str) -> None:
         self.policy = policy
@@ -127,8 +127,8 @@ class MultiRegionAccessPointOperation(BaseModel):
         account_id: str,
         operation: str,
         region_name: str,
-        name: Optional[str] = None,
-        details: Optional[dict[str, Any]] = None,
+        name: str | None = None,
+        details: dict[str, Any] | None = None,
     ):
         self.request_token_arn = f"arn:aws:s3:{region_name}:{account_id}:async-request/mrap/{operation.lower()}/{uuid.uuid4().hex[:24]}"
         self.request_status = "SUCCEEDED"
@@ -191,7 +191,7 @@ class StorageLensConfiguration(BaseModel):
         account_id: str,
         config_id: str,
         storage_lens_configuration: dict[str, Any],
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ):
         self.account_id = account_id
         self.config_id = config_id
@@ -203,7 +203,7 @@ class StorageLensConfiguration(BaseModel):
 class S3ControlBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
-        self.public_access_block: Optional[PublicAccessBlock] = None
+        self.public_access_block: PublicAccessBlock | None = None
         self.access_points: dict[str, dict[str, AccessPoint]] = defaultdict(dict)
         self.multi_region_access_points: dict[
             str, dict[str, MultiRegionAccessPoint]
@@ -425,8 +425,8 @@ class S3ControlBackend(BaseBackend):
     def list_multi_region_access_points(
         self,
         account_id: str,
-        max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
+        max_results: int | None = None,
+        next_token: str | None = None,
     ) -> list[MultiRegionAccessPoint]:
         return list(self.multi_region_access_points[account_id].values())
 
@@ -456,7 +456,7 @@ class S3ControlBackend(BaseBackend):
         config_id: str,
         account_id: str,
         storage_lens_configuration: dict[str, Any],
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> None:
         if account_id != self.account_id:
             raise WrongPublicAccessBlockAccountIdError()
@@ -497,9 +497,9 @@ class S3ControlBackend(BaseBackend):
     def list_access_points(
         self,
         account_id: str,
-        bucket: Optional[str] = None,
-        max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
+        bucket: str | None = None,
+        max_results: int | None = None,
+        next_token: str | None = None,
     ) -> list[AccessPoint]:
         account_access_points = self.access_points.get(account_id, {})
         all_access_points = list(account_access_points.values())

--- a/moto/s3tables/models.py
+++ b/moto/s3tables/models.py
@@ -3,7 +3,7 @@
 import datetime
 import re
 from hashlib import md5
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
@@ -88,7 +88,7 @@ class Table:
         format: Literal["ICEBERG"],
         namespace: str,
         table_bucket_arn: str,
-        type: Union[Literal["customer"], Literal["aws"]],
+        type: Literal["customer"] | Literal["aws"],
         managed_by_service: bool,
         partition: str,
     ):
@@ -102,12 +102,12 @@ class Table:
         self.version_token = self._generate_version_token()
         self.creation_date = datetime.datetime.now(tz=datetime.timezone.utc)
         self.last_modified = self.creation_date
-        self.modified_by: Optional[str] = None
+        self.modified_by: str | None = None
         self.namespace = namespace
         self.table_bucket_arn = table_bucket_arn
         self.region_name = table_bucket_arn.split(":")[3]
         self.managed_by_service = managed_by_service
-        self.metadata_location: Optional[str] = None
+        self.metadata_location: str | None = None
         self._bucket = self._create_underlying_bucket()
         self.warehouse_location: str = f"s3://{self._bucket.name}"
 
@@ -194,7 +194,7 @@ class S3TablesBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_table_buckets(
         self,
-        prefix: Optional[str] = None,
+        prefix: str | None = None,
     ) -> list[FakeTableBucket]:
         all_buckets = [
             bucket
@@ -238,7 +238,7 @@ class S3TablesBackend(BaseBackend):
     def list_namespaces(
         self,
         table_bucket_arn: str,
-        prefix: Optional[str] = None,
+        prefix: str | None = None,
     ) -> list[Namespace]:
         bucket = self.get_table_bucket(table_bucket_arn)
 
@@ -311,8 +311,8 @@ class S3TablesBackend(BaseBackend):
     def list_tables(
         self,
         table_bucket_arn: str,
-        namespace: Optional[str] = None,
-        prefix: Optional[str] = None,
+        namespace: str | None = None,
+        prefix: str | None = None,
     ) -> list[Table]:
         bucket = self.table_buckets.get(table_bucket_arn)
         if not bucket or (namespace and namespace not in bucket.namespaces):
@@ -341,7 +341,7 @@ class S3TablesBackend(BaseBackend):
         table_bucket_arn: str,
         namespace: str,
         name: str,
-        version_token: Optional[str] = None,
+        version_token: str | None = None,
     ) -> None:
         bucket = self.table_buckets.get(table_bucket_arn)
         if (
@@ -387,9 +387,9 @@ class S3TablesBackend(BaseBackend):
         table_bucket_arn: str,
         namespace: str,
         name: str,
-        new_namespace_name: Optional[str] = None,
-        new_name: Optional[str] = None,
-        version_token: Optional[str] = None,
+        new_namespace_name: str | None = None,
+        new_name: str | None = None,
+        version_token: str | None = None,
     ) -> None:
         if not new_namespace_name and not new_name:
             raise NothingToRename()

--- a/moto/s3vectors/models.py
+++ b/moto/s3vectors/models.py
@@ -1,7 +1,7 @@
 """S3VectorsBackend class with methods for supported APIs."""
 
 from collections.abc import Iterable
-from typing import Any, Literal, Optional, TypedDict
+from typing import Any, Literal, TypedDict
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -83,7 +83,7 @@ class VectorBucket(BaseModel):
         }
 
         self.indexes: dict[str, Index] = {}
-        self.policy: Optional[str] = None
+        self.policy: str | None = None
 
 
 class S3VectorsBackend(BaseBackend):
@@ -113,8 +113,8 @@ class S3VectorsBackend(BaseBackend):
 
     def get_vector_bucket(
         self,
-        vector_bucket_name: Optional[str] = None,
-        vector_bucket_arn: Optional[str] = None,
+        vector_bucket_name: str | None = None,
+        vector_bucket_arn: str | None = None,
     ) -> VectorBucket:
         if vector_bucket_name:
             for vector_bucket in self.vector_buckets.values():
@@ -131,7 +131,7 @@ class S3VectorsBackend(BaseBackend):
                 raise VectorBucketNotEmpty
             self.vector_buckets.pop(bucket.vector_bucket_arn, None)
 
-    def list_vector_buckets(self, prefix: Optional[str]) -> list[VectorBucket]:
+    def list_vector_buckets(self, prefix: str | None) -> list[VectorBucket]:
         return [
             bucket
             for bucket in self.vector_buckets.values()

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -6,7 +6,7 @@ import string
 from collections import defaultdict
 from collections.abc import Iterable
 from datetime import datetime, timezone
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
@@ -162,7 +162,7 @@ PAGINATION_MODEL = {
     },
 }
 
-METRIC_INFO_TYPE = dict[str, Union[str, int, float, datetime]]
+METRIC_INFO_TYPE = dict[str, str | int | float | datetime]
 METRIC_STEP_TYPE = dict[int, METRIC_INFO_TYPE]
 
 
@@ -264,7 +264,7 @@ class FakePipeline(BaseObject):
         now = utcnow()
         self.creation_time = now
         self.last_modified_time = now
-        self.last_execution_time: Optional[datetime] = None
+        self.last_execution_time: datetime | None = None
 
         self.pipeline_status = "Active"
         fake_user_profile_name = "fake-user-profile-name"
@@ -861,10 +861,10 @@ class FakeTransformJob(BaseObject):
         max_payload_in_mb: int,
         batch_strategy: str,
         environment: dict[str, str],
-        transform_input: dict[str, Union[dict[str, str], str]],
+        transform_input: dict[str, dict[str, str] | str],
         transform_output: dict[str, str],
-        data_capture_config: dict[str, Union[str, bool]],
-        transform_resources: dict[str, Union[str, int]],
+        data_capture_config: dict[str, str | bool],
+        transform_resources: dict[str, str | int],
         data_processing: dict[str, str],
         tags: dict[str, str],
         experiment_config: dict[str, str],
@@ -933,8 +933,8 @@ class Model(BaseObject, CloudFormationModel):
         execution_role_arn: str,
         primary_container: dict[str, Any],
         vpc_config: dict[str, Any],
-        containers: Optional[list[dict[str, Any]]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        containers: list[dict[str, Any]] | None = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.model_name = model_name
         self.creation_time = utcnow()
@@ -1052,7 +1052,7 @@ class ModelPackageGroup(BaseObject):
         model_package_group_description: str,
         account_id: str,
         region_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> None:
         model_package_group_arn = arn_formatter(
             region_name=region_name,
@@ -1106,10 +1106,10 @@ class FakeModelCard(BaseObject):
         model_card_version: int,
         content: str,
         model_card_status: str,
-        security_config: Optional[dict[str, str]] = None,
-        tags: Optional[list[dict[str, Any]]] = None,
-        creation_time: Optional[datetime] = None,
-        last_modified_time: Optional[datetime] = None,
+        security_config: dict[str, str] | None = None,
+        tags: list[dict[str, Any]] | None = None,
+        creation_time: datetime | None = None,
+        last_modified_time: datetime | None = None,
     ) -> None:
         datetime_now = utcnow()
         self.arn = arn_formatter("model-card", model_card_name, account_id, region_name)
@@ -1169,7 +1169,7 @@ class FeatureGroup(BaseObject):
         feature_definitions: list[dict[str, str]],
         offline_store_config: dict[str, Any],
         role_arn: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> None:
         self.feature_group_name = feature_group_name
         self.record_identifier_feature_name = record_identifier_feature_name
@@ -1219,17 +1219,17 @@ class ModelPackage(BaseObject):
     def __init__(
         self,
         model_package_name: str,
-        model_package_group_name: Optional[str],
-        model_package_version: Optional[int],
-        model_package_description: Optional[str],
+        model_package_group_name: str | None,
+        model_package_version: int | None,
+        model_package_description: str | None,
         inference_specification: Any,
         source_algorithm_specification: Any,
         validation_specification: Any,
         certify_for_marketplace: bool,
-        model_approval_status: Optional[str],
+        model_approval_status: str | None,
         metadata_properties: Any,
         model_metrics: Any,
-        approval_description: Optional[str],
+        approval_description: str | None,
         customer_metadata_properties: Any,
         drift_check_baselines: Any,
         domain: str,
@@ -1240,7 +1240,7 @@ class ModelPackage(BaseObject):
         region_name: str,
         account_id: str,
         model_package_type: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> None:
         fake_user_profile_name = "fake-user-profile-name"
         fake_domain_id = "fake-domain-id"
@@ -1286,7 +1286,7 @@ class ModelPackage(BaseObject):
             ],
         }
         self.certify_for_marketplace = certify_for_marketplace
-        self.model_approval_status: Optional[str] = None
+        self.model_approval_status: str | None = None
         self.set_model_approval_status(model_approval_status)
         self.created_by = {
             "UserProfileArn": fake_user_profile_arn,
@@ -1295,20 +1295,20 @@ class ModelPackage(BaseObject):
         }
         self.metadata_properties = metadata_properties
         self.model_metrics = model_metrics
-        self.last_modified_time: Optional[datetime] = None
+        self.last_modified_time: datetime | None = None
         self.approval_description = approval_description
         self.customer_metadata_properties = customer_metadata_properties
         self.drift_check_baselines = drift_check_baselines
         self.domain = domain
         self.task = task
         self.sample_payload_url = sample_payload_url
-        self.additional_inference_specifications: Optional[list[Any]] = None
+        self.additional_inference_specifications: list[Any] | None = None
         self.add_additional_inference_specifications(
             additional_inference_specifications
         )
         self.tags = tags
         self.model_package_status = "Completed"
-        self.last_modified_by: Optional[dict[str, str]] = None
+        self.last_modified_by: dict[str, str] | None = None
         self.client_token = client_token
 
     def gen_response_object(self) -> dict[str, Any]:
@@ -1359,7 +1359,7 @@ class ModelPackage(BaseObject):
         self.last_modified_time = utcnow()
         self.last_modified_by = self.created_by
 
-    def set_model_approval_status(self, model_approval_status: Optional[str]) -> None:
+    def set_model_approval_status(self, model_approval_status: str | None) -> None:
         if model_approval_status is not None:
             validate_model_approval_status(model_approval_status)
         self.model_approval_status = model_approval_status
@@ -1372,7 +1372,7 @@ class ModelPackage(BaseObject):
                 self.customer_metadata_properties.pop(customer_metadata_property, None)
 
     def add_additional_inference_specifications(
-        self, additional_inference_specifications_to_add: Optional[list[Any]]
+        self, additional_inference_specifications_to_add: list[Any] | None
     ) -> None:
         self.validate_additional_inference_specifications(
             additional_inference_specifications_to_add
@@ -1390,7 +1390,7 @@ class ModelPackage(BaseObject):
             )
 
     def validate_additional_inference_specifications(
-        self, additional_inference_specifications: Optional[list[dict[str, Any]]]
+        self, additional_inference_specifications: list[dict[str, Any]] | None
     ) -> None:
         specifications_to_validate = additional_inference_specifications or []
         for additional_inference_specification in specifications_to_validate:
@@ -1621,7 +1621,7 @@ class Cluster(BaseObject):
         account_id: str,
         instance_groups: list[dict[str, Any]],
         vpc_config: dict[str, list[str]],
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.region_name = region_name
         self.account_id = account_id
@@ -1728,7 +1728,7 @@ class ClusterNode(BaseObject):
         life_cycle_config: dict[str, Any],
         execution_role: str,
         node_id: str,
-        threads_per_core: Optional[int] = None,
+        threads_per_core: int | None = None,
     ):
         self.region_name = region_name
         self.account_id = account_id
@@ -1774,10 +1774,10 @@ class CompilationJob(BaseObject):
         account_id: str,
         output_config: dict[str, Any],
         stopping_condition: dict[str, Any],
-        model_package_version_arn: Optional[str],
-        input_config: Optional[dict[str, Any]],
-        vpc_config: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
+        model_package_version_arn: str | None,
+        input_config: dict[str, Any] | None,
+        vpc_config: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
     ):
         self.compilation_job_name = compilation_job_name
         if (
@@ -1875,11 +1875,11 @@ class AutoMLJob(BaseObject):
         role_arn: str,
         region_name: str,
         account_id: str,
-        security_config: Optional[dict[str, Any]],
-        auto_ml_job_objective: Optional[dict[str, Any]],
-        model_deploy_config: Optional[dict[str, Any]],
-        data_split_config: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]] = None,
+        security_config: dict[str, Any] | None,
+        auto_ml_job_objective: dict[str, Any] | None,
+        model_deploy_config: dict[str, Any] | None,
+        data_split_config: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None = None,
     ):
         self.region_name = region_name
         self.account_id = account_id
@@ -1894,7 +1894,7 @@ class AutoMLJob(BaseObject):
         self.role_arn = role_arn
         self.security_config = security_config
         self.auto_ml_job_objective = auto_ml_job_objective
-        self.auto_ml_problem_type_resolved_attributes: Optional[dict[str, Any]] = None
+        self.auto_ml_problem_type_resolved_attributes: dict[str, Any] | None = None
         if "ImageClassificationJobConfig" in self.auto_ml_problem_type_config:
             self.auto_ml_job_objective = (
                 {"MetricName": "Accuracy"}
@@ -2127,13 +2127,13 @@ class Domain(BaseObject):
         vpc_id: str,
         account_id: str,
         region_name: str,
-        domain_settings: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
-        app_network_access_type: Optional[str],
-        home_efs_file_system_kms_key_id: Optional[str],
-        kms_key_id: Optional[str],
-        app_security_group_management: Optional[str],
-        default_space_settings: Optional[dict[str, Any]],
+        domain_settings: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
+        app_network_access_type: str | None,
+        home_efs_file_system_kms_key_id: str | None,
+        kms_key_id: str | None,
+        app_security_group_management: str | None,
+        default_space_settings: dict[str, Any] | None,
     ):
         self.domain_name = domain_name
         if domain_name in sagemaker_backends[account_id][region_name].domains:
@@ -2216,17 +2216,17 @@ class ModelExplainabilityJobDefinition(BaseObject):
     def __init__(
         self,
         job_definition_name: str,
-        model_explainability_baseline_config: Optional[dict[str, Any]],
+        model_explainability_baseline_config: dict[str, Any] | None,
         model_explainability_app_specification: dict[str, Any],
         model_explainability_job_input: dict[str, Any],
         model_explainability_job_output_config: dict[str, Any],
         job_resources: dict[str, Any],
-        network_config: Optional[dict[str, Any]],
+        network_config: dict[str, Any] | None,
         role_arn: str,
-        stopping_condition: Optional[dict[str, Any]],
+        stopping_condition: dict[str, Any] | None,
         region_name: str,
         account_id: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ):
         self.job_definition_name = job_definition_name
         if (
@@ -2296,11 +2296,11 @@ class HyperParameterTuningJob(BaseObject):
         hyper_parameter_tuning_job_config: dict[str, Any],
         region_name: str,
         account_id: str,
-        training_job_definition: Optional[dict[str, Any]],
-        training_job_definitions: Optional[list[dict[str, Any]]],
-        warm_start_config: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
-        autotune: Optional[dict[str, Any]],
+        training_job_definition: dict[str, Any] | None,
+        training_job_definitions: list[dict[str, Any]] | None,
+        warm_start_config: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
+        autotune: dict[str, Any] | None,
     ):
         self.hyper_parameter_tuning_job_name = hyper_parameter_tuning_job_name
         if (
@@ -2424,15 +2424,15 @@ class ModelQualityJobDefinition(BaseObject):
     def __init__(
         self,
         job_definition_name: str,
-        model_quality_baseline_config: Optional[dict[str, Any]],
+        model_quality_baseline_config: dict[str, Any] | None,
         model_quality_app_specification: dict[str, Any],
         model_quality_job_input: dict[str, Any],
         model_quality_job_output_config: dict[str, Any],
         job_resources: dict[str, Any],
-        network_config: Optional[dict[str, Any]],
+        network_config: dict[str, Any] | None,
         role_arn: str,
-        stopping_condition: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
+        stopping_condition: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
         region_name: str,
         account_id: str,
     ):
@@ -2527,17 +2527,17 @@ class FakeSagemakerNotebookInstance(CloudFormationModel):
         notebook_instance_name: str,
         instance_type: str,
         role_arn: str,
-        subnet_id: Optional[str],
-        security_group_ids: Optional[list[str]],
-        kms_key_id: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        lifecycle_config_name: Optional[str],
+        subnet_id: str | None,
+        security_group_ids: list[str] | None,
+        kms_key_id: str | None,
+        tags: list[dict[str, str]] | None,
+        lifecycle_config_name: str | None,
         direct_internet_access: str,
         volume_size_in_gb: int,
-        accelerator_types: Optional[list[str]],
-        default_code_repository: Optional[str],
-        additional_code_repositories: Optional[list[str]],
-        root_access: Optional[str],
+        accelerator_types: list[str] | None,
+        default_code_repository: str | None,
+        additional_code_repositories: list[str] | None,
+        root_access: str | None,
     ):
         self.validate_volume_size_in_gb(volume_size_in_gb)
         self.validate_instance_type(instance_type)
@@ -2953,10 +2953,10 @@ class SageMakerModelBackend(BaseBackend):
         self,
         model_name: str,
         execution_role_arn: str,
-        primary_container: Optional[dict[str, Any]],
-        vpc_config: Optional[dict[str, Any]],
-        containers: Optional[list[dict[str, Any]]],
-        tags: Optional[list[dict[str, str]]],
+        primary_container: dict[str, Any] | None,
+        vpc_config: dict[str, Any] | None,
+        containers: list[dict[str, Any]] | None,
+        tags: list[dict[str, str]] | None,
     ) -> Model:
         model_obj = Model(
             account_id=self.account_id,
@@ -3200,8 +3200,8 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_trials(
         self,
-        experiment_name: Optional[str] = None,
-        trial_component_name: Optional[str] = None,
+        experiment_name: str | None = None,
+        trial_component_name: str | None = None,
     ) -> list["FakeTrial"]:
         trials_fetched = list(self.trials.values())
 
@@ -3227,13 +3227,13 @@ class SageMakerModelBackend(BaseBackend):
         trial_component_name: str,
         trial_name: str,
         status: dict[str, str],
-        start_time: Optional[datetime],
-        end_time: Optional[datetime],
-        display_name: Optional[str],
-        parameters: Optional[dict[str, dict[str, Union[str, float]]]],
-        input_artifacts: Optional[dict[str, dict[str, str]]],
-        output_artifacts: Optional[dict[str, dict[str, str]]],
-        metadata_properties: Optional[dict[str, str]],
+        start_time: datetime | None,
+        end_time: datetime | None,
+        display_name: str | None,
+        parameters: dict[str, dict[str, str | float]] | None,
+        input_artifacts: dict[str, dict[str, str]] | None,
+        output_artifacts: dict[str, dict[str, str]] | None,
+        metadata_properties: dict[str, str] | None,
     ) -> dict[str, Any]:
         trial_component = FakeTrialComponent(
             account_id=self.account_id,
@@ -3280,7 +3280,7 @@ class SageMakerModelBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_trial_components(
-        self, trial_name: Optional[str] = None
+        self, trial_name: str | None = None
     ) -> list["FakeTrialComponent"]:
         trial_components_fetched = list(self.trial_components.values())
 
@@ -3330,16 +3330,16 @@ class SageMakerModelBackend(BaseBackend):
     def update_trial_component(
         self,
         trial_component_name: str,
-        status: Optional[dict[str, str]],
-        display_name: Optional[str],
-        start_time: Optional[datetime],
-        end_time: Optional[datetime],
-        parameters: Optional[dict[str, dict[str, Union[str, float]]]],
-        parameters_to_remove: Optional[list[str]],
-        input_artifacts: Optional[dict[str, dict[str, str]]],
-        input_artifacts_to_remove: Optional[list[str]],
-        output_artifacts: Optional[dict[str, dict[str, str]]],
-        output_artifacts_to_remove: Optional[list[str]],
+        status: dict[str, str] | None,
+        display_name: str | None,
+        start_time: datetime | None,
+        end_time: datetime | None,
+        parameters: dict[str, dict[str, str | float]] | None,
+        parameters_to_remove: list[str] | None,
+        input_artifacts: dict[str, dict[str, str]] | None,
+        input_artifacts_to_remove: list[str] | None,
+        output_artifacts: dict[str, dict[str, str]] | None,
+        output_artifacts_to_remove: list[str] | None,
     ) -> dict[str, str]:
         try:
             trial_component = self.trial_components[trial_component_name]
@@ -3386,17 +3386,17 @@ class SageMakerModelBackend(BaseBackend):
         notebook_instance_name: str,
         instance_type: str,
         role_arn: str,
-        subnet_id: Optional[str] = None,
-        security_group_ids: Optional[list[str]] = None,
-        kms_key_id: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        lifecycle_config_name: Optional[str] = None,
+        subnet_id: str | None = None,
+        security_group_ids: list[str] | None = None,
+        kms_key_id: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        lifecycle_config_name: str | None = None,
         direct_internet_access: str = "Enabled",
         volume_size_in_gb: int = 5,
-        accelerator_types: Optional[list[str]] = None,
-        default_code_repository: Optional[str] = None,
-        additional_code_repositories: Optional[list[str]] = None,
-        root_access: Optional[str] = None,
+        accelerator_types: list[str] | None = None,
+        default_code_repository: str | None = None,
+        additional_code_repositories: list[str] | None = None,
+        root_access: str | None = None,
     ) -> FakeSagemakerNotebookInstance:
         self._validate_unique_notebook_instance_name(notebook_instance_name)
 
@@ -3461,8 +3461,8 @@ class SageMakerModelBackend(BaseBackend):
         self,
         sort_by: str,
         sort_order: str,
-        name_contains: Optional[str],
-        status: Optional[str],
+        name_contains: str | None,
+        status: str | None,
     ) -> list[FakeSagemakerNotebookInstance]:
         """
         The following parameters are not yet implemented:
@@ -3896,8 +3896,8 @@ class SageMakerModelBackend(BaseBackend):
     def list_pipelines(
         self,
         pipeline_name_prefix: str,
-        created_after: Optional[datetime],
-        created_before: Optional[datetime],
+        created_after: datetime | None,
+        created_before: datetime | None,
         next_token: str,
         max_results: int,
         sort_by: str,
@@ -3974,10 +3974,10 @@ class SageMakerModelBackend(BaseBackend):
         self,
         next_token: str,
         max_results: int,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        last_modified_time_after: Optional[datetime],
-        last_modified_time_before: Optional[datetime],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        last_modified_time_after: datetime | None,
+        last_modified_time_before: datetime | None,
         name_contains: str,
         status_equals: str,
     ) -> dict[str, Any]:
@@ -4064,10 +4064,10 @@ class SageMakerModelBackend(BaseBackend):
         max_payload_in_mb: int,
         batch_strategy: str,
         environment: dict[str, str],
-        transform_input: dict[str, Union[dict[str, str], str]],
+        transform_input: dict[str, dict[str, str] | str],
         transform_output: dict[str, str],
-        data_capture_config: dict[str, Union[str, bool]],
-        transform_resources: dict[str, Union[str, int]],
+        data_capture_config: dict[str, str | bool],
+        transform_resources: dict[str, str | int],
         data_processing: dict[str, str],
         tags: dict[str, str],
         experiment_config: dict[str, str],
@@ -4097,10 +4097,10 @@ class SageMakerModelBackend(BaseBackend):
         self,
         next_token: str,
         max_results: int,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        last_modified_time_after: Optional[datetime],
-        last_modified_time_before: Optional[datetime],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        last_modified_time_after: datetime | None,
+        last_modified_time_before: datetime | None,
         name_contains: str,
         status_equals: str,
     ) -> dict[str, Any]:
@@ -4246,10 +4246,10 @@ class SageMakerModelBackend(BaseBackend):
         self,
         next_token: str,
         max_results: int,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        last_modified_time_after: Optional[datetime],
-        last_modified_time_before: Optional[datetime],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        last_modified_time_after: datetime | None,
+        last_modified_time_before: datetime | None,
         name_contains: str,
         status_equals: str,
     ) -> dict[str, Any]:
@@ -4377,7 +4377,7 @@ class SageMakerModelBackend(BaseBackend):
         self,
         model_package_group_name: str,
         model_package_group_description: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> str:
         self.model_package_groups[model_package_group_name] = ModelPackageGroup(
             model_package_group_name=model_package_group_name,
@@ -4389,7 +4389,7 @@ class SageMakerModelBackend(BaseBackend):
         return self.model_package_groups[model_package_group_name].arn
 
     def _get_versioned_or_not(
-        self, model_package_type: Optional[str], model_package_version: Optional[int]
+        self, model_package_type: str | None, model_package_version: int | None
     ) -> bool:
         if model_package_type == "Versioned":
             return model_package_version is not None
@@ -4402,11 +4402,11 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_model_package_groups(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        name_contains: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        name_contains: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[ModelPackageGroup]:
         model_package_group_summary_list = list(
             filter(
@@ -4454,14 +4454,14 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_model_packages(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        name_contains: Optional[str],
-        model_approval_status: Optional[str],
-        model_package_group_name: Optional[str],
-        model_package_type: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        name_contains: str | None,
+        model_approval_status: str | None,
+        model_package_group_name: str | None,
+        model_package_type: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[ModelPackage]:
         if model_package_group_name is not None:
             model_package_type = "Versioned"
@@ -4517,11 +4517,11 @@ class SageMakerModelBackend(BaseBackend):
     def update_model_package(
         self,
         model_package_arn: str,
-        model_approval_status: Optional[str],
-        approval_description: Optional[str],
-        customer_metadata_properties: Optional[dict[str, str]],
+        model_approval_status: str | None,
+        approval_description: str | None,
+        customer_metadata_properties: dict[str, str] | None,
         customer_metadata_properties_to_remove: list[str],
-        additional_inference_specifications_to_add: Optional[list[Any]],
+        additional_inference_specifications_to_add: list[Any] | None,
     ) -> str:
         model_package_name_mapped = self.model_package_name_mapping.get(
             model_package_arn, model_package_arn
@@ -4546,15 +4546,15 @@ class SageMakerModelBackend(BaseBackend):
 
     def create_model_package(
         self,
-        model_package_name: Optional[str],
-        model_package_group_name: Optional[str],
-        model_package_description: Optional[str],
+        model_package_name: str | None,
+        model_package_group_name: str | None,
+        model_package_description: str | None,
         inference_specification: Any,
         validation_specification: Any,
         source_algorithm_specification: Any,
         certify_for_marketplace: bool,
         tags: Any,
-        model_approval_status: Optional[str],
+        model_approval_status: str | None,
         metadata_properties: Any,
         model_metrics: Any,
         client_token: Any,
@@ -4742,11 +4742,11 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_clusters(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        name_contains: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        name_contains: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[Cluster]:
         clusters = list(self.clusters.values())
         if name_contains:
@@ -4766,11 +4766,11 @@ class SageMakerModelBackend(BaseBackend):
     def list_cluster_nodes(
         self,
         cluster_name: str,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        instance_group_name_contains: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        instance_group_name_contains: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[ClusterNode]:
         if cluster_name.startswith(f"arn:{self.partition}:sagemaker:"):
             cluster_name = (cluster_name.split(":")[-1]).split("/")[-1]
@@ -4804,16 +4804,16 @@ class SageMakerModelBackend(BaseBackend):
         self,
         account_id: str,
         job_definition_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
         role_arn: str = "",
-        job_resources: Optional[dict[str, Any]] = None,
-        stopping_condition: Optional[dict[str, Any]] = None,
-        environment: Optional[dict[str, str]] = None,
-        network_config: Optional[dict[str, Any]] = None,
-        model_bias_baseline_config: Optional[dict[str, Any]] = None,
-        model_bias_app_specification: Optional[dict[str, Any]] = None,
-        model_bias_job_input: Optional[dict[str, Any]] = None,
-        model_bias_job_output_config: Optional[dict[str, Any]] = None,
+        job_resources: dict[str, Any] | None = None,
+        stopping_condition: dict[str, Any] | None = None,
+        environment: dict[str, str] | None = None,
+        network_config: dict[str, Any] | None = None,
+        model_bias_baseline_config: dict[str, Any] | None = None,
+        model_bias_app_specification: dict[str, Any] | None = None,
+        model_bias_job_input: dict[str, Any] | None = None,
+        model_bias_job_output_config: dict[str, Any] | None = None,
     ) -> dict[str, str]:
         job_definition = FakeModelBiasJobDefinition(
             account_id=account_id,
@@ -4858,11 +4858,11 @@ class SageMakerModelBackend(BaseBackend):
         output_data_config: dict[str, Any],
         auto_ml_problem_type_config: dict[str, Any],
         role_arn: str,
-        tags: Optional[list[dict[str, str]]],
-        security_config: Optional[dict[str, Any]],
-        auto_ml_job_objective: Optional[dict[str, str]],
-        model_deploy_config: Optional[dict[str, Any]],
-        data_split_config: Optional[dict[str, Any]],
+        tags: list[dict[str, str]] | None,
+        security_config: dict[str, Any] | None,
+        auto_ml_job_objective: dict[str, str] | None,
+        model_deploy_config: dict[str, Any] | None,
+        data_split_config: dict[str, Any] | None,
     ) -> str:
         auto_ml_job = AutoMLJob(
             auto_ml_job_name=auto_ml_job_name,
@@ -4893,14 +4893,14 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_auto_ml_jobs(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        last_modified_time_after: Optional[datetime],
-        last_modified_time_before: Optional[datetime],
-        name_contains: Optional[str],
-        status_equals: Optional[str],
-        sort_order: Optional[str],
-        sort_by: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        last_modified_time_after: datetime | None,
+        last_modified_time_before: datetime | None,
+        name_contains: str | None,
+        status_equals: str | None,
+        sort_order: str | None,
+        sort_by: str | None,
     ) -> list[AutoMLJob]:
         auto_ml_jobs = list(self.auto_ml_jobs.values())
         if name_contains:
@@ -4958,14 +4958,14 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_endpoints(
         self,
-        sort_by: Optional[str],
-        sort_order: Optional[str],
-        name_contains: Optional[str],
-        creation_time_before: Optional[datetime],
-        creation_time_after: Optional[datetime],
-        last_modified_time_before: Optional[datetime],
-        last_modified_time_after: Optional[datetime],
-        status_equals: Optional[str],
+        sort_by: str | None,
+        sort_order: str | None,
+        name_contains: str | None,
+        creation_time_before: datetime | None,
+        creation_time_after: datetime | None,
+        last_modified_time_before: datetime | None,
+        last_modified_time_after: datetime | None,
+        status_equals: str | None,
     ) -> list[FakeEndpoint]:
         endpoints = list(self.endpoints.values())
         if name_contains:
@@ -5002,11 +5002,11 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_endpoint_configs(
         self,
-        sort_by: Optional[str],
-        sort_order: Optional[str],
-        name_contains: Optional[str],
-        creation_time_before: Optional[datetime],
-        creation_time_after: Optional[datetime],
+        sort_by: str | None,
+        sort_order: str | None,
+        name_contains: str | None,
+        creation_time_before: datetime | None,
+        creation_time_after: datetime | None,
     ) -> list[FakeEndpointConfig]:
         endpoint_configs = list(self.endpoint_configs.values())
         if name_contains:
@@ -5038,10 +5038,10 @@ class SageMakerModelBackend(BaseBackend):
         role_arn: str,
         output_config: dict[str, Any],
         stopping_condition: dict[str, Any],
-        model_package_version_arn: Optional[str],
-        input_config: Optional[dict[str, Any]],
-        vpc_config: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
+        model_package_version_arn: str | None,
+        input_config: dict[str, Any] | None,
+        vpc_config: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
     ) -> str:
         compilation_job = CompilationJob(
             compilation_job_name=compilation_job_name,
@@ -5069,14 +5069,14 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_compilation_jobs(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        last_modified_time_after: Optional[datetime],
-        last_modified_time_before: Optional[datetime],
-        name_contains: Optional[str],
-        status_equals: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        last_modified_time_after: datetime | None,
+        last_modified_time_before: datetime | None,
+        name_contains: str | None,
+        status_equals: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[CompilationJob]:
         compilation_jobs = list(self.compilation_jobs.values())
         if name_contains:
@@ -5138,13 +5138,13 @@ class SageMakerModelBackend(BaseBackend):
         default_user_settings: dict[str, Any],
         subnet_ids: list[str],
         vpc_id: str,
-        domain_settings: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
-        app_network_access_type: Optional[str],
-        home_efs_file_system_kms_key_id: Optional[str],
-        kms_key_id: Optional[str],
-        app_security_group_management: Optional[str],
-        default_space_settings: Optional[dict[str, Any]],
+        domain_settings: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
+        app_network_access_type: str | None,
+        home_efs_file_system_kms_key_id: str | None,
+        kms_key_id: str | None,
+        app_security_group_management: str | None,
+        default_space_settings: dict[str, Any] | None,
     ) -> dict[str, Any]:
         domain = Domain(
             domain_name=domain_name,
@@ -5175,7 +5175,7 @@ class SageMakerModelBackend(BaseBackend):
         return list(self.domains.values())
 
     def delete_domain(
-        self, domain_id: str, retention_policy: Optional[dict[str, str]]
+        self, domain_id: str, retention_policy: dict[str, str] | None
     ) -> None:
         # 'retention_policy' parameter is not used
         if domain_id not in self.domains:
@@ -5185,14 +5185,14 @@ class SageMakerModelBackend(BaseBackend):
     def create_model_explainability_job_definition(
         self,
         job_definition_name: str,
-        model_explainability_baseline_config: Optional[dict[str, Any]],
+        model_explainability_baseline_config: dict[str, Any] | None,
         model_explainability_app_specification: dict[str, Any],
         model_explainability_job_input: dict[str, Any],
         model_explainability_job_output_config: dict[str, Any],
         job_resources: dict[str, Any],
-        network_config: Optional[dict[str, Any]],
+        network_config: dict[str, Any] | None,
         role_arn: str,
-        stopping_condition: Optional[dict[str, Any]],
+        stopping_condition: dict[str, Any] | None,
         tags: list[dict[str, str]],
     ) -> str:
         model_explainability_job_definition = ModelExplainabilityJobDefinition(
@@ -5226,12 +5226,12 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_model_explainability_job_definitions(
         self,
-        endpoint_name: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
-        name_contains: Optional[str],
-        creation_time_before: Optional[datetime],
-        creation_time_after: Optional[datetime],
+        endpoint_name: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
+        name_contains: str | None,
+        creation_time_before: datetime | None,
+        creation_time_after: datetime | None,
     ) -> list[ModelExplainabilityJobDefinition]:
         model_explainability_job_definitions = list(
             self.model_explainability_job_definitions.values()
@@ -5288,11 +5288,11 @@ class SageMakerModelBackend(BaseBackend):
         self,
         hyper_parameter_tuning_job_name: str,
         hyper_parameter_tuning_job_config: dict[str, Any],
-        training_job_definition: Optional[dict[str, Any]],
-        training_job_definitions: Optional[list[dict[str, Any]]],
-        warm_start_config: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
-        autotune: Optional[dict[str, Any]],
+        training_job_definition: dict[str, Any] | None,
+        training_job_definitions: list[dict[str, Any]] | None,
+        warm_start_config: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
+        autotune: dict[str, Any] | None,
     ) -> str:
         hyper_parameter_tuning_job = HyperParameterTuningJob(
             hyper_parameter_tuning_job_name=hyper_parameter_tuning_job_name,
@@ -5325,14 +5325,14 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_hyper_parameter_tuning_jobs(
         self,
-        sort_by: Optional[str],
-        sort_order: Optional[str],
-        name_contains: Optional[str],
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        last_modified_time_after: Optional[datetime],
-        last_modified_time_before: Optional[datetime],
-        status_equals: Optional[str],
+        sort_by: str | None,
+        sort_order: str | None,
+        name_contains: str | None,
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        last_modified_time_after: datetime | None,
+        last_modified_time_before: datetime | None,
+        status_equals: str | None,
     ) -> list[HyperParameterTuningJob]:
         hyper_parameter_tuning_jobs = list(self.hyper_parameter_tuning_jobs.values())
         if name_contains:
@@ -5404,15 +5404,15 @@ class SageMakerModelBackend(BaseBackend):
     def create_model_quality_job_definition(
         self,
         job_definition_name: str,
-        model_quality_baseline_config: Optional[dict[str, Any]],
+        model_quality_baseline_config: dict[str, Any] | None,
         model_quality_app_specification: dict[str, Any],
         model_quality_job_input: dict[str, Any],
         model_quality_job_output_config: dict[str, Any],
         job_resources: dict[str, Any],
-        network_config: Optional[dict[str, Any]],
+        network_config: dict[str, Any] | None,
         role_arn: str,
-        stopping_condition: Optional[dict[str, Any]],
-        tags: Optional[list[dict[str, str]]],
+        stopping_condition: dict[str, Any] | None,
+        tags: list[dict[str, str]] | None,
     ) -> str:
         model_quality_job_definition = ModelQualityJobDefinition(
             job_definition_name=job_definition_name,
@@ -5445,12 +5445,12 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_model_quality_job_definitions(
         self,
-        endpoint_name: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
-        name_contains: Optional[str],
-        creation_time_before: Optional[datetime],
-        creation_time_after: Optional[datetime],
+        endpoint_name: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
+        name_contains: str | None,
+        creation_time_before: datetime | None,
+        creation_time_after: datetime | None,
     ) -> list[ModelQualityJobDefinition]:
         model_quality_job_definitions = list(
             self.model_quality_job_definitions.values()
@@ -5504,13 +5504,13 @@ class SageMakerModelBackend(BaseBackend):
     def create_model_card(
         self,
         model_card_name: str,
-        security_config: Optional[dict[str, str]],
+        security_config: dict[str, str] | None,
         content: str,
         model_card_status: str,
-        tags: Optional[list[dict[str, str]]],
-        model_card_version: Optional[int] = None,
-        creation_time: Optional[datetime] = None,
-        last_modified_time: Optional[datetime] = None,
+        tags: list[dict[str, str]] | None,
+        model_card_version: int | None = None,
+        creation_time: datetime | None = None,
+        last_modified_time: datetime | None = None,
     ) -> str:
         if model_card_name in self.model_cards:
             raise ConflictException(f"Modelcard {model_card_name} already exists")
@@ -5568,12 +5568,12 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_model_cards(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
-        name_contains: Optional[str],
-        model_card_status: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
+        name_contains: str | None,
+        model_card_status: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[FakeModelCard]:
         model_cards = self.model_cards
 
@@ -5590,12 +5590,12 @@ class SageMakerModelBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_model_card_versions(
         self,
-        creation_time_after: Optional[datetime],
-        creation_time_before: Optional[datetime],
+        creation_time_after: datetime | None,
+        creation_time_before: datetime | None,
         model_card_name: str,
-        model_card_status: Optional[str],
-        sort_by: Optional[str],
-        sort_order: Optional[str],
+        model_card_status: str | None,
+        sort_by: str | None,
+        sort_order: str | None,
     ) -> list[FakeModelCard]:
         if model_card_name not in self.model_cards:
             raise ResourceNotFound(f"Modelcard {model_card_name} does not exist")
@@ -5646,16 +5646,16 @@ class SageMakerModelBackend(BaseBackend):
         self,
         account_id: str,
         job_definition_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
         role_arn: str = "",
-        job_resources: Optional[dict[str, Any]] = None,
-        stopping_condition: Optional[dict[str, Any]] = None,
-        environment: Optional[dict[str, str]] = None,
-        network_config: Optional[dict[str, Any]] = None,
-        data_quality_baseline_config: Optional[dict[str, Any]] = None,
-        data_quality_app_specification: Optional[dict[str, Any]] = None,
-        data_quality_job_input: Optional[dict[str, Any]] = None,
-        data_quality_job_output_config: Optional[dict[str, Any]] = None,
+        job_resources: dict[str, Any] | None = None,
+        stopping_condition: dict[str, Any] | None = None,
+        environment: dict[str, str] | None = None,
+        network_config: dict[str, Any] | None = None,
+        data_quality_baseline_config: dict[str, Any] | None = None,
+        data_quality_app_specification: dict[str, Any] | None = None,
+        data_quality_job_input: dict[str, Any] | None = None,
+        data_quality_job_output_config: dict[str, Any] | None = None,
     ) -> dict[str, str]:
         job_definition = FakeDataQualityJobDefinition(
             account_id=account_id,
@@ -5702,16 +5702,16 @@ class FakeDataQualityJobDefinition(BaseObject):
         account_id: str,
         region_name: str,
         job_definition_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
         role_arn: str = "",
-        job_resources: Optional[dict[str, Any]] = None,
-        stopping_condition: Optional[dict[str, Any]] = None,
-        environment: Optional[dict[str, str]] = None,
-        network_config: Optional[dict[str, Any]] = None,
-        data_quality_baseline_config: Optional[dict[str, Any]] = None,
-        data_quality_app_specification: Optional[dict[str, Any]] = None,
-        data_quality_job_input: Optional[dict[str, Any]] = None,
-        data_quality_job_output_config: Optional[dict[str, Any]] = None,
+        job_resources: dict[str, Any] | None = None,
+        stopping_condition: dict[str, Any] | None = None,
+        environment: dict[str, str] | None = None,
+        network_config: dict[str, Any] | None = None,
+        data_quality_baseline_config: dict[str, Any] | None = None,
+        data_quality_app_specification: dict[str, Any] | None = None,
+        data_quality_job_input: dict[str, Any] | None = None,
+        data_quality_job_output_config: dict[str, Any] | None = None,
     ):
         self.job_definition_name = job_definition_name
         self.arn = FakeDataQualityJobDefinition.arn_formatter(
@@ -5823,15 +5823,15 @@ class FakeTrialComponent(BaseObject):
         account_id: str,
         region_name: str,
         trial_component_name: str,
-        display_name: Optional[str],
-        start_time: Optional[datetime],
-        end_time: Optional[datetime],
-        parameters: Optional[dict[str, dict[str, Union[str, float]]]],
-        input_artifacts: Optional[dict[str, dict[str, str]]],
-        output_artifacts: Optional[dict[str, dict[str, str]]],
-        metadata_properties: Optional[dict[str, str]],
-        status: Optional[dict[str, str]],
-        trial_name: Optional[str],
+        display_name: str | None,
+        start_time: datetime | None,
+        end_time: datetime | None,
+        parameters: dict[str, dict[str, str | float]] | None,
+        input_artifacts: dict[str, dict[str, str]] | None,
+        output_artifacts: dict[str, dict[str, str]] | None,
+        metadata_properties: dict[str, str] | None,
+        status: dict[str, str] | None,
+        trial_name: str | None,
         tags: list[dict[str, str]],
     ):
         self.trial_component_name = trial_component_name
@@ -5848,13 +5848,13 @@ class FakeTrialComponent(BaseObject):
         self.end_time = end_time
         now = utcnow()
         self.creation_time = self.last_modified_time = now
-        self.created_by: dict[str, Union[dict[str, str], str]] = {}
-        self.last_modified_by: dict[str, Union[dict[str, str], str]] = {}
+        self.created_by: dict[str, dict[str, str] | str] = {}
+        self.last_modified_by: dict[str, dict[str, str] | str] = {}
         self.parameters = parameters if parameters is not None else {}
         self.input_artifacts = input_artifacts if input_artifacts is not None else {}
         self.output_artifacts = output_artifacts if output_artifacts is not None else {}
         self.metadata_properties = metadata_properties
-        self.metrics: dict[str, dict[str, Union[str, int, METRIC_STEP_TYPE]]] = {}
+        self.metrics: dict[str, dict[str, str | int | METRIC_STEP_TYPE]] = {}
         self.sources: list[dict[str, str]] = []
 
     @property
@@ -5870,7 +5870,7 @@ class FakeTrialComponent(BaseObject):
 
     def gen_metrics_response_object(
         self,
-    ) -> list[dict[str, Union[str, int, float, datetime]]]:
+    ) -> list[dict[str, str | int | float | datetime]]:
         metrics_names = self.metrics.keys()
         metrics_response_objects = []
         for metrics_name in metrics_names:
@@ -5920,16 +5920,16 @@ class FakeModelBiasJobDefinition(BaseObject):
         account_id: str,
         region_name: str,
         job_definition_name: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
         role_arn: str = "",
-        job_resources: Optional[dict[str, Any]] = None,
-        stopping_condition: Optional[dict[str, Any]] = None,
-        environment: Optional[dict[str, str]] = None,
-        network_config: Optional[dict[str, Any]] = None,
-        model_bias_baseline_config: Optional[dict[str, Any]] = None,
-        model_bias_app_specification: Optional[dict[str, Any]] = None,
-        model_bias_job_input: Optional[dict[str, Any]] = None,
-        model_bias_job_output_config: Optional[dict[str, Any]] = None,
+        job_resources: dict[str, Any] | None = None,
+        stopping_condition: dict[str, Any] | None = None,
+        environment: dict[str, str] | None = None,
+        network_config: dict[str, Any] | None = None,
+        model_bias_baseline_config: dict[str, Any] | None = None,
+        model_bias_app_specification: dict[str, Any] | None = None,
+        model_bias_job_input: dict[str, Any] | None = None,
+        model_bias_job_output_config: dict[str, Any] | None = None,
     ):
         self.job_definition_name = job_definition_name
         self.arn = FakeModelBiasJobDefinition.arn_formatter(

--- a/moto/sagemaker/utils.py
+++ b/moto/sagemaker/utils.py
@@ -1,15 +1,14 @@
 import json
-import typing
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.s3.models import s3_backends
 from moto.utilities.utils import get_partition
 
 from .exceptions import ValidationError
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from .models import FakeModelCard, FakePipeline, FakePipelineExecution
 
 
@@ -56,7 +55,7 @@ def arn_formatter(_type: str, _id: str, account_id: str, region_name: str) -> st
     return f"arn:{get_partition(region_name)}:sagemaker:{region_name}:{account_id}:{_type}/{_id}"
 
 
-def validate_model_approval_status(model_approval_status: typing.Optional[str]) -> None:
+def validate_model_approval_status(model_approval_status: str | None) -> None:
     if model_approval_status is not None and model_approval_status not in [
         "Approved",
         "Rejected",
@@ -70,12 +69,12 @@ def validate_model_approval_status(model_approval_status: typing.Optional[str]) 
 
 def filter_model_cards(
     model_cards: defaultdict[str, list["FakeModelCard"]],
-    creation_time_after: Optional[datetime],
-    creation_time_before: Optional[datetime],
-    name_contains: Optional[str],
-    model_card_status: Optional[str],
-    sort_by: Optional[str],
-    sort_order: Optional[str],
+    creation_time_after: datetime | None,
+    creation_time_before: datetime | None,
+    name_contains: str | None,
+    model_card_status: str | None,
+    sort_by: str | None,
+    sort_order: str | None,
 ) -> list["FakeModelCard"]:
     reverse = sort_order == "Descending"
 

--- a/moto/sagemaker/validators.py
+++ b/moto/sagemaker/validators.py
@@ -1,14 +1,14 @@
-from typing import Any, Optional
+from typing import Any
 
 
 def is_integer_between(
-    x: int, mn: Optional[int] = None, mx: Optional[int] = None, optional: bool = False
+    x: int, mn: int | None = None, mx: int | None = None, optional: bool = False
 ) -> bool:
     if optional and x is None:
         return True
     try:
         if mn is not None and mx is not None:
-            return int(x) >= mn and int(x) < mx
+            return mn <= int(x) < mx
         elif mn is not None:
             return int(x) >= mn
         elif mx is not None:

--- a/moto/sagemakermetrics/models.py
+++ b/moto/sagemakermetrics/models.py
@@ -1,13 +1,13 @@
 """SageMakerMetricsBackend class with methods for supported APIs."""
 
 from datetime import datetime
-from typing import Union, cast
+from typing import cast
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.sagemaker import sagemaker_backends
 from moto.sagemaker.models import METRIC_STEP_TYPE
 
-RESPONSE_TYPE = dict[str, list[dict[str, Union[str, int]]]]
+RESPONSE_TYPE = dict[str, list[dict[str, str | int]]]
 
 
 class SageMakerMetricsBackend(BaseBackend):
@@ -20,7 +20,7 @@ class SageMakerMetricsBackend(BaseBackend):
     def batch_put_metrics(
         self,
         trial_component_name: str,
-        metric_data: list[dict[str, Union[str, int, float, datetime]]],
+        metric_data: list[dict[str, str | int | float | datetime]],
     ) -> RESPONSE_TYPE:
         return_response: RESPONSE_TYPE = {"Errors": []}
 
@@ -36,8 +36,8 @@ class SageMakerMetricsBackend(BaseBackend):
             metric_name: str = cast(str, metric["MetricName"])
             if metric_name not in trial_component.metrics:
                 metric_timestamp: int = cast(int, metric["Timestamp"])
-                values_dict: dict[int, dict[str, Union[str, int, float, datetime]]] = {}
-                new_metric: dict[str, Union[str, int, METRIC_STEP_TYPE]] = {
+                values_dict: dict[int, dict[str, str | int | float | datetime]] = {}
+                new_metric: dict[str, str | int | METRIC_STEP_TYPE] = {
                     "MetricName": metric_name,
                     "Timestamp": metric_timestamp,
                     "Values": values_dict,

--- a/moto/scheduler/models.py
+++ b/moto/scheduler/models.py
@@ -1,7 +1,7 @@
 """EventBridgeSchedulerBackend class with methods for supported APIs."""
 
 import datetime
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -25,16 +25,16 @@ class Schedule(BaseModel):
         account_id: str,
         group_name: str,
         name: str,
-        description: Optional[str],
+        description: str | None,
         schedule_expression: str,
-        schedule_expression_timezone: Optional[str],
+        schedule_expression_timezone: str | None,
         flexible_time_window: dict[str, Any],
         target: dict[str, Any],
-        state: Optional[str],
-        kms_key_arn: Optional[str],
-        start_date: Optional[str],
-        end_date: Optional[str],
-        action_after_completion: Optional[str],
+        state: str | None,
+        kms_key_arn: str | None,
+        start_date: str | None,
+        end_date: str | None,
+        action_after_completion: str | None,
     ):
         self.name = name
         self.group_name = group_name
@@ -60,7 +60,7 @@ class Schedule(BaseModel):
             }
         return target
 
-    def _validate_start_date(self, start_date: Optional[str]) -> Optional[str]:
+    def _validate_start_date(self, start_date: str | None) -> str | None:
         # `.count("*")` means a recurrence expression
         # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/scheduler/client/create_schedule.html (StartDate parameter)
         if self.schedule_expression.count("*") and start_date is not None:
@@ -194,7 +194,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
         start_date: str,
         state: str,
         target: dict[str, Any],
-        action_after_completion: Optional[str],
+        action_after_completion: str | None,
     ) -> Schedule:
         """
         The ClientToken parameter is not yet implemented
@@ -221,11 +221,11 @@ class EventBridgeSchedulerBackend(BaseBackend):
         group.add_schedule(schedule)
         return schedule
 
-    def get_schedule(self, group_name: Optional[str], name: str) -> Schedule:
+    def get_schedule(self, group_name: str | None, name: str) -> Schedule:
         group = self.get_schedule_group(group_name)
         return group.get_schedule(name)
 
-    def delete_schedule(self, group_name: Optional[str], name: str) -> None:
+    def delete_schedule(self, group_name: str | None, name: str) -> None:
         group = self.get_schedule_group(group_name)
         group.delete_schedule(name)
 
@@ -263,9 +263,9 @@ class EventBridgeSchedulerBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_schedules(
         self,
-        group_names: Optional[str],
-        state: Optional[str],
-        name_prefix: Optional[str] = None,
+        group_names: str | None,
+        state: str | None,
+        name_prefix: str | None = None,
     ) -> list[Schedule]:
         """
         The following parameters are not yet implemented: MaxResults, NamePrefix, NextToken
@@ -294,14 +294,14 @@ class EventBridgeSchedulerBackend(BaseBackend):
         self.tagger.tag_resource(group.arn, tags)
         return group
 
-    def get_schedule_group(self, group_name: Optional[str]) -> ScheduleGroup:
+    def get_schedule_group(self, group_name: str | None) -> ScheduleGroup:
         if (group_name or "default") not in self.schedule_groups:
             raise ScheduleGroupNotFound(group_name or "default")
         return self.schedule_groups[group_name or "default"]
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_schedule_groups(
-        self, name_prefix: Optional[str] = None
+        self, name_prefix: str | None = None
     ) -> list[ScheduleGroup]:
         results = []
         for group in self.schedule_groups.values():
@@ -318,7 +318,7 @@ class EventBridgeSchedulerBackend(BaseBackend):
         )
         return results
 
-    def delete_schedule_group(self, name: Optional[str]) -> None:
+    def delete_schedule_group(self, name: str | None) -> None:
         self.schedule_groups.pop(name or "default")
 
     def list_tags_for_resource(

--- a/moto/sdb/models.py
+++ b/moto/sdb/models.py
@@ -4,7 +4,7 @@ import re
 from collections import defaultdict
 from collections.abc import Iterable
 from threading import Lock
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -17,7 +17,7 @@ class FakeItem(BaseModel):
         self.attributes: list[dict[str, Any]] = []
         self.lock = Lock()
 
-    def get_attributes(self, names: Optional[list[str]]) -> list[dict[str, Any]]:
+    def get_attributes(self, names: list[str] | None) -> list[dict[str, Any]]:
         if not names:
             return self.attributes
         return [attr for attr in self.attributes if attr["Name"] in names]

--- a/moto/secretsmanager/list_secrets/filters.py
+++ b/moto/secretsmanager/list_secrets/filters.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 import re
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..models import FakeSecret, ReplicaSecret
 
 
-def name_filter(secret: "FakeSecret", names: list[str]) -> bool:
+def name_filter(secret: FakeSecret, names: list[str]) -> bool:
     return _matcher(names, [secret.name])
 
 
-def description_filter(secret: "FakeSecret", descriptions: list[str]) -> bool:
+def description_filter(secret: FakeSecret, descriptions: list[str]) -> bool:
     if not secret.description:
         return False
     # The documentation states that this search uses `Prefix match`
@@ -21,7 +23,7 @@ def description_filter(secret: "FakeSecret", descriptions: list[str]) -> bool:
     )
 
 
-def owning_service_filter(secret: "FakeSecret", owning_services: list[str]) -> bool:
+def owning_service_filter(secret: FakeSecret, owning_services: list[str]) -> bool:
     return _matcher(
         owning_services,
         [secret.owning_service] if secret.owning_service else [],
@@ -30,21 +32,19 @@ def owning_service_filter(secret: "FakeSecret", owning_services: list[str]) -> b
     )
 
 
-def tag_key(secret: Union["FakeSecret", "ReplicaSecret"], tag_keys: list[str]) -> bool:
+def tag_key(secret: FakeSecret | ReplicaSecret, tag_keys: list[str]) -> bool:
     if not secret.tags:
         return False
     return _matcher(tag_keys, [tag["Key"] for tag in secret.tags])
 
 
-def tag_value(
-    secret: Union["FakeSecret", "ReplicaSecret"], tag_values: list[str]
-) -> bool:
+def tag_value(secret: FakeSecret | ReplicaSecret, tag_values: list[str]) -> bool:
     if not secret.tags:
         return False
     return _matcher(tag_values, [tag["Value"] for tag in secret.tags])
 
 
-def filter_all(secret: Union["FakeSecret", "ReplicaSecret"], values: list[str]) -> bool:
+def filter_all(secret: FakeSecret | ReplicaSecret, values: list[str]) -> bool:
     attributes = [secret.name]
     if secret.description:
         attributes.append(secret.description)
@@ -128,7 +128,7 @@ def split_words(s: str) -> list[str]:
     return list(split_by_uppercase(s))
 
 
-def split_by_uppercase(s: Union[str, list[str]]) -> Iterator[str]:
+def split_by_uppercase(s: str | list[str]) -> Iterator[str]:
     """
     Split a string into words. Words are recognized by upper case letters, i.e.:
     test   -> [test]

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import datetime
 import json
 import time
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -37,7 +39,7 @@ MAX_RESULTS_DEFAULT = 100
 
 
 def filter_primary_region(
-    secret: Union["FakeSecret", "ReplicaSecret"], values: list[str]
+    secret: FakeSecret | ReplicaSecret, values: list[str]
 ) -> bool:
     if isinstance(secret, FakeSecret):
         return len(secret.replicas) > 0 and secret.region in values
@@ -60,9 +62,7 @@ def filter_keys() -> list[str]:
     return list(_filter_functions.keys())
 
 
-def _matches(
-    secret: Union["FakeSecret", "ReplicaSecret"], filters: list[dict[str, Any]]
-) -> bool:
+def _matches(secret: FakeSecret | ReplicaSecret, filters: list[dict[str, Any]]) -> bool:
     is_match = True
 
     for f in filters:
@@ -81,15 +81,15 @@ class FakeSecret(BaseModel):
         secret_id: str,
         secret_version: dict[str, Any],
         version_id: str,
-        secret_string: Optional[str] = None,
-        secret_binary: Optional[str] = None,
-        description: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        kms_key_id: Optional[str] = None,
-        version_stages: Optional[list[str]] = None,
-        last_changed_date: Optional[int] = None,
-        created_date: Optional[int] = None,
-        replica_regions: Optional[list[dict[str, str]]] = None,
+        secret_string: str | None = None,
+        secret_binary: str | None = None,
+        description: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        kms_key_id: str | None = None,
+        version_stages: list[str] | None = None,
+        last_changed_date: int | None = None,
+        created_date: int | None = None,
+        replica_regions: list[dict[str, str]] | None = None,
         force_overwrite: bool = False,
     ):
         self.secret_id = secret_id
@@ -112,10 +112,10 @@ class FakeSecret(BaseModel):
         self.rotation_enabled = False
         self.rotation_lambda_arn = ""
         self.auto_rotate_after_days = 0
-        self.deleted_date: Optional[float] = None
-        self.policy: Optional[str] = None
-        self.next_rotation_date: Optional[int] = None
-        self.last_rotation_date: Optional[int] = None
+        self.deleted_date: float | None = None
+        self.policy: str | None = None
+        self.next_rotation_date: int | None = None
+        self.last_rotation_date: int | None = None
 
         self.versions: dict[str, dict[str, Any]] = {}
         if secret_string or secret_binary:
@@ -129,7 +129,7 @@ class FakeSecret(BaseModel):
         )
 
     @property
-    def owning_service(self) -> Optional[str]:
+    def owning_service(self) -> str | None:
         for tag in self.tags or []:
             if tag["Key"] == "aws:secretsmanager:owningService":
                 return tag["Value"]
@@ -137,7 +137,7 @@ class FakeSecret(BaseModel):
 
     def create_replicas(
         self, replica_regions: list[dict[str, str]], force_overwrite: bool
-    ) -> list["ReplicaSecret"]:
+    ) -> list[ReplicaSecret]:
         # Validate first, before we create anything
         for replica_config in replica_regions or []:
             if replica_config["Region"] == self.region:
@@ -163,10 +163,10 @@ class FakeSecret(BaseModel):
 
     def update(
         self,
-        description: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        kms_key_id: Optional[str] = None,
-        last_changed_date: Optional[int] = None,
+        description: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        kms_key_id: str | None = None,
+        last_changed_date: int | None = None,
     ) -> None:
         self.description = description
         self.tags = tags or None
@@ -176,7 +176,7 @@ class FakeSecret(BaseModel):
         if kms_key_id is not None:
             self.kms_key_id = kms_key_id
 
-    def set_default_version_id(self, version_id: Optional[str]) -> None:
+    def set_default_version_id(self, version_id: str | None) -> None:
         self.default_version_id = version_id
 
     def reset_default_version(
@@ -217,7 +217,7 @@ class FakeSecret(BaseModel):
     def to_short_dict(
         self,
         include_version_stages: bool = False,
-        version_id: Optional[str] = None,
+        version_id: str | None = None,
         include_version_id: bool = True,
     ) -> str:
         if not version_id:
@@ -291,8 +291,8 @@ class ReplicaSecret:
         self,
         source: FakeSecret,
         region: str,
-        status: Optional[str] = None,
-        message: Optional[str] = None,
+        status: str | None = None,
+        message: str | None = None,
     ):
         self.source = source
         self.arn = source.arn.replace(source.region, region)
@@ -317,7 +317,7 @@ class ReplicaSecret:
         return dct
 
     @property
-    def default_version_id(self) -> Optional[str]:
+    def default_version_id(self) -> str | None:
         return self.source.default_version_id
 
     @property
@@ -333,27 +333,27 @@ class ReplicaSecret:
         return self.source.secret_id
 
     @property
-    def description(self) -> Optional[str]:
+    def description(self) -> str | None:
         return self.source.description
 
     @property
-    def tags(self) -> Optional[list[dict[str, str]]]:
+    def tags(self) -> list[dict[str, str]] | None:
         return self.source.tags
 
     @property
-    def owning_service(self) -> Optional[str]:
+    def owning_service(self) -> str | None:
         return self.source.owning_service
 
 
-class SecretsStore(dict[str, Union[FakeSecret, ReplicaSecret]]):
+class SecretsStore(dict[str, FakeSecret | ReplicaSecret]):
     # Parameters to this dictionary can be three possible values:
     # names, full ARNs, and partial ARNs
     # Every retrieval method should check which type of input it receives
 
-    def __setitem__(self, key: str, value: Union[FakeSecret, ReplicaSecret]) -> None:
+    def __setitem__(self, key: str, value: FakeSecret | ReplicaSecret) -> None:
         super().__setitem__(key, value)
 
-    def __getitem__(self, key: str) -> Union[FakeSecret, ReplicaSecret]:
+    def __getitem__(self, key: str) -> FakeSecret | ReplicaSecret:
         for secret in dict.values(self):
             if secret.arn == key or secret.name == key:
                 return secret
@@ -367,14 +367,14 @@ class SecretsStore(dict[str, Union[FakeSecret, ReplicaSecret]]):
         name = get_secret_name_from_partial_arn(key)
         return dict.__contains__(self, name)  # type: ignore
 
-    def get(self, key: str) -> Optional[Union[FakeSecret, ReplicaSecret]]:  # type: ignore
+    def get(self, key: str) -> FakeSecret | ReplicaSecret | None:  # type: ignore
         for secret in dict.values(self):
             if secret.arn == key or secret.name == key:
                 return secret
         name = get_secret_name_from_partial_arn(key)
         return super().get(name)
 
-    def pop(self, key: str) -> Optional[Union[FakeSecret, ReplicaSecret]]:  # type: ignore
+    def pop(self, key: str) -> FakeSecret | ReplicaSecret | None:  # type: ignore
         for secret in dict.values(self):
             if secret.arn == key or secret.name == key:
                 key = secret.name
@@ -402,7 +402,7 @@ class SecretsManagerBackend(BaseBackend):
             msg = "ClientRequestToken must be 32-64 characters long."
             raise InvalidParameterException(msg)
 
-    def _from_client_request_token(self, client_request_token: Optional[str]) -> str:
+    def _from_client_request_token(self, client_request_token: str | None) -> str:
         if client_request_token:
             self._client_request_token_validator(client_request_token)
             return client_request_token
@@ -498,11 +498,11 @@ class SecretsManagerBackend(BaseBackend):
 
     def batch_get_secret_value(
         self,
-        secret_id_list: Optional[list[str]] = None,
-        filters: Optional[list[dict[str, Any]]] = None,
-        max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
-    ) -> tuple[list[dict[str, Any]], list[Any], Optional[str]]:
+        secret_id_list: list[str] | None = None,
+        filters: list[dict[str, Any]] | None = None,
+        max_results: int | None = None,
+        next_token: str | None = None,
+    ) -> tuple[list[dict[str, Any]], list[Any], str | None]:
         secret_list = []
         errors: list[Any] = []
         if secret_id_list and filters:
@@ -550,11 +550,11 @@ class SecretsManagerBackend(BaseBackend):
     def update_secret(
         self,
         secret_id: str,
-        secret_string: Optional[str] = None,
-        secret_binary: Optional[str] = None,
-        client_request_token: Optional[str] = None,
-        kms_key_id: Optional[str] = None,
-        description: Optional[str] = None,
+        secret_string: str | None = None,
+        secret_binary: str | None = None,
+        client_request_token: str | None = None,
+        kms_key_id: str | None = None,
+        description: str | None = None,
     ) -> str:
         # error if secret does not exist
         if secret_id not in self.secrets:
@@ -591,12 +591,12 @@ class SecretsManagerBackend(BaseBackend):
     def create_secret(
         self,
         name: str,
-        secret_string: Optional[str],
-        secret_binary: Optional[str],
-        description: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        kms_key_id: Optional[str],
-        client_request_token: Optional[str],
+        secret_string: str | None,
+        secret_binary: str | None,
+        description: str | None,
+        tags: list[dict[str, str]] | None,
+        kms_key_id: str | None,
+        client_request_token: str | None,
         replica_regions: list[dict[str, str]],
         force_overwrite: bool,
     ) -> str:
@@ -623,11 +623,11 @@ class SecretsManagerBackend(BaseBackend):
     def _check_with_existing_secrets_and_versions(
         self,
         secret_name: str,
-        client_request_token: Optional[str],
-        secret_string: Optional[str],
-        secret_binary: Optional[str],
+        client_request_token: str | None,
+        secret_string: str | None,
+        secret_binary: str | None,
         on_create: bool = False,
-    ) -> Optional[FakeSecret]:
+    ) -> FakeSecret | None:
         """
         Check if a secret with the given name and version ID already exists.
         If they do and the original operation is intending to modify it, that will be flagged.
@@ -679,14 +679,14 @@ class SecretsManagerBackend(BaseBackend):
     def _add_secret(
         self,
         secret_id: str,
-        secret_string: Optional[str] = None,
-        secret_binary: Optional[str] = None,
-        description: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        kms_key_id: Optional[str] = None,
-        version_id: Optional[str] = None,
-        version_stages: Optional[list[str]] = None,
-        replica_regions: Optional[list[dict[str, str]]] = None,
+        secret_string: str | None = None,
+        secret_binary: str | None = None,
+        description: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        kms_key_id: str | None = None,
+        version_id: str | None = None,
+        version_stages: list[str] | None = None,
+        replica_regions: list[dict[str, str]] | None = None,
         force_overwrite: bool = False,
     ) -> tuple[FakeSecret, bool]:
         if version_stages is None:
@@ -746,13 +746,13 @@ class SecretsManagerBackend(BaseBackend):
         self,
         service_name: str,
         secret_id: str,
-        secret_string: Optional[str] = None,
-        secret_binary: Optional[str] = None,
-        description: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        kms_key_id: Optional[str] = None,
-        version_id: Optional[str] = None,
-        replica_regions: Optional[list[dict[str, str]]] = None,
+        secret_string: str | None = None,
+        secret_binary: str | None = None,
+        description: str | None = None,
+        tags: list[dict[str, str]] | None = None,
+        kms_key_id: str | None = None,
+        version_id: str | None = None,
+        replica_regions: list[dict[str, str]] | None = None,
         force_overwrite: bool = False,
     ) -> FakeSecret:
         """Create an AWS managed secret for the specified service name."""
@@ -822,7 +822,7 @@ class SecretsManagerBackend(BaseBackend):
 
         return secret.to_short_dict(include_version_stages=True, version_id=version_id)
 
-    def describe_secret(self, secret_id: str) -> Union[FakeSecret, ReplicaSecret]:
+    def describe_secret(self, secret_id: str) -> FakeSecret | ReplicaSecret:
         if not self._is_valid_identifier(secret_id):
             raise SecretNotFoundException()
 
@@ -831,9 +831,9 @@ class SecretsManagerBackend(BaseBackend):
     def rotate_secret(
         self,
         secret_id: str,
-        client_request_token: Optional[str] = None,
-        rotation_lambda_arn: Optional[str] = None,
-        rotation_rules: Optional[dict[str, Any]] = None,
+        client_request_token: str | None = None,
+        rotation_lambda_arn: str | None = None,
+        rotation_rules: dict[str, Any] | None = None,
         rotate_immediately: bool = True,
     ) -> str:
         rotation_days = "AutomaticallyAfterDays"
@@ -1037,9 +1037,9 @@ class SecretsManagerBackend(BaseBackend):
         self,
         filters: list[dict[str, Any]],
         max_results: int = MAX_RESULTS_DEFAULT,
-        next_token: Optional[str] = None,
+        next_token: str | None = None,
         include_planned_deletion: bool = False,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+    ) -> tuple[list[dict[str, Any]], str | None]:
         secret_list: list[dict[str, Any]] = []
         for secret in self.secrets.values():
             if hasattr(secret, "deleted_date"):
@@ -1055,7 +1055,7 @@ class SecretsManagerBackend(BaseBackend):
     def delete_secret(
         self,
         secret_id: str,
-        recovery_window_in_days: Optional[int],
+        recovery_window_in_days: int | None,
         force_delete_without_recovery: bool,
     ) -> tuple[str, str, float]:
         if recovery_window_in_days is not None and (
@@ -1286,9 +1286,9 @@ class SecretsManagerBackend(BaseBackend):
     def _get_secret_values_page_and_next_token(
         self,
         secret_list: list[dict[str, Any]],
-        max_results: Optional[int],
-        next_token: Optional[str],
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        max_results: int | None,
+        next_token: str | None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         starting_point = int(next_token or 0)
         ending_point = starting_point + int(max_results or MAX_RESULTS_DEFAULT)
         secret_page = secret_list[starting_point:ending_point]

--- a/moto/securityhub/models.py
+++ b/moto/securityhub/models.py
@@ -1,7 +1,7 @@
 """SecurityHubBackend class with methods for supported APIs."""
 
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -51,7 +51,7 @@ class SecurityHubBackend(BaseBackend):
         self.findings: list[Finding] = []
         self.region_name = region_name
         self.org_backend = organizations_backends[self.account_id]["aws"]
-        self.enabled_at: Optional[str] = None
+        self.enabled_at: str | None = None
         self.enabled = False
         self.members: dict[str, dict[str, str]] = {}
 
@@ -79,7 +79,7 @@ class SecurityHubBackend(BaseBackend):
     def enable_security_hub(
         self,
         enable_default_standards: bool = True,
-        tags: Optional[dict[str, str]] = None,
+        tags: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         if self.enabled:
             return {}
@@ -106,7 +106,7 @@ class SecurityHubBackend(BaseBackend):
 
         return {}
 
-    def describe_hub(self, hub_arn: Optional[str] = None) -> dict[str, Any]:
+    def describe_hub(self, hub_arn: str | None = None) -> dict[str, Any]:
         if not self.enabled:
             raise RESTError(
                 "InvalidAccessException",
@@ -133,9 +133,9 @@ class SecurityHubBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def get_findings(
         self,
-        filters: Optional[dict[str, Any]] = None,
-        sort_criteria: Optional[list[dict[str, str]]] = None,
-        max_results: Optional[int] = None,
+        filters: dict[str, Any] | None = None,
+        sort_criteria: list[dict[str, str]] | None = None,
+        max_results: int | None = None,
     ) -> list[dict[str, str]]:
         """
         Filters and SortCriteria is not yet implemented
@@ -229,8 +229,8 @@ class SecurityHubBackend(BaseBackend):
     def update_organization_configuration(
         self,
         auto_enable: bool,
-        auto_enable_standards: Optional[str] = None,
-        organization_configuration: Optional[dict[str, Any]] = None,
+        auto_enable_standards: str | None = None,
+        organization_configuration: dict[str, Any] | None = None,
     ) -> None:
         try:
             self.org_backend.describe_organization()
@@ -427,9 +427,7 @@ class SecurityHubBackend(BaseBackend):
         return members, unprocessed_accounts
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
-    def list_members(
-        self, only_associated: Optional[bool] = None
-    ) -> list[dict[str, str]]:
+    def list_members(self, only_associated: bool | None = None) -> list[dict[str, str]]:
         if only_associated is None:
             only_associated = True
 

--- a/moto/server.py
+++ b/moto/server.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import signal
 import sys
-from typing import Any, Optional
+from typing import Any
 
 from werkzeug.serving import run_simple
 
@@ -20,7 +20,7 @@ def signal_handler(signum: Any, frame: Any) -> None:
     sys.exit(0)
 
 
-def main(argv: Optional[list[str]] = None) -> None:
+def main(argv: list[str] | None = None) -> None:
     argv = argv or sys.argv[1:]
     parser = argparse.ArgumentParser()
 

--- a/moto/servicecatalog/models.py
+++ b/moto/servicecatalog/models.py
@@ -1,7 +1,7 @@
 """ServiceCatalogBackend class with methods for supported APIs."""
 
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -73,16 +73,16 @@ class Product(BaseModel):
         self,
         name: str,
         owner: str,
-        description: Optional[str],
-        distributor: Optional[str],
-        support_description: Optional[str],
-        support_email: Optional[str],
-        support_url: Optional[str],
+        description: str | None,
+        distributor: str | None,
+        support_description: str | None,
+        support_email: str | None,
+        support_url: str | None,
         product_type: str,
-        tags: Optional[list[dict[str, str]]],
-        provisioning_artifact_parameters: Optional[dict[str, Any]],
-        source_connection: Optional[dict[str, Any]],
-        accept_language: Optional[str],
+        tags: list[dict[str, str]] | None,
+        provisioning_artifact_parameters: dict[str, Any] | None,
+        source_connection: dict[str, Any] | None,
+        accept_language: str | None,
         region_name: str,
         account_id: str,
         backend: "ServiceCatalogBackend",
@@ -144,18 +144,18 @@ class ServiceCatalogBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_portfolio_access(
         self,
-        accept_language: Optional[str],
+        accept_language: str | None,
         portfolio_id: str,
-        organization_parent_id: Optional[str],
-        page_token: Optional[str],
-        page_size: Optional[int] = None,
+        organization_parent_id: str | None,
+        page_token: str | None,
+        page_size: int | None = None,
     ) -> list[dict[str, str]]:
         # TODO: Implement organization_parent_id and accept_language
 
         account_ids = self.portfolio_access.get(portfolio_id, [])
         return [{"account_id": account_id} for account_id in account_ids]
 
-    def delete_portfolio(self, accept_language: Optional[str], id: str) -> None:
+    def delete_portfolio(self, accept_language: str | None, id: str) -> None:
         # TODO: Implement accept_language
 
         if id in self.portfolio_access:
@@ -168,11 +168,11 @@ class ServiceCatalogBackend(BaseBackend):
 
     def delete_portfolio_share(
         self,
-        accept_language: Optional[str],
+        accept_language: str | None,
         portfolio_id: str,
-        account_id: Optional[str],
-        organization_node: Optional[dict[str, str]],
-    ) -> Optional[str]:
+        account_id: str | None,
+        organization_node: dict[str, str] | None,
+    ) -> str | None:
         # TODO: Implement accept_language
 
         if (
@@ -204,12 +204,12 @@ class ServiceCatalogBackend(BaseBackend):
 
     def create_portfolio(
         self,
-        accept_language: Optional[str],
+        accept_language: str | None,
         display_name: str,
-        description: Optional[str],
+        description: str | None,
         provider_name: str,
-        tags: Optional[list[dict[str, str]]],
-        idempotency_token: Optional[str],
+        tags: list[dict[str, str]] | None,
+        idempotency_token: str | None,
     ) -> tuple[dict[str, str], list[dict[str, str]]]:
         # TODO: Implement accept_language
 
@@ -242,13 +242,13 @@ class ServiceCatalogBackend(BaseBackend):
 
     def create_portfolio_share(
         self,
-        accept_language: Optional[str],
+        accept_language: str | None,
         portfolio_id: str,
-        account_id: Optional[str],
-        organization_node: Optional[dict[str, str]],
+        account_id: str | None,
+        organization_node: dict[str, str] | None,
         share_tag_options: bool,
         share_principals: bool,
-    ) -> Optional[str]:
+    ) -> str | None:
         # TODO: Implement accept_language
 
         if portfolio_id not in self.portfolios:
@@ -286,10 +286,10 @@ class ServiceCatalogBackend(BaseBackend):
 
     def list_portfolios(
         self,
-        accept_language: Optional[str] = None,
-        page_token: Optional[str] = None,
-        page_size: Optional[int] = None,
-    ) -> tuple[list[dict[str, str]], Optional[str]]:
+        accept_language: str | None = None,
+        page_token: str | None = None,
+        page_size: int | None = None,
+    ) -> tuple[list[dict[str, str]], str | None]:
         """TODO: Implement pagination and accept_language"""
         portfolio_details = [
             portfolio.to_dict() for portfolio in self.portfolios.values()
@@ -300,9 +300,9 @@ class ServiceCatalogBackend(BaseBackend):
         self,
         portfolio_id: str,
         type: str,
-        page_token: Optional[str] = None,
-        page_size: Optional[int] = None,
-    ) -> tuple[Optional[str], list[dict[str, Any]]]:
+        page_token: str | None = None,
+        page_size: int | None = None,
+    ) -> tuple[str | None, list[dict[str, Any]]]:
         """TODO: Implement pagination"""
 
         portfolio_share_details = []
@@ -352,7 +352,7 @@ class ServiceCatalogBackend(BaseBackend):
         return None, portfolio_share_details
 
     def describe_portfolio(
-        self, accept_language: Optional[str], id: str
+        self, accept_language: str | None, id: str
     ) -> tuple[
         dict[str, Any], list[dict[str, str]], list[dict[str, Any]], list[dict[str, str]]
     ]:
@@ -375,17 +375,17 @@ class ServiceCatalogBackend(BaseBackend):
         self,
         name: str,
         owner: str,
-        description: Optional[str],
-        distributor: Optional[str],
-        support_description: Optional[str],
-        support_email: Optional[str],
-        support_url: Optional[str],
+        description: str | None,
+        distributor: str | None,
+        support_description: str | None,
+        support_email: str | None,
+        support_url: str | None,
         product_type: str,
         tags: list[dict[str, str]],
-        provisioning_artifact_parameters: Optional[dict[str, Any]],
-        idempotency_token: Optional[str] = None,
-        source_connection: Optional[dict[str, Any]] = None,
-        accept_language: Optional[str] = None,
+        provisioning_artifact_parameters: dict[str, Any] | None,
+        idempotency_token: str | None = None,
+        source_connection: dict[str, Any] | None = None,
+        accept_language: str | None = None,
     ) -> Product:
         token = idempotency_token or str(uuid.uuid4())
         existing_id = self.idempotency_tokens.get(token)
@@ -416,7 +416,7 @@ class ServiceCatalogBackend(BaseBackend):
         return product
 
     def describe_product(
-        self, accept_language: Optional[str], id: str, name: str
+        self, accept_language: str | None, id: str, name: str
     ) -> Product:
         if not id and not name:
             raise InvalidParametersException("Either Id or Name must be specified.")
@@ -434,14 +434,14 @@ class ServiceCatalogBackend(BaseBackend):
 
         return product
 
-    def lookup_by_name(self, name: str) -> Optional[Product]:
+    def lookup_by_name(self, name: str) -> Product | None:
         for product in self.products.values():
             if name == product.name:
                 return product
 
         return None
 
-    def delete_product(self, accept_language: Optional[str], id: str) -> None:
+    def delete_product(self, accept_language: str | None, id: str) -> None:
         if id in self.products:
             del self.products[id]
 

--- a/moto/servicediscovery/models.py
+++ b/moto/servicediscovery/models.py
@@ -1,6 +1,6 @@
 import string
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -38,7 +38,7 @@ class Namespace(BaseModel):
         description: str,
         dns_properties: dict[str, Any],
         http_properties: dict[str, Any],
-        vpc: Optional[str] = None,
+        vpc: str | None = None,
     ):
         self.id = f"ns-{random_id(20)}"
         self.arn = f"arn:{get_partition(region)}:servicediscovery:{region}:{account_id}:namespace/{self.id}"
@@ -89,7 +89,7 @@ class Service(BaseModel):
         self.namespace_id = namespace_id
         self.description = description
         self.creator_request_id = creator_request_id
-        self.dns_config: Optional[dict[str, Any]] = dns_config
+        self.dns_config: dict[str, Any] | None = dns_config
         self.health_check_config = health_check_config
         self.health_check_custom_config = health_check_custom_config
         self.service_type = service_type
@@ -133,8 +133,8 @@ class ServiceInstance(BaseModel):
         self,
         service_id: str,
         instance_id: str,
-        creator_request_id: Optional[str] = None,
-        attributes: Optional[dict[str, str]] = None,
+        creator_request_id: str | None = None,
+        attributes: dict[str, str] | None = None,
     ):
         self.service_id = service_id
         self.instance_id = instance_id
@@ -400,7 +400,7 @@ class ServiceDiscoveryBackend(BaseBackend):
         self,
         _id: str,
         namespace_dict: dict[str, Any],
-        updater_request_id: Optional[str] = None,
+        updater_request_id: str | None = None,
     ) -> str:
         if "Description" not in namespace_dict:
             raise InvalidInput("Description is required")
@@ -499,7 +499,7 @@ class ServiceDiscoveryBackend(BaseBackend):
     def get_instances_health_status(
         self,
         service_id: str,
-        instances: Optional[list[str]] = None,
+        instances: list[str] | None = None,
     ) -> list[tuple[str, str]]:
         service = self.get_service(service_id)
         status = []
@@ -527,9 +527,9 @@ class ServiceDiscoveryBackend(BaseBackend):
     def _filter_instances(
         self,
         instances: list[ServiceInstance],
-        query_parameters: Optional[dict[str, str]] = None,
-        optional_parameters: Optional[dict[str, str]] = None,
-        health_status: Optional[str] = None,
+        query_parameters: dict[str, str] | None = None,
+        optional_parameters: dict[str, str] | None = None,
+        health_status: str | None = None,
     ) -> list[ServiceInstance]:
         if query_parameters is None:
             query_parameters = {}
@@ -584,9 +584,9 @@ class ServiceDiscoveryBackend(BaseBackend):
         self,
         namespace_name: str,
         service_name: str,
-        query_parameters: Optional[dict[str, str]] = None,
-        optional_parameters: Optional[dict[str, str]] = None,
-        health_status: Optional[str] = None,
+        query_parameters: dict[str, str] | None = None,
+        optional_parameters: dict[str, str] | None = None,
+        health_status: str | None = None,
     ) -> tuple[list[ServiceInstance], dict[str, int]]:
         if query_parameters is None:
             query_parameters = {}
@@ -632,9 +632,9 @@ class ServiceDiscoveryBackend(BaseBackend):
     def paginate(
         self,
         items: list[Any],
-        max_results: Optional[int] = None,
-        next_token: Optional[str] = None,
-    ) -> tuple[list[Any], Optional[str]]:
+        max_results: int | None = None,
+        next_token: str | None = None,
+    ) -> tuple[list[Any], str | None]:
         """
         Paginates a list of items. If called without optional parameters, the entire list is returned as-is.
         """

--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -7,7 +7,7 @@ from email.encoders import encode_7or8bit
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.utils import formataddr, getaddresses, parseaddr
-from typing import Any, Literal, Optional
+from typing import Any, Literal
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -157,13 +157,13 @@ class ConfigurationSet(BaseModel):
     def __init__(
         self,
         configuration_set_name: str,
-        tracking_options: Optional[dict[str, str]] = None,
-        delivery_options: Optional[dict[str, Any]] = None,
-        reputation_options: Optional[dict[str, Any]] = None,
-        sending_options: Optional[dict[str, bool]] = None,
-        tags: Optional[list[dict[str, str]]] = None,
-        suppression_options: Optional[dict[str, list[str]]] = None,
-        vdm_options: Optional[dict[str, dict[str, str]]] = None,
+        tracking_options: dict[str, str] | None = None,
+        delivery_options: dict[str, Any] | None = None,
+        reputation_options: dict[str, Any] | None = None,
+        sending_options: dict[str, bool] | None = None,
+        tags: list[dict[str, str]] | None = None,
+        suppression_options: dict[str, list[str]] | None = None,
+        vdm_options: dict[str, dict[str, str]] | None = None,
     ) -> None:
         # Shared between SES and SESv2
         self.configuration_set_name = configuration_set_name
@@ -274,9 +274,9 @@ class EmailIdentity(BaseModel):
     def __init__(
         self,
         email_identity: str,
-        tags: Optional[list[dict[str, str]]],
-        dkim_signing_attributes: Optional[object],
-        configuration_set_name: Optional[str],
+        tags: list[dict[str, str]] | None,
+        dkim_signing_attributes: object | None,
+        configuration_set_name: str | None,
     ) -> None:
         self.email_identity = email_identity
         self.tags = tags
@@ -411,9 +411,9 @@ class SESBackend(BaseBackend):
     def create_email_identity_v2(
         self,
         email_identity: str,
-        tags: Optional[list[dict[str, str]]],
-        dkim_signing_attributes: Optional[object],
-        configuration_set_name: Optional[str],
+        tags: list[dict[str, str]] | None,
+        dkim_signing_attributes: object | None,
+        configuration_set_name: str | None,
     ) -> EmailIdentity:
         identity = EmailIdentity(
             email_identity=email_identity,
@@ -431,7 +431,7 @@ class SESBackend(BaseBackend):
         return identity
 
     def list_identities(
-        self, identity_type: Optional[Literal["EmailAddress", "Domain"]]
+        self, identity_type: Literal["EmailAddress", "Domain"] | None
     ) -> list[str]:
         if identity_type is not None:
             return [
@@ -550,7 +550,7 @@ class SESBackend(BaseBackend):
         self.sent_message_count += recipient_count
         return message
 
-    def __type_of_message__(self, destinations: Any) -> Optional[str]:
+    def __type_of_message__(self, destinations: Any) -> str | None:
         """Checks the destination for any special address that could indicate delivery,
         complaint or bounce like in SES simulator"""
         if isinstance(destinations, list):
@@ -661,7 +661,7 @@ class SESBackend(BaseBackend):
         self.sns_topics[identity] = identity_sns_topics
 
     def set_identity_notification_topic(
-        self, identity: str, notification_type: str, sns_topic: Optional[str]
+        self, identity: str, notification_type: str, sns_topic: str | None
     ) -> None:
         identity_sns_topics = self.sns_topics.get(identity, {})
         if sns_topic is None:
@@ -853,7 +853,7 @@ class SESBackend(BaseBackend):
         self.receipt_rule_set[rule_set_name] = ReceiptRuleSet(name=rule_set_name)
 
     def create_receipt_rule(
-        self, rule_set_name: str, rule: dict[str, Any], after: Optional[str]
+        self, rule_set_name: str, rule: dict[str, Any], after: str | None
     ) -> None:
         # Validate ruleSetName
         self._validate_name_param(self.__RULE_SET_PARAM, rule_set_name)
@@ -906,8 +906,8 @@ class SESBackend(BaseBackend):
         )
 
     def set_active_receipt_rule_set(
-        self, rule_set_name: Optional[str]
-    ) -> Optional[ReceiptRuleSet]:
+        self, rule_set_name: str | None
+    ) -> ReceiptRuleSet | None:
         if not rule_set_name:
             # A null rule_set_name parameter (i.e., not passed in the request at all) means that all receipt rule sets should be marked inactive
             for rs in self.receipt_rule_set.values():
@@ -923,7 +923,7 @@ class SESBackend(BaseBackend):
         self.receipt_rule_set[rule_set_name].is_active = True
         return self.receipt_rule_set[rule_set_name]
 
-    def describe_active_receipt_rule_set(self) -> Optional[ReceiptRuleSet]:
+    def describe_active_receipt_rule_set(self) -> ReceiptRuleSet | None:
         for rs in self.receipt_rule_set.values():
             if rs.is_active:
                 return rs
@@ -1019,7 +1019,7 @@ class SESBackend(BaseBackend):
                 f"Unable to use AWS KMS key: {kms_key_arn}"
             )
 
-    def _validate_sns_topic(self, topic_arn: Optional[str]) -> None:
+    def _validate_sns_topic(self, topic_arn: str | None) -> None:
         # Nothing to validate
         if not topic_arn:
             return
@@ -1078,8 +1078,8 @@ class SESBackend(BaseBackend):
     def set_identity_mail_from_domain(
         self,
         identity: str,
-        mail_from_domain: Optional[str] = None,
-        behavior_on_mx_failure: Optional[str] = None,
+        mail_from_domain: str | None = None,
+        behavior_on_mx_failure: str | None = None,
     ) -> None:
         if not self._is_verified_address(identity):
             raise InvalidParameterValue(f"Identity '{identity}' does not exist.")
@@ -1108,7 +1108,7 @@ class SESBackend(BaseBackend):
         }
 
     def get_identity_mail_from_domain_attributes(
-        self, identities: Optional[list[str]] = None
+        self, identities: list[str] | None = None
     ) -> dict[str, dict[str, str]]:
         if identities is None:
             actual_identities = []
@@ -1132,7 +1132,7 @@ class SESBackend(BaseBackend):
         return attributes_by_identity
 
     def get_identity_verification_attributes(
-        self, identities: Optional[list[str]] = None
+        self, identities: list[str] | None = None
     ) -> dict[str, dict[str, str]]:
         if identities is None:
             actual_identities = []

--- a/moto/ses/responses.py
+++ b/moto/ses/responses.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult, PaginatedResult
 from moto.core.utils import utcnow
@@ -151,7 +151,7 @@ class EmailResponse(BaseResponse):
 
         attribute_names = self._get_param("ConfigurationSetAttributeNames", [])
 
-        event_destination: Optional[dict[str, Any]] = None
+        event_destination: dict[str, Any] | None = None
         if "eventDestinations" in attribute_names:
             event_destination = self.backend.config_set_event_destination.get(
                 configuration_set_name

--- a/moto/ses/template.py
+++ b/moto/ses/template.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.utilities.tokenizer import GenericTokenizer
 
@@ -163,7 +163,7 @@ def get_processor(tokenizer: GenericTokenizer) -> type[BlockProcessor]:
 def parse_template(
     template: str,
     template_data: dict[str, Any],
-    tokenizer: Optional[GenericTokenizer] = None,
+    tokenizer: GenericTokenizer | None = None,
 ) -> str:
     tokenizer = tokenizer or GenericTokenizer(template)
 

--- a/moto/ses/utils.py
+++ b/moto/ses/utils.py
@@ -1,11 +1,11 @@
 import string
 from email.utils import parseaddr
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 from moto.moto_api._internal import mock_random as random
 
 if TYPE_CHECKING:
-    from sesv2.models import SESV2Backend
+    from moto.sesv2.models import SESV2Backend
 
     from .models import SESBackend
 
@@ -18,7 +18,7 @@ def get_random_message_id() -> str:
     return f"{random_hex(16)}-{random_hex(8)}-{random_hex(4)}-{random_hex(4)}-{random_hex(4)}-{random_hex(12)}-{random_hex(6)}"
 
 
-def is_valid_address(addr: str) -> Optional[str]:
+def is_valid_address(addr: str) -> str | None:
     _, address = parseaddr(addr)
     address_parts = address.split("@")
     if len(address_parts) != 2 or not address_parts[1]:

--- a/moto/sesv2/models.py
+++ b/moto/sesv2/models.py
@@ -1,6 +1,6 @@
 """SESV2Backend class with methods for supported APIs."""
 
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.utilities.paginator import paginate
@@ -124,9 +124,9 @@ class SESV2Backend(BaseBackend):
     def create_email_identity(
         self,
         email_identity: str,
-        tags: Optional[list[dict[str, str]]],
-        dkim_signing_attributes: Optional[object],
-        configuration_set_name: Optional[str],
+        tags: list[dict[str, str]] | None,
+        dkim_signing_attributes: object | None,
+        configuration_set_name: str | None,
     ) -> EmailIdentity:
         if tags:
             self.core_backend.tagger.tag_resource(

--- a/moto/settings.py
+++ b/moto/settings.py
@@ -2,7 +2,6 @@ import json
 import os
 import pathlib
 from functools import lru_cache
-from typing import Optional
 
 from moto.core.config import default_user_config
 
@@ -130,11 +129,11 @@ def moto_lambda_image() -> str:
     return os.environ.get("MOTO_DOCKER_LAMBDA_IMAGE", "mlupin/docker-lambda")
 
 
-def moto_network_name() -> Optional[str]:
+def moto_network_name() -> str | None:
     return os.environ.get("MOTO_DOCKER_NETWORK_NAME")
 
 
-def moto_network_mode() -> Optional[str]:
+def moto_network_mode() -> str | None:
     return os.environ.get("MOTO_DOCKER_NETWORK_MODE")
 
 
@@ -182,11 +181,11 @@ def get_docker_host() -> str:
         return "http://host.docker.internal"
 
 
-def get_cognito_idp_user_pool_id_strategy() -> Optional[str]:
+def get_cognito_idp_user_pool_id_strategy() -> str | None:
     return os.environ.get("MOTO_COGNITO_IDP_USER_POOL_ID_STRATEGY")
 
 
-def get_cognito_idp_user_pool_client_id_strategy() -> Optional[str]:
+def get_cognito_idp_user_pool_client_id_strategy() -> str | None:
     return os.environ.get("MOTO_COGNITO_IDP_USER_POOL_CLIENT_ID_STRATEGY")
 
 

--- a/moto/shield/models.py
+++ b/moto/shield/models.py
@@ -4,7 +4,7 @@ import random
 import string
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -189,7 +189,7 @@ class ShieldBackend(BaseBackend):
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.protections: dict[str, Protection] = {}
-        self.subscription: Optional[Subscription] = None
+        self.subscription: Subscription | None = None
         self.tagger = TaggingService()
 
     def validate_resource_arn(self, resource_arn: str) -> None:

--- a/moto/signer/models.py
+++ b/moto/signer/models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -14,7 +14,7 @@ class SigningProfile(BaseModel):
         name: str,
         platform_id: str,
         signing_material: dict[str, str],
-        signature_validity_period: Optional[dict[str, Any]],
+        signature_validity_period: dict[str, Any] | None,
     ):
         self.name = name
         self.platform_id = platform_id
@@ -175,7 +175,7 @@ class SignerBackend(BaseBackend):
     def put_signing_profile(
         self,
         profile_name: str,
-        signature_validity_period: Optional[dict[str, Any]],
+        signature_validity_period: dict[str, Any] | None,
         platform_id: str,
         signing_material: dict[str, str],
         tags: dict[str, str],

--- a/moto/sns/config.py
+++ b/moto/sns/config.py
@@ -1,7 +1,7 @@
 """AWS Config integration for SNS resources."""
 
 import json
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import ConfigQueryModel
 from moto.sns import sns_backends
@@ -15,14 +15,14 @@ class SNSConfigQuery(ConfigQueryModel[SNSBackend]):
         self,
         account_id: str,
         partition: str,
-        resource_ids: Optional[list[str]],
-        resource_name: Optional[str],
+        resource_ids: list[str] | None,
+        resource_name: str | None,
         limit: int,
-        next_token: Optional[str],
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-        aggregator: Optional[dict[str, Any]] = None,
-    ) -> tuple[list[dict[str, Any]], Optional[str]]:
+        next_token: str | None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+        aggregator: dict[str, Any] | None = None,
+    ) -> tuple[list[dict[str, Any]], str | None]:
         region = resource_region or backend_region or "us-east-1"
         backend = self.backends[account_id][region]
 
@@ -40,10 +40,10 @@ class SNSConfigQuery(ConfigQueryModel[SNSBackend]):
         account_id: str,
         partition: str,
         resource_id: str,
-        resource_name: Optional[str] = None,
-        backend_region: Optional[str] = None,
-        resource_region: Optional[str] = None,
-    ) -> Optional[dict[str, Any]]:
+        resource_name: str | None = None,
+        backend_region: str | None = None,
+        resource_region: str | None = None,
+    ) -> dict[str, Any] | None:
         region = resource_region or backend_region or "us-east-1"
         backend = self.backends[account_id][region]
 

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 from datetime import timedelta
 from functools import lru_cache
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 import cryptography
 import requests
@@ -88,7 +88,7 @@ class Topic(CloudFormationModel):
         self.subscriptions_confimed = 0
         self.subscriptions_deleted = 0
         self.sent_notifications: list[
-            tuple[str, str, Optional[str], Optional[dict[str, Any]], Optional[str]]
+            tuple[str, str, str | None, dict[str, Any] | None, str | None]
         ] = []
 
         self._policy_json = self._create_default_topic_policy(
@@ -101,11 +101,11 @@ class Topic(CloudFormationModel):
     def publish(
         self,
         message: str,
-        subject: Optional[str] = None,
-        message_attributes: Optional[dict[str, Any]] = None,
-        group_id: Optional[str] = None,
-        deduplication_id: Optional[str] = None,
-        message_structure: Optional[str] = None,
+        subject: str | None = None,
+        message_attributes: dict[str, Any] | None = None,
+        group_id: str | None = None,
+        deduplication_id: str | None = None,
+        message_structure: str | None = None,
     ) -> str:
         message_id = str(mock_random.uuid4())
         subscriptions, _ = self.sns_backend.list_subscriptions_by_topic(
@@ -234,7 +234,7 @@ class Subscription(BaseModel):
         self.arn = make_arn_for_subscription(self.topic.arn)
         self.attributes: dict[str, Any] = {}
         self._filter_policy = None  # filter policy as a dict, not json.
-        self._filter_policy_matcher: Optional[FilterPolicyMatcher] = None
+        self._filter_policy_matcher: FilterPolicyMatcher | None = None
         self.confirmed = False
 
     @property
@@ -245,11 +245,11 @@ class Subscription(BaseModel):
         self,
         message: str,
         message_id: str,
-        subject: Optional[str] = None,
-        message_attributes: Optional[dict[str, Any]] = None,
-        group_id: Optional[str] = None,
-        deduplication_id: Optional[str] = None,
-        message_structure: Optional[str] = None,
+        subject: str | None = None,
+        message_attributes: dict[str, Any] | None = None,
+        group_id: str | None = None,
+        deduplication_id: str | None = None,
+        message_structure: str | None = None,
     ) -> None:
         if self._filter_policy_matcher is not None:
             if not self._filter_policy_matcher.matches(message_attributes, message):
@@ -338,8 +338,8 @@ class Subscription(BaseModel):
         self,
         message: str,
         message_id: str,
-        subject: Optional[str],
-        message_attributes: Optional[dict[str, Any]] = None,
+        subject: str | None,
+        message_attributes: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         key = self.private_key()
         cert_subject = [NameAttribute(NameOID.COMMON_NAME, "sns.amazonaws.com")]
@@ -547,8 +547,8 @@ class SNSBackend(BaseBackend):
     def create_topic(
         self,
         name: str,
-        attributes: Optional[dict[str, str]] = None,
-        tags: Optional[dict[str, str]] = None,
+        attributes: dict[str, str] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> Topic:
         if attributes is None:
             attributes = {}
@@ -580,8 +580,8 @@ class SNSBackend(BaseBackend):
             return candidate_topic
 
     def _get_values_nexttoken(
-        self, values_map: dict[str, Any], next_token: Optional[str] = None
-    ) -> tuple[list[Any], Optional[int]]:
+        self, values_map: dict[str, Any], next_token: str | None = None
+    ) -> tuple[list[Any], int | None]:
         i_next_token = int(next_token or "0")
         values = list(values_map.values())[
             i_next_token : i_next_token + DEFAULT_PAGE_SIZE
@@ -596,8 +596,8 @@ class SNSBackend(BaseBackend):
         return [sub for sub in self.subscriptions.values() if sub.topic == topic]
 
     def list_topics(
-        self, next_token: Optional[str] = None
-    ) -> tuple[list[Topic], Optional[int]]:
+        self, next_token: str | None = None
+    ) -> tuple[list[Topic], int | None]:
         return self._get_values_nexttoken(self.topics, next_token)
 
     def delete_topic_subscriptions(self, topic: Topic) -> None:
@@ -693,7 +693,7 @@ class SNSBackend(BaseBackend):
 
     def _find_subscription(
         self, topic_arn: str, endpoint: str, protocol: str
-    ) -> Optional[Subscription]:
+    ) -> Subscription | None:
         for subscription in self.subscriptions.values():
             if (
                 subscription.topic.arn == topic_arn
@@ -707,13 +707,13 @@ class SNSBackend(BaseBackend):
         self.subscriptions.pop(subscription_arn, None)
 
     def list_subscriptions(
-        self, next_token: Optional[str] = None
-    ) -> tuple[list[Subscription], Optional[int]]:
+        self, next_token: str | None = None
+    ) -> tuple[list[Subscription], int | None]:
         return self._get_values_nexttoken(self.subscriptions, next_token)
 
     def list_subscriptions_by_topic(
-        self, topic_arn: str, next_token: Optional[str] = None
-    ) -> tuple[list[Subscription], Optional[int]]:
+        self, topic_arn: str, next_token: str | None = None
+    ) -> tuple[list[Subscription], int | None]:
         topic = self.get_topic(topic_arn)
         filtered = OrderedDict(
             [(sub.arn, sub) for sub in self._get_topic_subscriptions(topic)]
@@ -723,13 +723,13 @@ class SNSBackend(BaseBackend):
     def publish(
         self,
         message: str,
-        arn: Optional[str],
-        phone_number: Optional[str] = None,
-        subject: Optional[str] = None,
-        message_attributes: Optional[dict[str, Any]] = None,
-        group_id: Optional[str] = None,
-        deduplication_id: Optional[str] = None,
-        message_structure: Optional[str] = None,
+        arn: str | None,
+        phone_number: str | None = None,
+        subject: str | None = None,
+        message_attributes: dict[str, Any] | None = None,
+        group_id: str | None = None,
+        deduplication_id: str | None = None,
+        message_structure: str | None = None,
     ) -> str:
         if subject is not None and len(subject) > 100:
             # Note that the AWS docs around length are wrong: https://github.com/getmoto/moto/issues/1503
@@ -927,7 +927,7 @@ class SNSBackend(BaseBackend):
 
         subscription.attributes[name] = value
 
-    def _validate_filter_policy(self, value: Any, scope: Optional[str]) -> None:
+    def _validate_filter_policy(self, value: Any, scope: str | None) -> None:
         combinations = 1
 
         def aggregate_rules(
@@ -1244,8 +1244,8 @@ class SNSBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore[misc]
     def list_config_service_resources(  # type: ignore[misc]
         self,
-        resource_ids: Optional[list[str]] = None,
-        resource_name: Optional[str] = None,
+        resource_ids: list[str] | None = None,
+        resource_name: str | None = None,
     ) -> list[dict[str, Any]]:
         """List SNS topics for AWS Config."""
         topics = list(self.topics.values())
@@ -1269,7 +1269,7 @@ class SNSBackend(BaseBackend):
 
         return config_resources
 
-    def get_config_resource(self, resource_id: str) -> Optional[dict[str, Any]]:
+    def get_config_resource(self, resource_id: str) -> dict[str, Any] | None:
         """Get a specific SNS topic configuration for AWS Config."""
         if resource_id not in self.topics:
             return None

--- a/moto/sns/utils.py
+++ b/moto/sns/utils.py
@@ -1,7 +1,7 @@
 import json
 import re
 from collections.abc import Callable, Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 from moto.moto_api._internal import mock_random
 from moto.utilities.utils import get_partition
@@ -26,9 +26,7 @@ class FilterPolicyMatcher:
     class CheckException(Exception):
         pass
 
-    def __init__(
-        self, filter_policy: dict[str, Any], filter_policy_scope: Optional[str]
-    ):
+    def __init__(self, filter_policy: dict[str, Any], filter_policy_scope: str | None):
         self.filter_policy = filter_policy
         self.filter_policy_scope = (
             filter_policy_scope
@@ -41,9 +39,7 @@ class FilterPolicyMatcher:
                 f"Unsupported filter_policy_scope: {filter_policy_scope}"
             )
 
-    def matches(
-        self, message_attributes: Optional[dict[str, Any]], message: str
-    ) -> bool:
+    def matches(self, message_attributes: dict[str, Any] | None, message: str) -> bool:
         if not self.filter_policy:
             return True
 
@@ -97,8 +93,8 @@ class FilterPolicyMatcher:
 
     def _compute_body_checks(
         self,
-        filter_policy: dict[str, Union[dict[str, Any], list[Any]]],
-        message_body: Union[dict[str, Any], list[Any]],
+        filter_policy: dict[str, dict[str, Any] | list[Any]],
+        message_body: dict[str, Any] | list[Any],
     ) -> tuple[Callable[[Iterable[Any]], bool], Any]:
         """
         Generate (possibly nested) list of checks to be performed based on the filter policy
@@ -188,7 +184,7 @@ class FilterPolicyMatcher:
         # Iterate over every rule from the list of rules
         # At least one rule has to match the field for the function to return a match
 
-        def _str_exact_match(value: str, rule: Union[str, list[str]]) -> bool:
+        def _str_exact_match(value: str, rule: str | list[str]) -> bool:
             if value == rule:
                 return True
 
@@ -231,7 +227,7 @@ class FilterPolicyMatcher:
             return value.endswith(prefix)
 
         def _anything_but_match(
-            filter_value: Union[dict[str, Any], list[str], str],
+            filter_value: dict[str, Any] | list[str] | str,
             actual_values: list[str],
         ) -> bool:
             if isinstance(filter_value, dict):

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -5,7 +5,7 @@ import string
 import struct
 from copy import deepcopy
 from threading import Condition
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 from urllib.parse import ParseResult
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -73,20 +73,20 @@ class Message(BaseModel):
         self,
         message_id: str,
         body: str,
-        system_attributes: Optional[dict[str, Any]] = None,
+        system_attributes: dict[str, Any] | None = None,
     ):
         self.id = message_id
         self.body = body
         self.message_attributes: dict[str, Any] = {}
-        self.receipt_handle: Optional[str] = None
+        self.receipt_handle: str | None = None
         self._old_receipt_handles: list[str] = []
         self.sender_id = DEFAULT_SENDER_ID
         self.sent_timestamp = None
-        self.approximate_first_receive_timestamp: Optional[int] = None
+        self.approximate_first_receive_timestamp: int | None = None
         self.approximate_receive_count = 0
-        self.deduplication_id: Optional[str] = None
-        self.group_id: Optional[str] = None
-        self.sequence_number: Optional[str] = None
+        self.deduplication_id: str | None = None
+        self.group_id: str | None = None
+        self.sequence_number: str | None = None
         self.visible_at = 0.0
         self.delayed_until = 0.0
         self.system_attributes = system_attributes or {}
@@ -142,12 +142,12 @@ class Message(BaseModel):
             return value.encode("utf-8")
         return value
 
-    def mark_sent(self, delay_seconds: Optional[int] = None) -> None:
+    def mark_sent(self, delay_seconds: int | None = None) -> None:
         self.sent_timestamp = int(unix_time_millis())  # type: ignore
         if delay_seconds:
             self.delay(delay_seconds=delay_seconds)
 
-    def mark_received(self, visibility_timeout: Optional[int] = None) -> None:
+    def mark_received(self, visibility_timeout: int | None = None) -> None:
         """
         When a message is received we will set the first receive timestamp,
         tap the ``approximate_receive_count`` and the ``visible_at`` time.
@@ -194,7 +194,7 @@ class Message(BaseModel):
         return False
 
     @property
-    def all_receipt_handles(self) -> list[Optional[str]]:
+    def all_receipt_handles(self) -> list[str | None]:
         return [self.receipt_handle] + self._old_receipt_handles  # type: ignore
 
     def had_receipt_handle(self, receipt_handle: str) -> bool:
@@ -255,7 +255,7 @@ class Queue(CloudFormationModel):
         now = unix_time()
         self.created_timestamp = now
         self.queue_arn = f"arn:{get_partition(region)}:sqs:{region}:{account_id}:{name}"
-        self.dead_letter_queue: Optional[Queue] = None
+        self.dead_letter_queue: Queue | None = None
         self.fifo_queue = False
 
         self.lambda_event_source_mappings: dict[str, EventSourceMapping] = {}
@@ -319,7 +319,7 @@ class Queue(CloudFormationModel):
         }
 
     def _set_attributes(
-        self, attributes: dict[str, Any], now: Optional[float] = None
+        self, attributes: dict[str, Any], now: float | None = None
     ) -> None:
         if not now:
             now = unix_time()
@@ -690,7 +690,7 @@ class SQSBackend(BaseBackend):
         self.queues: dict[str, Queue] = {}
 
     def create_queue(
-        self, name: str, tags: Optional[dict[str, str]] = None, **kwargs: Any
+        self, name: str, tags: dict[str, str] | None = None, **kwargs: Any
     ) -> Queue:
         queue = self.queues.get(name)
         if queue:
@@ -794,8 +794,8 @@ class SQSBackend(BaseBackend):
         queue: Queue,
         message_body: str,
         delay_seconds: int,
-        deduplication_id: Optional[str] = None,
-        group_id: Optional[str] = None,
+        deduplication_id: str | None = None,
+        group_id: str | None = None,
         validate_group_id: bool = True,
     ) -> None:
         if queue.fifo_queue:
@@ -836,11 +836,11 @@ class SQSBackend(BaseBackend):
         self,
         queue_name: str,
         message_body: str,
-        message_attributes: Optional[dict[str, Any]] = None,
-        delay_seconds: Optional[int] = None,
-        deduplication_id: Optional[str] = None,
-        group_id: Optional[str] = None,
-        system_attributes: Optional[dict[str, Any]] = None,
+        message_attributes: dict[str, Any] | None = None,
+        delay_seconds: int | None = None,
+        deduplication_id: str | None = None,
+        group_id: str | None = None,
+        system_attributes: dict[str, Any] | None = None,
         validate_group_id: bool = True,
     ) -> Message:
         queue = self.get_queue(queue_name)
@@ -952,7 +952,7 @@ class SQSBackend(BaseBackend):
 
         return messages, failedInvalidDelay
 
-    def _get_first_duplicate_id(self, ids: list[str]) -> Optional[str]:
+    def _get_first_duplicate_id(self, ids: list[str]) -> str | None:
         unique_ids = set()
         for _id in ids:
             if _id in unique_ids:
@@ -966,7 +966,7 @@ class SQSBackend(BaseBackend):
         count: int,
         wait_seconds_timeout: int,
         visibility_timeout: int,
-        message_attribute_names: Optional[list[str]] = None,
+        message_attribute_names: list[str] | None = None,
     ) -> list[Message]:
         # Attempt to retrieve visible messages from a queue.
 

--- a/moto/sqs/responses.py
+++ b/moto/sqs/responses.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Optional
+from typing import Any
 from urllib.parse import urlparse
 
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
@@ -51,7 +51,7 @@ class SQSResponse(BaseResponse):
         # Fallback to reading from the URL for botocore
         return self.path.split("/")[-1]
 
-    def _get_validated_visibility_timeout(self, timeout: Optional[str] = None) -> int:
+    def _get_validated_visibility_timeout(self, timeout: str | None = None) -> int:
         """
         :raises ValueError: If specified visibility timeout exceeds MAXIMUM_VISIBILITY_TIMEOUT
         :raises TypeError: If visibility timeout was not specified

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import hashlib
 import json
@@ -5,7 +7,7 @@ import re
 from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 from uuid import uuid4
 
 import yaml
@@ -134,7 +136,7 @@ class ParameterDict(defaultdict[str, list["Parameter"]]):
                 )
             )
 
-    def _get_secretsmanager_parameter(self, secret_name: str) -> list["Parameter"]:
+    def _get_secretsmanager_parameter(self, secret_name: str) -> list[Parameter]:
         secrets_backend = secretsmanager_backends[self.account_id][self.region_name]
         secret = secrets_backend.describe_secret(secret_name).to_dict()
         version_id_to_stage = secret["VersionIdsToStages"]
@@ -168,7 +170,7 @@ class ParameterDict(defaultdict[str, list["Parameter"]]):
             for val in values
         ]
 
-    def __getitem__(self, item: str) -> list["Parameter"]:
+    def __getitem__(self, item: str) -> list[Parameter]:
         if item.startswith("/aws/reference/secretsmanager/"):
             return self._get_secretsmanager_parameter("/".join(item.split("/")[4:]))
         self._check_loading_status(item)
@@ -218,16 +220,16 @@ class Parameter(CloudFormationModel):
         name: str,
         value: str,
         parameter_type: str,
-        description: Optional[str],
-        allowed_pattern: Optional[str],
-        keyid: Optional[str],
+        description: str | None,
+        allowed_pattern: str | None,
+        keyid: str | None,
         last_modified_date: datetime.datetime,
         version: int,
         data_type: str,
-        labels: Optional[list[str]] = None,
-        source_result: Optional[str] = None,
-        tier: Optional[str] = None,
-        policies: Optional[str] = None,
+        labels: list[str] | None = None,
+        source_result: str | None = None,
+        tier: str | None = None,
+        policies: str | None = None,
     ):
         self.account_id = account_id
         self.name = name
@@ -254,7 +256,7 @@ class Parameter(CloudFormationModel):
     def encrypt(self, value: str) -> str:
         return f"kms:{self.keyid}:" + value
 
-    def decrypt(self, value: str) -> Optional[str]:
+    def decrypt(self, value: str) -> str | None:
         if self.parameter_type != "SecureString":
             return value
 
@@ -264,7 +266,7 @@ class Parameter(CloudFormationModel):
         return None
 
     def response_object(
-        self, decrypt: bool = False, region: Optional[str] = None
+        self, decrypt: bool = False, region: str | None = None
     ) -> dict[str, Any]:
         r: dict[str, Any] = {
             "Name": self.name,
@@ -330,7 +332,7 @@ class Parameter(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "Parameter":
+    ) -> Parameter:
         ssm_backend = ssm_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
 
@@ -357,7 +359,7 @@ class Parameter(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "Parameter":
+    ) -> Parameter:
         cls.delete_from_cloudformation_json(
             original_resource.name, cloudformation_json, account_id, region_name
         )
@@ -391,7 +393,7 @@ MAX_TIMEOUT_SECONDS = 3600
 
 def generate_ssm_doc_param_list(
     parameters: dict[str, Any],
-) -> Optional[list[dict[str, Any]]]:
+) -> list[dict[str, Any]] | None:
     if not parameters:
         return None
     param_list = []
@@ -427,7 +429,7 @@ class AccountPermission:
 
 
 class Documents(BaseModel):
-    def __init__(self, ssm_document: "Document"):
+    def __init__(self, ssm_document: Document):
         version = ssm_document.document_version
         self.versions = {version: ssm_document}
         self.default_version = version
@@ -436,13 +438,13 @@ class Documents(BaseModel):
             str, AccountPermission
         ] = {}  # {AccountID: AccountPermission }
 
-    def get_default_version(self) -> "Document":
+    def get_default_version(self) -> Document:
         return self.versions[self.default_version]
 
-    def get_latest_version(self) -> "Document":
+    def get_latest_version(self) -> Document:
         return self.versions[self.latest_version]
 
-    def find_by_version_name(self, version_name: str) -> Optional["Document"]:
+    def find_by_version_name(self, version_name: str) -> Document | None:
         return next(
             (
                 document
@@ -452,12 +454,12 @@ class Documents(BaseModel):
             None,
         )
 
-    def find_by_version(self, version: str) -> Optional["Document"]:
+    def find_by_version(self, version: str) -> Document | None:
         return self.versions.get(version)
 
     def find_by_version_and_version_name(
         self, version: str, version_name: str
-    ) -> Optional["Document"]:
+    ) -> Document | None:
         return next(
             (
                 document
@@ -469,12 +471,12 @@ class Documents(BaseModel):
 
     def find(
         self,
-        document_version: Optional[str] = None,
-        version_name: Optional[str] = None,
+        document_version: str | None = None,
+        version_name: str | None = None,
         strict: bool = True,
-    ) -> "Document":
+    ) -> Document:
         if document_version == "$LATEST":
-            ssm_document: Optional[Document] = self.get_latest_version()
+            ssm_document: Document | None = self.get_latest_version()
         elif version_name and document_version:
             ssm_document = self.find_by_version_and_version_name(
                 document_version, version_name
@@ -492,16 +494,16 @@ class Documents(BaseModel):
         return ssm_document  # type: ignore
 
     def exists(
-        self, document_version: Optional[str] = None, version_name: Optional[str] = None
+        self, document_version: str | None = None, version_name: str | None = None
     ) -> bool:
         return self.find(document_version, version_name, strict=False) is not None
 
-    def add_new_version(self, new_document_version: "Document") -> None:
+    def add_new_version(self, new_document_version: Document) -> None:
         version = new_document_version.document_version
         self.latest_version = version
         self.versions[version] = new_document_version
 
-    def update_default_version(self, version: str) -> "Document":
+    def update_default_version(self, version: str) -> Document:
         ssm_document = self.find_by_version(version)
         if not ssm_document:
             raise InvalidDocument("The specified document does not exist.")
@@ -520,9 +522,9 @@ class Documents(BaseModel):
 
     def describe(
         self,
-        document_version: Optional[str] = None,
-        version_name: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        document_version: str | None = None,
+        version_name: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         document = self.find(document_version, version_name)
         base: dict[str, Any] = {
@@ -664,9 +666,7 @@ class Document(CloudFormationModel):
     def hash(self) -> str:
         return hashlib.sha256(self.content.encode("utf-8")).hexdigest()
 
-    def list_describe(
-        self, tags: Optional[list[dict[str, str]]] = None
-    ) -> dict[str, Any]:
+    def list_describe(self, tags: list[dict[str, str]] | None = None) -> dict[str, Any]:
         base: dict[str, Any] = {
             "Name": self.name,
             "Owner": self.owner,
@@ -700,7 +700,7 @@ class Document(CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "Document":
+    ) -> Document:
         ssm_backend: SimpleSystemManagerBackend = ssm_backends[account_id][region_name]
         properties = cloudformation_json["Properties"]
 
@@ -725,7 +725,7 @@ class Document(CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "Document":
+    ) -> Document:
         cls.delete_from_cloudformation_json(
             original_resource.name, cloudformation_json, account_id, region_name
         )
@@ -763,18 +763,18 @@ class Command(BaseModel):
         self,
         account_id: str,
         comment: str = "",
-        document_name: Optional[str] = "",
-        timeout_seconds: Optional[int] = MAX_TIMEOUT_SECONDS,
-        instance_ids: Optional[list[str]] = None,
+        document_name: str | None = "",
+        timeout_seconds: int | None = MAX_TIMEOUT_SECONDS,
+        instance_ids: list[str] | None = None,
         max_concurrency: str = "",
         max_errors: str = "",
-        notification_config: Optional[dict[str, Any]] = None,
+        notification_config: dict[str, Any] | None = None,
         output_s3_bucket_name: str = "",
         output_s3_key_prefix: str = "",
         output_s3_region: str = "",
-        parameters: Optional[dict[str, list[str]]] = None,
+        parameters: dict[str, list[str]] | None = None,
         service_role_arn: str = "",
-        targets: Optional[list[dict[str, Any]]] = None,
+        targets: list[dict[str, Any]] | None = None,
         backend_region: str = "us-east-1",
     ):
         if instance_ids is None:
@@ -897,7 +897,7 @@ class Command(BaseModel):
         }
 
     def get_invocation(
-        self, instance_id: str, plugin_name: Optional[str]
+        self, instance_id: str, plugin_name: str | None
     ) -> dict[str, Any]:
         invocation = next(
             (
@@ -932,7 +932,7 @@ def _validate_document_format(document_format: str) -> None:
 def _validate_document_info(
     content: str,
     name: str,
-    document_type: Optional[str],
+    document_type: str | None,
     document_format: str,
     strict: bool = True,
 ) -> None:
@@ -1044,9 +1044,9 @@ class FakeMaintenanceWindowTarget:
         window_id: str,
         resource_type: str,
         targets: list[dict[str, Any]],
-        owner_information: Optional[str],
-        name: Optional[str],
-        description: Optional[str],
+        owner_information: str | None,
+        name: str | None,
+        description: str | None,
     ):
         self.window_id = window_id
         self.window_target_id = self.generate_id()
@@ -1076,20 +1076,20 @@ class FakeMaintenanceWindowTask:
     def __init__(
         self,
         window_id: str,
-        targets: Optional[list[dict[str, Any]]],
+        targets: list[dict[str, Any]] | None,
         task_arn: str,
-        service_role_arn: Optional[str],
+        service_role_arn: str | None,
         task_type: str,
-        task_parameters: Optional[dict[str, Any]],
-        task_invocation_parameters: Optional[dict[str, Any]],
-        priority: Optional[int],
-        max_concurrency: Optional[str],
-        max_errors: Optional[str],
-        logging_info: Optional[dict[str, Any]],
-        name: Optional[str],
-        description: Optional[str],
-        cutoff_behavior: Optional[str],
-        alarm_configurations: Optional[dict[str, Any]],
+        task_parameters: dict[str, Any] | None,
+        task_invocation_parameters: dict[str, Any] | None,
+        priority: int | None,
+        max_concurrency: str | None,
+        max_errors: str | None,
+        logging_info: dict[str, Any] | None,
+        name: str | None,
+        description: str | None,
+        cutoff_behavior: str | None,
+        alarm_configurations: dict[str, Any] | None,
     ):
         self.window_task_id = FakeMaintenanceWindowTask.generate_id()
         self.window_id = window_id
@@ -1132,7 +1132,7 @@ class FakeMaintenanceWindowTask:
 
 
 def _maintenance_window_target_filter_match(
-    filters: Optional[list[dict[str, Any]]], target: FakeMaintenanceWindowTarget
+    filters: list[dict[str, Any]] | None, target: FakeMaintenanceWindowTarget
 ) -> bool:
     if not filters and target:
         return True
@@ -1140,7 +1140,7 @@ def _maintenance_window_target_filter_match(
 
 
 def _maintenance_window_task_filter_match(
-    filters: Optional[list[dict[str, Any]]], task: FakeMaintenanceWindowTask
+    filters: list[dict[str, Any]] | None, task: FakeMaintenanceWindowTask
 ) -> bool:
     if not filters and task:
         return True
@@ -1199,15 +1199,15 @@ class FakePatchBaseline:
         self,
         name: str,
         operating_system: str,
-        global_filters: Optional[dict[str, Any]],
-        approval_rules: Optional[dict[str, Any]],
-        approved_patches: Optional[list[str]],
-        approved_patches_compliance_level: Optional[str],
-        approved_patches_enable_non_security: Optional[bool],
-        rejected_patches: Optional[list[str]],
-        rejected_patches_action: Optional[str],
-        description: Optional[str],
-        sources: Optional[list[dict[str, Any]]],
+        global_filters: dict[str, Any] | None,
+        approval_rules: dict[str, Any] | None,
+        approved_patches: list[str] | None,
+        approved_patches_compliance_level: str | None,
+        approved_patches_enable_non_security: bool | None,
+        rejected_patches: list[str] | None,
+        rejected_patches_action: str | None,
+        description: str | None,
+        sources: list[dict[str, Any]] | None,
     ):
         self.id = FakePatchBaseline.generate_id()
         self.operating_system = operating_system
@@ -1704,7 +1704,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         return result
 
     def _validate_parameter_filters(
-        self, parameter_filters: Optional[list[dict[str, Any]]], by_path: bool
+        self, parameter_filters: list[dict[str, Any]] | None, by_path: bool
     ) -> None:
         for index, filter_obj in enumerate(parameter_filters or []):
             key = filter_obj["Key"]
@@ -1890,10 +1890,10 @@ class SimpleSystemManagerBackend(BaseBackend):
         self,
         path: str,
         recursive: bool,
-        filters: Optional[list[dict[str, Any]]] = None,
-        next_token: Optional[str] = None,
+        filters: list[dict[str, Any]] | None = None,
+        next_token: str | None = None,
         max_results: int = 10,
-    ) -> tuple[list[Parameter], Optional[str]]:
+    ) -> tuple[list[Parameter], str | None]:
         """Implement the get-parameters-by-path-API in the backend."""
         if max_results > PARAMETER_BY_PATH_MAX_RESULTS:
             raise ValidationException(
@@ -1920,8 +1920,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         self,
         values_list: list[Parameter],
         max_results: int,
-        token: Optional[str] = None,
-    ) -> tuple[list[Parameter], Optional[str]]:
+        token: str | None = None,
+    ) -> tuple[list[Parameter], str | None]:
         next_token = int(token or "0")
         max_results = int(max_results)
         values = values_list[next_token : next_token + max_results]
@@ -1931,8 +1931,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         )
 
     def get_parameter_history(
-        self, name: str, next_token: Optional[str], max_results: int = 50
-    ) -> tuple[Optional[list[Parameter]], Optional[str]]:
+        self, name: str, next_token: str | None, max_results: int = 50
+    ) -> tuple[list[Parameter] | None, str | None]:
         if max_results > PARAMETER_HISTORY_MAX_RESULTS:
             raise ValidationException(
                 "1 validation error detected: "
@@ -1947,8 +1947,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         return None, None
 
     def _get_history_nexttoken(
-        self, history: list[Parameter], token: Optional[str], max_results: int
-    ) -> tuple[list[Parameter], Optional[str]]:
+        self, history: list[Parameter], token: str | None, max_results: int
+    ) -> tuple[list[Parameter], str | None]:
         next_token = int(token or "0")
         max_results = int(max_results)
         history_to_return = history[next_token : next_token + max_results]
@@ -1961,7 +1961,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         return history_to_return, None
 
     def _match_filters(
-        self, parameter: Parameter, filters: Optional[list[dict[str, Any]]] = None
+        self, parameter: Parameter, filters: list[dict[str, Any]] | None = None
     ) -> bool:
         """Return True if the given parameter matches all the filters"""
         parameter_tags = self.list_tags_for_resource("Parameter", parameter.name)
@@ -2043,7 +2043,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         # True if no false match (or no filters at all)
         return True
 
-    def get_parameter(self, name: str) -> Optional[Parameter]:
+    def get_parameter(self, name: str) -> Parameter | None:
         if name.startswith(self.ssm_prefix):
             name = name.replace(self.ssm_prefix, "")
 
@@ -2122,7 +2122,6 @@ class SimpleSystemManagerBackend(BaseBackend):
                     "Member must satisfy constraint: "
                     "[Member must have length less than or equal to 100, Member must have length greater than or equal to 1]"
                 )
-                continue
             if label not in found_parameter.labels:
                 labels_to_append.append(label)
         if (len(found_parameter.labels) + len(labels_to_append)) > 10:
@@ -2137,7 +2136,7 @@ class SimpleSystemManagerBackend(BaseBackend):
                 for label in parameter.labels[:]:
                     if label in labels_needing_removal:
                         parameter.labels.remove(label)
-        return (invalid_labels, version)
+        return invalid_labels, version
 
     def unlabel_parameter_version(
         self, name: str, version: int, labels: list[str]
@@ -2200,8 +2199,8 @@ class SimpleSystemManagerBackend(BaseBackend):
         overwrite: bool,
         tags: list[dict[str, str]],
         data_type: str,
-        tier: Optional[str],
-        policies: Optional[str],
+        tier: str | None,
+        policies: str | None,
     ) -> Parameter:
         if not value:
             raise ValidationException(
@@ -2370,12 +2369,12 @@ class SimpleSystemManagerBackend(BaseBackend):
     def send_command(
         self,
         comment: str,
-        document_name: Optional[str],
+        document_name: str | None,
         timeout_seconds: int,
         instance_ids: list[str],
         max_concurrency: str,
         max_errors: str,
-        notification_config: Optional[dict[str, Any]],
+        notification_config: dict[str, Any] | None,
         output_s3_bucket_name: str,
         output_s3_key_prefix: str,
         output_s3_region: str,
@@ -2405,7 +2404,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         return command
 
     def list_commands(
-        self, command_id: Optional[str], instance_id: Optional[str]
+        self, command_id: str | None, instance_id: str | None
     ) -> list[Command]:
         """
         Pagination and the Filters-parameter is not yet implemented
@@ -2434,7 +2433,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         ]
 
     def get_command_invocation(
-        self, command_id: str, instance_id: str, plugin_name: Optional[str]
+        self, command_id: str, instance_id: str, plugin_name: str | None
     ) -> dict[str, Any]:
         command = self.get_command_by_id(command_id)
         return command.get_invocation(instance_id, plugin_name)
@@ -2450,7 +2449,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         schedule_offset: int,
         start_date: str,
         end_date: str,
-        tags: Optional[list[dict[str, str]]],
+        tags: list[dict[str, str]] | None,
     ) -> str:
         """
         Creates a maintenance window. No error handling or input validation has been implemented yet.
@@ -2483,7 +2482,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         return self.windows[window_id]
 
     def describe_maintenance_windows(
-        self, filters: Optional[list[dict[str, Any]]]
+        self, filters: list[dict[str, Any]] | None
     ) -> list[FakeMaintenanceWindow]:
         """
         Returns all windows. No pagination has been implemented yet. Only filtering for Name is supported.
@@ -2509,16 +2508,16 @@ class SimpleSystemManagerBackend(BaseBackend):
         self,
         name: str,
         operating_system: str,
-        global_filters: Optional[dict[str, Any]],
-        approval_rules: Optional[dict[str, Any]],
-        approved_patches: Optional[list[str]],
-        approved_patches_compliance_level: Optional[str],
-        approved_patches_enable_non_security: Optional[bool],
-        rejected_patches: Optional[list[str]],
-        rejected_patches_action: Optional[str],
-        description: Optional[str],
-        sources: Optional[list[dict[str, Any]]],
-        tags: Optional[list[dict[str, str]]],
+        global_filters: dict[str, Any] | None,
+        approval_rules: dict[str, Any] | None,
+        approved_patches: list[str] | None,
+        approved_patches_compliance_level: str | None,
+        approved_patches_enable_non_security: bool | None,
+        rejected_patches: list[str] | None,
+        rejected_patches_action: str | None,
+        description: str | None,
+        sources: list[dict[str, Any]] | None,
+        tags: list[dict[str, str]] | None,
     ) -> str:
         """
         Registers a patch baseline. No error handling or input validation has been implemented yet.
@@ -2545,7 +2544,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         return baseline.id
 
     def describe_patch_baselines(
-        self, filters: Optional[list[dict[str, Any]]]
+        self, filters: list[dict[str, Any]] | None
     ) -> list[FakePatchBaseline]:
         """
         Returns all baselines. No pagination has been implemented yet.
@@ -2572,9 +2571,9 @@ class SimpleSystemManagerBackend(BaseBackend):
         window_id: str,
         resource_type: str,
         targets: list[dict[str, Any]],
-        owner_information: Optional[str],
-        name: Optional[str],
-        description: Optional[str],
+        owner_information: str | None,
+        name: str | None,
+        description: str | None,
     ) -> str:
         """
         Registers a target with a maintenance window. No error handling has been implemented yet.
@@ -2602,7 +2601,7 @@ class SimpleSystemManagerBackend(BaseBackend):
         del window.targets[window_target_id]
 
     def describe_maintenance_window_targets(
-        self, window_id: str, filters: Optional[list[dict[str, Any]]]
+        self, window_id: str, filters: list[dict[str, Any]] | None
     ) -> list[FakeMaintenanceWindowTarget]:
         """
         Describes all targets for a maintenance window. No error handling has been implemented yet.
@@ -2618,20 +2617,20 @@ class SimpleSystemManagerBackend(BaseBackend):
     def register_task_with_maintenance_window(
         self,
         window_id: str,
-        targets: Optional[list[dict[str, Any]]],
+        targets: list[dict[str, Any]] | None,
         task_arn: str,
-        service_role_arn: Optional[str],
+        service_role_arn: str | None,
         task_type: str,
-        task_parameters: Optional[dict[str, Any]],
-        task_invocation_parameters: Optional[dict[str, Any]],
-        priority: Optional[int],
-        max_concurrency: Optional[str],
-        max_errors: Optional[str],
-        logging_info: Optional[dict[str, Any]],
-        name: Optional[str],
-        description: Optional[str],
-        cutoff_behavior: Optional[str],
-        alarm_configurations: Optional[dict[str, Any]],
+        task_parameters: dict[str, Any] | None,
+        task_invocation_parameters: dict[str, Any] | None,
+        priority: int | None,
+        max_concurrency: str | None,
+        max_errors: str | None,
+        logging_info: dict[str, Any] | None,
+        name: str | None,
+        description: str | None,
+        cutoff_behavior: str | None,
+        alarm_configurations: dict[str, Any] | None,
     ) -> str:
         window = self.get_maintenance_window(window_id)
         task = FakeMaintenanceWindowTask(

--- a/moto/ssoadmin/models.py
+++ b/moto/ssoadmin/models.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -129,7 +129,7 @@ class Instance:
         self.instance_arn = f"arn:{get_partition(region)}:sso:::instance/ssoins-{random.get_random_string(length=16, lower_case=True)}"
         self.account_id = account_id
         self.status = "ACTIVE"
-        self.name: Optional[str] = None
+        self.name: str | None = None
 
         self.provisioned_permission_sets: list[PermissionSet] = []
 
@@ -152,7 +152,7 @@ class SSOAdminBackend(BaseBackend):
         self.account_assignments: list[AccountAssignment] = []
         self.deleted_account_assignments: list[AccountAssignment] = []
         self.permission_sets: list[PermissionSet] = []
-        self.aws_managed_policies: Optional[dict[str, Any]] = None
+        self.aws_managed_policies: dict[str, Any] | None = None
         self.instances: list[Instance] = []
 
         self.instances.append(Instance(self.account_id, self.region_name))

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import json
 import re
 from datetime import datetime, timezone
 from re import Pattern
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -37,9 +39,9 @@ class StateMachineInstance:
         name: str,
         definition: str,
         roleArn: str,
-        encryptionConfiguration: Optional[dict[str, Any]] = None,
-        loggingConfiguration: Optional[dict[str, Any]] = None,
-        tracingConfiguration: Optional[dict[str, Any]] = None,
+        encryptionConfiguration: dict[str, Any] | None = None,
+        loggingConfiguration: dict[str, Any] | None = None,
+        tracingConfiguration: dict[str, Any] | None = None,
     ):
         self.creation_date = utcnow()
         self.update_date = self.creation_date
@@ -55,7 +57,7 @@ class StateMachineInstance:
         self.loggingConfiguration = loggingConfiguration or {"level": "OFF"}
         self.tracingConfiguration = tracingConfiguration or {"enabled": False}
         self.sm_type = "STANDARD"  # or express
-        self.description: Optional[str] = None
+        self.description: str | None = None
 
 
 class StateMachineAlias(CloudFormationModel):
@@ -64,7 +66,7 @@ class StateMachineAlias(CloudFormationModel):
         name: str,
         statemachine_arn: str,
         routing_configuration: list[dict[str, Any]],
-        description: Optional[str] = None,
+        description: str | None = None,
     ):
         self.name = name
         self.statemachine_arn = statemachine_arn
@@ -83,7 +85,7 @@ class StateMachineAlias(CloudFormationModel):
 
 class StateMachineVersion(StateMachineInstance, CloudFormationModel):
     def __init__(
-        self, source: StateMachineInstance, version: int, description: Optional[str]
+        self, source: StateMachineInstance, version: int, description: str | None
     ):
         version_arn = f"{source.arn}:{version}"
         StateMachineInstance.__init__(
@@ -108,10 +110,10 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
         name: str,
         definition: str,
         roleArn: str,
-        backend: "StepFunctionBackend",
-        encryptionConfiguration: Optional[dict[str, Any]] = None,
-        loggingConfiguration: Optional[dict[str, Any]] = None,
-        tracingConfiguration: Optional[dict[str, Any]] = None,
+        backend: StepFunctionBackend,
+        encryptionConfiguration: dict[str, Any] | None = None,
+        loggingConfiguration: dict[str, Any] | None = None,
+        tracingConfiguration: dict[str, Any] | None = None,
     ):
         StateMachineInstance.__init__(
             self,
@@ -126,10 +128,10 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
         self.latest_version_number = 0
         self.versions: dict[int, StateMachineVersion] = {}
         self.aliases: dict[str, StateMachineAlias] = {}
-        self.latest_version: Optional[StateMachineVersion] = None
+        self.latest_version: StateMachineVersion | None = None
         self.backend = backend
 
-    def publish(self, description: Optional[str]) -> None:
+    def publish(self, description: str | None) -> None:
         new_version_number = self.latest_version_number + 1
         new_version = StateMachineVersion(
             source=self, version=new_version_number, description=description
@@ -144,7 +146,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
         account_id: str,
         execution_name: str,
         execution_input: str,
-    ) -> "Execution":
+    ) -> Execution:
         self._validate_execution_input(execution_input)
         existing_execution = self._handle_name_input_idempotency(
             execution_name, execution_input
@@ -164,7 +166,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
         self.executions.append(execution)
         return execution
 
-    def stop_execution(self, execution_arn: str) -> "Execution":
+    def stop_execution(self, execution_arn: str) -> Execution:
         execution = next(
             (x for x in self.executions if x.execution_arn == execution_arn), None
         )
@@ -177,7 +179,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
 
     def _handle_name_input_idempotency(
         self, name: str, execution_input: str
-    ) -> Optional["Execution"]:
+    ) -> Execution | None:
         for execution in self.executions:
             if execution.name == name:
                 # Executions with the same name and input are considered idempotent
@@ -274,7 +276,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
         account_id: str,
         region_name: str,
         **kwargs: Any,
-    ) -> "StateMachine":
+    ) -> StateMachine:
         properties = cloudformation_json["Properties"]
         name = properties.get("StateMachineName", resource_name)
         definition = properties.get("DefinitionString", "")
@@ -302,7 +304,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
         cloudformation_json: Any,
         account_id: str,
         region_name: str,
-    ) -> "StateMachine":
+    ) -> StateMachine:
         properties = cloudformation_json.get("Properties", {})
         name = properties.get("StateMachineName", original_resource.name)
 
@@ -359,13 +361,13 @@ class Execution:
             if settings.get_sf_execution_history_type() == "SUCCESS"
             else "FAILED"
         )
-        self.stop_date: Optional[datetime] = None
+        self.stop_date: datetime | None = None
         self.account_id = account_id
         self.region_name = region_name
-        self.output: Optional[str] = None
-        self.output_details: Optional[str] = None
-        self.cause: Optional[str] = None
-        self.error: Optional[str] = None
+        self.output: str | None = None
+        self.output_details: str | None = None
+        self.cause: str | None = None
+        self.error: str | None = None
 
     def get_execution_history(self, roleArn: str) -> list[dict[str, Any]]:
         sf_execution_history_type = settings.get_sf_execution_history_type()
@@ -463,7 +465,7 @@ class Activity:
         self,
         arn: str,
         name: str,
-        encryption_configuration: Optional[dict[str, Any]] = None,
+        encryption_configuration: dict[str, Any] | None = None,
     ):
         self.arn = arn
         self.name = name
@@ -621,12 +623,12 @@ class StepFunctionBackend(BaseBackend):
         name: str,
         definition: str,
         roleArn: str,
-        tags: Optional[list[dict[str, str]]] = None,
-        publish: Optional[bool] = None,
-        loggingConfiguration: Optional[dict[str, Any]] = None,
-        tracingConfiguration: Optional[dict[str, Any]] = None,
-        encryptionConfiguration: Optional[dict[str, Any]] = None,
-        version_description: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        publish: bool | None = None,
+        loggingConfiguration: dict[str, Any] | None = None,
+        tracingConfiguration: dict[str, Any] | None = None,
+        encryptionConfiguration: dict[str, Any] | None = None,
+        version_description: str | None = None,
     ) -> StateMachine:
         self._validate_name(name)
         self._validate_role_arn(roleArn)
@@ -657,7 +659,7 @@ class StepFunctionBackend(BaseBackend):
         self,
         name: str,
         routing_configuration: list[dict[str, Any]],
-        description: Optional[str],
+        description: str | None,
     ) -> StateMachineAlias:
         state_version_arn = routing_configuration[0]["stateMachineVersionArn"]
         # Get the corresponding sm version
@@ -759,13 +761,13 @@ class StepFunctionBackend(BaseBackend):
     def update_state_machine(
         self,
         arn: str,
-        definition: Optional[str] = None,
-        role_arn: Optional[str] = None,
-        logging_configuration: Optional[dict[str, bool]] = None,
-        tracing_configuration: Optional[dict[str, bool]] = None,
-        encryption_configuration: Optional[dict[str, Any]] = None,
-        publish: Optional[bool] = None,
-        version_description: Optional[str] = None,
+        definition: str | None = None,
+        role_arn: str | None = None,
+        logging_configuration: dict[str, bool] | None = None,
+        tracing_configuration: dict[str, bool] | None = None,
+        encryption_configuration: dict[str, Any] | None = None,
+        publish: bool | None = None,
+        version_description: str | None = None,
     ) -> StateMachine:
         sm = self.describe_state_machine(arn)
         updates: dict[str, Any] = {
@@ -786,8 +788,8 @@ class StepFunctionBackend(BaseBackend):
     def update_state_machine_alias(
         self,
         arn: str,
-        description: Optional[str],
-        routing_configuration: Optional[list[dict[str, Any]]],
+        description: str | None,
+        routing_configuration: list[dict[str, Any]] | None,
     ) -> StateMachineAlias:
         alias = self.describe_state_machine_alias(arn=arn)
 
@@ -819,7 +821,7 @@ class StepFunctionBackend(BaseBackend):
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_executions(
-        self, state_machine_arn: str, status_filter: Optional[str] = None
+        self, state_machine_arn: str, status_filter: str | None = None
     ) -> list[Execution]:
         executions = self.describe_state_machine(state_machine_arn).executions
 
@@ -873,7 +875,7 @@ class StepFunctionBackend(BaseBackend):
     def get_tags_list_for_state_machine(self, arn: str) -> list[dict[str, str]]:
         return self.list_tags_for_resource(arn)[self.tagger.tag_name]
 
-    def send_task_failure(self, task_token: str, error: Optional[str] = None) -> None:
+    def send_task_failure(self, task_token: str, error: str | None = None) -> None:
         pass
 
     def send_task_heartbeat(self, task_token: str) -> None:
@@ -973,8 +975,8 @@ class StepFunctionBackend(BaseBackend):
     def create_activity(
         self,
         name: str,
-        tags: Optional[list[dict[str, str]]] = None,
-        encryption_configuration: Optional[dict[str, Any]] = None,
+        tags: list[dict[str, str]] | None = None,
+        encryption_configuration: dict[str, Any] | None = None,
     ) -> Activity:
         self._validate_name(name)
 

--- a/moto/stepfunctions/parser/api.py
+++ b/moto/stepfunctions/parser/api.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from datetime import datetime
 from enum import Enum
-from typing import IO, Optional, TypedDict, Union
+from typing import IO, Optional, TypedDict
 
 from ..exceptions import AWSError as ServiceException
 
@@ -348,7 +348,7 @@ class KmsInvalidStateException(ServiceException):
     code: str = "KmsInvalidStateException"
     sender_fault: bool = False
     status_code: int = 400
-    kmsKeyState: Optional[KmsKeyState]
+    kmsKeyState: KmsKeyState | None
 
 
 class KmsThrottlingException(ServiceException):
@@ -367,7 +367,7 @@ class ResourceNotFound(ServiceException):
     code: str = "ResourceNotFound"
     sender_fault: bool = False
     status_code: int = 400
-    resourceName: Optional[Arn]
+    resourceName: Arn | None
 
 
 class ServiceQuotaExceededException(ServiceException):
@@ -422,19 +422,19 @@ class TooManyTags(ServiceException):
     code: str = "TooManyTags"
     sender_fault: bool = False
     status_code: int = 400
-    resourceName: Optional[Arn]
+    resourceName: Arn | None
 
 
 class ValidationException(ServiceException):
     code: str = "ValidationException"
     sender_fault: bool = False
     status_code: int = 400
-    reason: Optional[ValidationExceptionReason]
+    reason: ValidationExceptionReason | None
 
 
 class ActivityFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 Timestamp = datetime
@@ -450,44 +450,44 @@ ActivityList = list[ActivityListItem]
 
 
 class ActivityScheduleFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 TimeoutInSeconds = int
 
 
 class HistoryEventExecutionDataDetails(TypedDict, total=False):
-    truncated: Optional[truncated]
+    truncated: truncated | None
 
 
 class ActivityScheduledEventDetails(TypedDict, total=False):
     resource: Arn
-    input: Optional[SensitiveData]
-    inputDetails: Optional[HistoryEventExecutionDataDetails]
-    timeoutInSeconds: Optional[TimeoutInSeconds]
-    heartbeatInSeconds: Optional[TimeoutInSeconds]
+    input: SensitiveData | None
+    inputDetails: HistoryEventExecutionDataDetails | None
+    timeoutInSeconds: TimeoutInSeconds | None
+    heartbeatInSeconds: TimeoutInSeconds | None
 
 
 class ActivityStartedEventDetails(TypedDict, total=False):
-    workerName: Optional[Identity]
+    workerName: Identity | None
 
 
 class ActivitySucceededEventDetails(TypedDict, total=False):
-    output: Optional[SensitiveData]
-    outputDetails: Optional[HistoryEventExecutionDataDetails]
+    output: SensitiveData | None
+    outputDetails: HistoryEventExecutionDataDetails | None
 
 
 class ActivityTimedOutEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 AssignedVariables = dict[VariableName, VariableValue]
 
 
 class AssignedVariablesDetails(TypedDict, total=False):
-    truncated: Optional[truncated]
+    truncated: truncated | None
 
 
 BilledDuration = int
@@ -495,27 +495,27 @@ BilledMemoryUsed = int
 
 
 class BillingDetails(TypedDict, total=False):
-    billedMemoryUsedInMB: Optional[BilledMemoryUsed]
-    billedDurationInMilliseconds: Optional[BilledDuration]
+    billedMemoryUsedInMB: BilledMemoryUsed | None
+    billedDurationInMilliseconds: BilledDuration | None
 
 
 class CloudWatchEventsExecutionDataDetails(TypedDict, total=False):
-    included: Optional[includedDetails]
+    included: includedDetails | None
 
 
 class CloudWatchLogsLogGroup(TypedDict, total=False):
-    logGroupArn: Optional[Arn]
+    logGroupArn: Arn | None
 
 
 class EncryptionConfiguration(TypedDict, total=False):
-    kmsKeyId: Optional[KmsKeyId]
-    kmsDataKeyReusePeriodSeconds: Optional[KmsDataKeyReusePeriodSeconds]
+    kmsKeyId: KmsKeyId | None
+    kmsDataKeyReusePeriodSeconds: KmsDataKeyReusePeriodSeconds | None
     type: EncryptionType
 
 
 class Tag(TypedDict, total=False):
-    key: Optional[TagKey]
-    value: Optional[TagValue]
+    key: TagKey | None
+    value: TagValue | None
 
 
 TagList = list[Tag]
@@ -540,39 +540,39 @@ class CreateStateMachineAliasOutput(TypedDict, total=False):
 
 
 class TracingConfiguration(TypedDict, total=False):
-    enabled: Optional[Enabled]
+    enabled: Enabled | None
 
 
 class LogDestination(TypedDict, total=False):
-    cloudWatchLogsLogGroup: Optional[CloudWatchLogsLogGroup]
+    cloudWatchLogsLogGroup: CloudWatchLogsLogGroup | None
 
 
 LogDestinationList = list[LogDestination]
 
 
 class LoggingConfiguration(TypedDict, total=False):
-    level: Optional[LogLevel]
-    includeExecutionData: Optional[IncludeExecutionData]
-    destinations: Optional[LogDestinationList]
+    level: LogLevel | None
+    includeExecutionData: IncludeExecutionData | None
+    destinations: LogDestinationList | None
 
 
 class CreateStateMachineInput(TypedDict, total=False):
     name: Name
     definition: Definition
     roleArn: Arn
-    type: Optional[StateMachineType]
-    loggingConfiguration: Optional[LoggingConfiguration]
-    tags: Optional[TagList]
-    tracingConfiguration: Optional[TracingConfiguration]
-    publish: Optional[Publish]
-    versionDescription: Optional[VersionDescription]
-    encryptionConfiguration: Optional[EncryptionConfiguration]
+    type: StateMachineType | None
+    loggingConfiguration: LoggingConfiguration | None
+    tags: TagList | None
+    tracingConfiguration: TracingConfiguration | None
+    publish: Publish | None
+    versionDescription: VersionDescription | None
+    encryptionConfiguration: EncryptionConfiguration | None
 
 
 class CreateStateMachineOutput(TypedDict, total=False):
     stateMachineArn: Arn
     creationDate: Timestamp
-    stateMachineVersionArn: Optional[Arn]
+    stateMachineVersionArn: Arn | None
 
 
 class DeleteActivityOutput(TypedDict, total=False):
@@ -595,30 +595,30 @@ class DescribeActivityOutput(TypedDict, total=False):
     activityArn: Arn
     name: Name
     creationDate: Timestamp
-    encryptionConfiguration: Optional[EncryptionConfiguration]
+    encryptionConfiguration: EncryptionConfiguration | None
 
 
 class DescribeExecutionOutput(TypedDict, total=False):
     executionArn: Arn
     stateMachineArn: Arn
-    name: Optional[Name]
+    name: Name | None
     status: ExecutionStatus
     startDate: Timestamp
-    stopDate: Optional[Timestamp]
-    input: Optional[SensitiveData]
-    inputDetails: Optional[CloudWatchEventsExecutionDataDetails]
-    output: Optional[SensitiveData]
-    outputDetails: Optional[CloudWatchEventsExecutionDataDetails]
-    traceHeader: Optional[TraceHeader]
-    mapRunArn: Optional[LongArn]
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
-    stateMachineVersionArn: Optional[Arn]
-    stateMachineAliasArn: Optional[Arn]
-    redriveCount: Optional[RedriveCount]
-    redriveDate: Optional[Timestamp]
-    redriveStatus: Optional[ExecutionRedriveStatus]
-    redriveStatusReason: Optional[SensitiveData]
+    stopDate: Timestamp | None
+    input: SensitiveData | None
+    inputDetails: CloudWatchEventsExecutionDataDetails | None
+    output: SensitiveData | None
+    outputDetails: CloudWatchEventsExecutionDataDetails | None
+    traceHeader: TraceHeader | None
+    mapRunArn: LongArn | None
+    error: SensitiveError | None
+    cause: SensitiveCause | None
+    stateMachineVersionArn: Arn | None
+    stateMachineAliasArn: Arn | None
+    redriveCount: RedriveCount | None
+    redriveDate: Timestamp | None
+    redriveStatus: ExecutionRedriveStatus | None
+    redriveStatusReason: SensitiveData | None
 
 
 LongObject = int
@@ -634,8 +634,8 @@ class MapRunExecutionCounts(TypedDict, total=False):
     aborted: UnsignedLong
     total: UnsignedLong
     resultsWritten: UnsignedLong
-    failuresNotRedrivable: Optional[LongObject]
-    pendingRedrive: Optional[LongObject]
+    failuresNotRedrivable: LongObject | None
+    pendingRedrive: LongObject | None
 
 
 class MapRunItemCounts(TypedDict, total=False):
@@ -647,8 +647,8 @@ class MapRunItemCounts(TypedDict, total=False):
     aborted: UnsignedLong
     total: UnsignedLong
     resultsWritten: UnsignedLong
-    failuresNotRedrivable: Optional[LongObject]
-    pendingRedrive: Optional[LongObject]
+    failuresNotRedrivable: LongObject | None
+    pendingRedrive: LongObject | None
 
 
 ToleratedFailureCount = int
@@ -659,23 +659,23 @@ class DescribeMapRunOutput(TypedDict, total=False):
     executionArn: Arn
     status: MapRunStatus
     startDate: Timestamp
-    stopDate: Optional[Timestamp]
+    stopDate: Timestamp | None
     maxConcurrency: MaxConcurrency
     toleratedFailurePercentage: ToleratedFailurePercentage
     toleratedFailureCount: ToleratedFailureCount
     itemCounts: MapRunItemCounts
     executionCounts: MapRunExecutionCounts
-    redriveCount: Optional[RedriveCount]
-    redriveDate: Optional[Timestamp]
+    redriveCount: RedriveCount | None
+    redriveDate: Timestamp | None
 
 
 class DescribeStateMachineAliasOutput(TypedDict, total=False):
-    stateMachineAliasArn: Optional[Arn]
-    name: Optional[Name]
-    description: Optional[AliasDescription]
-    routingConfiguration: Optional[RoutingConfigurationList]
-    creationDate: Optional[Timestamp]
-    updateDate: Optional[Timestamp]
+    stateMachineAliasArn: Arn | None
+    name: Name | None
+    description: AliasDescription | None
+    routingConfiguration: RoutingConfigurationList | None
+    creationDate: Timestamp | None
+    updateDate: Timestamp | None
 
 
 VariableNameList = list[VariableName]
@@ -688,36 +688,36 @@ class DescribeStateMachineForExecutionOutput(TypedDict, total=False):
     definition: Definition
     roleArn: Arn
     updateDate: Timestamp
-    loggingConfiguration: Optional[LoggingConfiguration]
-    tracingConfiguration: Optional[TracingConfiguration]
-    mapRunArn: Optional[LongArn]
-    label: Optional[MapRunLabel]
-    revisionId: Optional[RevisionId]
-    encryptionConfiguration: Optional[EncryptionConfiguration]
-    variableReferences: Optional[VariableReferences]
+    loggingConfiguration: LoggingConfiguration | None
+    tracingConfiguration: TracingConfiguration | None
+    mapRunArn: LongArn | None
+    label: MapRunLabel | None
+    revisionId: RevisionId | None
+    encryptionConfiguration: EncryptionConfiguration | None
+    variableReferences: VariableReferences | None
 
 
 class DescribeStateMachineOutput(TypedDict, total=False):
     stateMachineArn: Arn
     name: Name
-    status: Optional[StateMachineStatus]
+    status: StateMachineStatus | None
     definition: Definition
     roleArn: Arn
     type: StateMachineType
     creationDate: Timestamp
-    loggingConfiguration: Optional[LoggingConfiguration]
-    tracingConfiguration: Optional[TracingConfiguration]
-    label: Optional[MapRunLabel]
-    revisionId: Optional[RevisionId]
-    description: Optional[VersionDescription]
-    encryptionConfiguration: Optional[EncryptionConfiguration]
-    variableReferences: Optional[VariableReferences]
+    loggingConfiguration: LoggingConfiguration | None
+    tracingConfiguration: TracingConfiguration | None
+    label: MapRunLabel | None
+    revisionId: RevisionId | None
+    description: VersionDescription | None
+    encryptionConfiguration: EncryptionConfiguration | None
+    variableReferences: VariableReferences | None
 
 
 class EvaluationFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
-    location: Optional[EvaluationFailureLocation]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
+    location: EvaluationFailureLocation | None
     state: StateName
 
 
@@ -725,13 +725,13 @@ EventId = int
 
 
 class ExecutionAbortedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class ExecutionFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class ExecutionListItem(TypedDict, total=False):
@@ -740,145 +740,145 @@ class ExecutionListItem(TypedDict, total=False):
     name: Name
     status: ExecutionStatus
     startDate: Timestamp
-    stopDate: Optional[Timestamp]
-    mapRunArn: Optional[LongArn]
-    itemCount: Optional[UnsignedInteger]
-    stateMachineVersionArn: Optional[Arn]
-    stateMachineAliasArn: Optional[Arn]
-    redriveCount: Optional[RedriveCount]
-    redriveDate: Optional[Timestamp]
+    stopDate: Timestamp | None
+    mapRunArn: LongArn | None
+    itemCount: UnsignedInteger | None
+    stateMachineVersionArn: Arn | None
+    stateMachineAliasArn: Arn | None
+    redriveCount: RedriveCount | None
+    redriveDate: Timestamp | None
 
 
 ExecutionList = list[ExecutionListItem]
 
 
 class ExecutionRedrivenEventDetails(TypedDict, total=False):
-    redriveCount: Optional[RedriveCount]
+    redriveCount: RedriveCount | None
 
 
 class ExecutionStartedEventDetails(TypedDict, total=False):
-    input: Optional[SensitiveData]
-    inputDetails: Optional[HistoryEventExecutionDataDetails]
-    roleArn: Optional[Arn]
-    stateMachineAliasArn: Optional[Arn]
-    stateMachineVersionArn: Optional[Arn]
+    input: SensitiveData | None
+    inputDetails: HistoryEventExecutionDataDetails | None
+    roleArn: Arn | None
+    stateMachineAliasArn: Arn | None
+    stateMachineVersionArn: Arn | None
 
 
 class ExecutionSucceededEventDetails(TypedDict, total=False):
-    output: Optional[SensitiveData]
-    outputDetails: Optional[HistoryEventExecutionDataDetails]
+    output: SensitiveData | None
+    outputDetails: HistoryEventExecutionDataDetails | None
 
 
 class ExecutionTimedOutEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class GetActivityTaskOutput(TypedDict, total=False):
-    taskToken: Optional[TaskToken]
-    input: Optional[SensitiveDataJobInput]
+    taskToken: TaskToken | None
+    input: SensitiveDataJobInput | None
 
 
 class MapRunRedrivenEventDetails(TypedDict, total=False):
-    mapRunArn: Optional[LongArn]
-    redriveCount: Optional[RedriveCount]
+    mapRunArn: LongArn | None
+    redriveCount: RedriveCount | None
 
 
 class MapRunFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class MapRunStartedEventDetails(TypedDict, total=False):
-    mapRunArn: Optional[LongArn]
+    mapRunArn: LongArn | None
 
 
 class StateExitedEventDetails(TypedDict, total=False):
     name: Name
-    output: Optional[SensitiveData]
-    outputDetails: Optional[HistoryEventExecutionDataDetails]
-    assignedVariables: Optional[AssignedVariables]
-    assignedVariablesDetails: Optional[AssignedVariablesDetails]
+    output: SensitiveData | None
+    outputDetails: HistoryEventExecutionDataDetails | None
+    assignedVariables: AssignedVariables | None
+    assignedVariablesDetails: AssignedVariablesDetails | None
 
 
 class StateEnteredEventDetails(TypedDict, total=False):
     name: Name
-    input: Optional[SensitiveData]
-    inputDetails: Optional[HistoryEventExecutionDataDetails]
+    input: SensitiveData | None
+    inputDetails: HistoryEventExecutionDataDetails | None
 
 
 class LambdaFunctionTimedOutEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class LambdaFunctionSucceededEventDetails(TypedDict, total=False):
-    output: Optional[SensitiveData]
-    outputDetails: Optional[HistoryEventExecutionDataDetails]
+    output: SensitiveData | None
+    outputDetails: HistoryEventExecutionDataDetails | None
 
 
 class LambdaFunctionStartFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class TaskCredentials(TypedDict, total=False):
-    roleArn: Optional[LongArn]
+    roleArn: LongArn | None
 
 
 class LambdaFunctionScheduledEventDetails(TypedDict, total=False):
     resource: Arn
-    input: Optional[SensitiveData]
-    inputDetails: Optional[HistoryEventExecutionDataDetails]
-    timeoutInSeconds: Optional[TimeoutInSeconds]
-    taskCredentials: Optional[TaskCredentials]
+    input: SensitiveData | None
+    inputDetails: HistoryEventExecutionDataDetails | None
+    timeoutInSeconds: TimeoutInSeconds | None
+    taskCredentials: TaskCredentials | None
 
 
 class LambdaFunctionScheduleFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class LambdaFunctionFailedEventDetails(TypedDict, total=False):
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class MapIterationEventDetails(TypedDict, total=False):
-    name: Optional[Name]
-    index: Optional[UnsignedInteger]
+    name: Name | None
+    index: UnsignedInteger | None
 
 
 class MapStateStartedEventDetails(TypedDict, total=False):
-    length: Optional[UnsignedInteger]
+    length: UnsignedInteger | None
 
 
 class TaskTimedOutEventDetails(TypedDict, total=False):
     resourceType: Name
     resource: Name
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class TaskSucceededEventDetails(TypedDict, total=False):
     resourceType: Name
     resource: Name
-    output: Optional[SensitiveData]
-    outputDetails: Optional[HistoryEventExecutionDataDetails]
+    output: SensitiveData | None
+    outputDetails: HistoryEventExecutionDataDetails | None
 
 
 class TaskSubmittedEventDetails(TypedDict, total=False):
     resourceType: Name
     resource: Name
-    output: Optional[SensitiveData]
-    outputDetails: Optional[HistoryEventExecutionDataDetails]
+    output: SensitiveData | None
+    outputDetails: HistoryEventExecutionDataDetails | None
 
 
 class TaskSubmitFailedEventDetails(TypedDict, total=False):
     resourceType: Name
     resource: Name
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class TaskStartedEventDetails(TypedDict, total=False):
@@ -889,8 +889,8 @@ class TaskStartedEventDetails(TypedDict, total=False):
 class TaskStartFailedEventDetails(TypedDict, total=False):
     resourceType: Name
     resource: Name
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class TaskScheduledEventDetails(TypedDict, total=False):
@@ -898,64 +898,64 @@ class TaskScheduledEventDetails(TypedDict, total=False):
     resource: Name
     region: Name
     parameters: ConnectorParameters
-    timeoutInSeconds: Optional[TimeoutInSeconds]
-    heartbeatInSeconds: Optional[TimeoutInSeconds]
-    taskCredentials: Optional[TaskCredentials]
+    timeoutInSeconds: TimeoutInSeconds | None
+    heartbeatInSeconds: TimeoutInSeconds | None
+    taskCredentials: TaskCredentials | None
 
 
 class TaskFailedEventDetails(TypedDict, total=False):
     resourceType: Name
     resource: Name
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
 
 class HistoryEvent(TypedDict, total=False):
     timestamp: Timestamp
     type: HistoryEventType
     id: EventId
-    previousEventId: Optional[EventId]
-    activityFailedEventDetails: Optional[ActivityFailedEventDetails]
-    activityScheduleFailedEventDetails: Optional[ActivityScheduleFailedEventDetails]
-    activityScheduledEventDetails: Optional[ActivityScheduledEventDetails]
-    activityStartedEventDetails: Optional[ActivityStartedEventDetails]
-    activitySucceededEventDetails: Optional[ActivitySucceededEventDetails]
-    activityTimedOutEventDetails: Optional[ActivityTimedOutEventDetails]
-    taskFailedEventDetails: Optional[TaskFailedEventDetails]
-    taskScheduledEventDetails: Optional[TaskScheduledEventDetails]
-    taskStartFailedEventDetails: Optional[TaskStartFailedEventDetails]
-    taskStartedEventDetails: Optional[TaskStartedEventDetails]
-    taskSubmitFailedEventDetails: Optional[TaskSubmitFailedEventDetails]
-    taskSubmittedEventDetails: Optional[TaskSubmittedEventDetails]
-    taskSucceededEventDetails: Optional[TaskSucceededEventDetails]
-    taskTimedOutEventDetails: Optional[TaskTimedOutEventDetails]
-    executionFailedEventDetails: Optional[ExecutionFailedEventDetails]
-    executionStartedEventDetails: Optional[ExecutionStartedEventDetails]
-    executionSucceededEventDetails: Optional[ExecutionSucceededEventDetails]
-    executionAbortedEventDetails: Optional[ExecutionAbortedEventDetails]
-    executionTimedOutEventDetails: Optional[ExecutionTimedOutEventDetails]
-    executionRedrivenEventDetails: Optional[ExecutionRedrivenEventDetails]
-    mapStateStartedEventDetails: Optional[MapStateStartedEventDetails]
-    mapIterationStartedEventDetails: Optional[MapIterationEventDetails]
-    mapIterationSucceededEventDetails: Optional[MapIterationEventDetails]
-    mapIterationFailedEventDetails: Optional[MapIterationEventDetails]
-    mapIterationAbortedEventDetails: Optional[MapIterationEventDetails]
-    lambdaFunctionFailedEventDetails: Optional[LambdaFunctionFailedEventDetails]
+    previousEventId: EventId | None
+    activityFailedEventDetails: ActivityFailedEventDetails | None
+    activityScheduleFailedEventDetails: ActivityScheduleFailedEventDetails | None
+    activityScheduledEventDetails: ActivityScheduledEventDetails | None
+    activityStartedEventDetails: ActivityStartedEventDetails | None
+    activitySucceededEventDetails: ActivitySucceededEventDetails | None
+    activityTimedOutEventDetails: ActivityTimedOutEventDetails | None
+    taskFailedEventDetails: TaskFailedEventDetails | None
+    taskScheduledEventDetails: TaskScheduledEventDetails | None
+    taskStartFailedEventDetails: TaskStartFailedEventDetails | None
+    taskStartedEventDetails: TaskStartedEventDetails | None
+    taskSubmitFailedEventDetails: TaskSubmitFailedEventDetails | None
+    taskSubmittedEventDetails: TaskSubmittedEventDetails | None
+    taskSucceededEventDetails: TaskSucceededEventDetails | None
+    taskTimedOutEventDetails: TaskTimedOutEventDetails | None
+    executionFailedEventDetails: ExecutionFailedEventDetails | None
+    executionStartedEventDetails: ExecutionStartedEventDetails | None
+    executionSucceededEventDetails: ExecutionSucceededEventDetails | None
+    executionAbortedEventDetails: ExecutionAbortedEventDetails | None
+    executionTimedOutEventDetails: ExecutionTimedOutEventDetails | None
+    executionRedrivenEventDetails: ExecutionRedrivenEventDetails | None
+    mapStateStartedEventDetails: MapStateStartedEventDetails | None
+    mapIterationStartedEventDetails: MapIterationEventDetails | None
+    mapIterationSucceededEventDetails: MapIterationEventDetails | None
+    mapIterationFailedEventDetails: MapIterationEventDetails | None
+    mapIterationAbortedEventDetails: MapIterationEventDetails | None
+    lambdaFunctionFailedEventDetails: LambdaFunctionFailedEventDetails | None
     lambdaFunctionScheduleFailedEventDetails: Optional[
         LambdaFunctionScheduleFailedEventDetails
     ]
-    lambdaFunctionScheduledEventDetails: Optional[LambdaFunctionScheduledEventDetails]
+    lambdaFunctionScheduledEventDetails: LambdaFunctionScheduledEventDetails | None
     lambdaFunctionStartFailedEventDetails: Optional[
         LambdaFunctionStartFailedEventDetails
     ]
-    lambdaFunctionSucceededEventDetails: Optional[LambdaFunctionSucceededEventDetails]
-    lambdaFunctionTimedOutEventDetails: Optional[LambdaFunctionTimedOutEventDetails]
-    stateEnteredEventDetails: Optional[StateEnteredEventDetails]
-    stateExitedEventDetails: Optional[StateExitedEventDetails]
-    mapRunStartedEventDetails: Optional[MapRunStartedEventDetails]
-    mapRunFailedEventDetails: Optional[MapRunFailedEventDetails]
-    mapRunRedrivenEventDetails: Optional[MapRunRedrivenEventDetails]
-    evaluationFailedEventDetails: Optional[EvaluationFailedEventDetails]
+    lambdaFunctionSucceededEventDetails: LambdaFunctionSucceededEventDetails | None
+    lambdaFunctionTimedOutEventDetails: LambdaFunctionTimedOutEventDetails | None
+    stateEnteredEventDetails: StateEnteredEventDetails | None
+    stateExitedEventDetails: StateExitedEventDetails | None
+    mapRunStartedEventDetails: MapRunStartedEventDetails | None
+    mapRunFailedEventDetails: MapRunFailedEventDetails | None
+    mapRunRedrivenEventDetails: MapRunRedrivenEventDetails | None
+    evaluationFailedEventDetails: EvaluationFailedEventDetails | None
 
 
 HistoryEventList = list[HistoryEvent]
@@ -963,36 +963,36 @@ HistoryEventList = list[HistoryEvent]
 
 class GetExecutionHistoryOutput(TypedDict, total=False):
     events: HistoryEventList
-    nextToken: Optional[PageToken]
+    nextToken: PageToken | None
 
 
 class InspectionDataResponse(TypedDict, total=False):
-    protocol: Optional[HTTPProtocol]
-    statusCode: Optional[HTTPStatusCode]
-    statusMessage: Optional[HTTPStatusMessage]
-    headers: Optional[HTTPHeaders]
-    body: Optional[HTTPBody]
+    protocol: HTTPProtocol | None
+    statusCode: HTTPStatusCode | None
+    statusMessage: HTTPStatusMessage | None
+    headers: HTTPHeaders | None
+    body: HTTPBody | None
 
 
 class InspectionDataRequest(TypedDict, total=False):
-    protocol: Optional[HTTPProtocol]
-    method: Optional[HTTPMethod]
-    url: Optional[URL]
-    headers: Optional[HTTPHeaders]
-    body: Optional[HTTPBody]
+    protocol: HTTPProtocol | None
+    method: HTTPMethod | None
+    url: URL | None
+    headers: HTTPHeaders | None
+    body: HTTPBody | None
 
 
 class InspectionData(TypedDict, total=False):
-    input: Optional[SensitiveData]
-    afterArguments: Optional[SensitiveData]
-    afterInputPath: Optional[SensitiveData]
-    afterParameters: Optional[SensitiveData]
-    result: Optional[SensitiveData]
-    afterResultSelector: Optional[SensitiveData]
-    afterResultPath: Optional[SensitiveData]
-    request: Optional[InspectionDataRequest]
-    response: Optional[InspectionDataResponse]
-    variables: Optional[SensitiveData]
+    input: SensitiveData | None
+    afterArguments: SensitiveData | None
+    afterInputPath: SensitiveData | None
+    afterParameters: SensitiveData | None
+    result: SensitiveData | None
+    afterResultSelector: SensitiveData | None
+    afterResultPath: SensitiveData | None
+    request: InspectionDataRequest | None
+    response: InspectionDataResponse | None
+    variables: SensitiveData | None
 
 
 class MapRunListItem(TypedDict, total=False):
@@ -1000,7 +1000,7 @@ class MapRunListItem(TypedDict, total=False):
     mapRunArn: LongArn
     stateMachineArn: Arn
     startDate: Timestamp
-    stopDate: Optional[Timestamp]
+    stopDate: Timestamp | None
 
 
 MapRunList = list[MapRunListItem]
@@ -1008,7 +1008,7 @@ MapRunList = list[MapRunListItem]
 
 class ListMapRunsOutput(TypedDict, total=False):
     mapRuns: MapRunList
-    nextToken: Optional[PageToken]
+    nextToken: PageToken | None
 
 
 class StateMachineAliasListItem(TypedDict, total=False):
@@ -1021,7 +1021,7 @@ StateMachineAliasList = list[StateMachineAliasListItem]
 
 class ListStateMachineAliasesOutput(TypedDict, total=False):
     stateMachineAliases: StateMachineAliasList
-    nextToken: Optional[PageToken]
+    nextToken: PageToken | None
 
 
 class StateMachineVersionListItem(TypedDict, total=False):
@@ -1034,7 +1034,7 @@ StateMachineVersionList = list[StateMachineVersionListItem]
 
 class ListStateMachineVersionsOutput(TypedDict, total=False):
     stateMachineVersions: StateMachineVersionList
-    nextToken: Optional[PageToken]
+    nextToken: PageToken | None
 
 
 class StateMachineListItem(TypedDict, total=False):
@@ -1049,11 +1049,11 @@ StateMachineList = list[StateMachineListItem]
 
 class ListStateMachinesOutput(TypedDict, total=False):
     stateMachines: StateMachineList
-    nextToken: Optional[PageToken]
+    nextToken: PageToken | None
 
 
 class ListTagsForResourceOutput(TypedDict, total=False):
-    tags: Optional[TagList]
+    tags: TagList | None
 
 
 class PublishStateMachineVersionOutput(TypedDict, total=False):
@@ -1084,19 +1084,19 @@ class StartExecutionOutput(TypedDict, total=False):
 
 class StartSyncExecutionOutput(TypedDict, total=False):
     executionArn: Arn
-    stateMachineArn: Optional[Arn]
-    name: Optional[Name]
+    stateMachineArn: Arn | None
+    name: Name | None
     startDate: Timestamp
     stopDate: Timestamp
     status: SyncExecutionStatus
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
-    input: Optional[SensitiveData]
-    inputDetails: Optional[CloudWatchEventsExecutionDataDetails]
-    output: Optional[SensitiveData]
-    outputDetails: Optional[CloudWatchEventsExecutionDataDetails]
-    traceHeader: Optional[TraceHeader]
-    billingDetails: Optional[BillingDetails]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
+    input: SensitiveData | None
+    inputDetails: CloudWatchEventsExecutionDataDetails | None
+    output: SensitiveData | None
+    outputDetails: CloudWatchEventsExecutionDataDetails | None
+    traceHeader: TraceHeader | None
+    billingDetails: BillingDetails | None
 
 
 class StopExecutionOutput(TypedDict, total=False):
@@ -1111,12 +1111,12 @@ class TagResourceOutput(TypedDict, total=False):
 
 
 class TestStateOutput(TypedDict, total=False):
-    output: Optional[SensitiveData]
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
-    inspectionData: Optional[InspectionData]
-    nextState: Optional[StateName]
-    status: Optional[TestExecutionStatus]
+    output: SensitiveData | None
+    error: SensitiveError | None
+    cause: SensitiveCause | None
+    inspectionData: InspectionData | None
+    nextState: StateName | None
+    status: TestExecutionStatus | None
 
 
 class UntagResourceOutput(TypedDict, total=False):
@@ -1133,15 +1133,15 @@ class UpdateStateMachineAliasOutput(TypedDict, total=False):
 
 class UpdateStateMachineOutput(TypedDict, total=False):
     updateDate: Timestamp
-    revisionId: Optional[RevisionId]
-    stateMachineVersionArn: Optional[Arn]
+    revisionId: RevisionId | None
+    stateMachineVersionArn: Arn | None
 
 
 class ValidateStateMachineDefinitionDiagnostic(TypedDict, total=False):
     severity: ValidateStateMachineDefinitionSeverity
     code: ValidateStateMachineDefinitionCode
     message: ValidateStateMachineDefinitionMessage
-    location: Optional[ValidateStateMachineDefinitionLocation]
+    location: ValidateStateMachineDefinitionLocation | None
 
 
 ValidateStateMachineDefinitionDiagnosticList = list[
@@ -1151,20 +1151,20 @@ ValidateStateMachineDefinitionDiagnosticList = list[
 
 class ValidateStateMachineDefinitionInput(TypedDict, total=False):
     definition: Definition
-    type: Optional[StateMachineType]
-    severity: Optional[ValidateStateMachineDefinitionSeverity]
-    maxResults: Optional[ValidateStateMachineDefinitionMaxResult]
+    type: StateMachineType | None
+    severity: ValidateStateMachineDefinitionSeverity | None
+    maxResults: ValidateStateMachineDefinitionMaxResult | None
 
 
 class ValidateStateMachineDefinitionOutput(TypedDict, total=False):
     result: ValidateStateMachineDefinitionResultCode
     diagnostics: ValidateStateMachineDefinitionDiagnosticList
-    truncated: Optional[ValidateStateMachineDefinitionTruncated]
+    truncated: ValidateStateMachineDefinitionTruncated | None
 
 
 class InvocationResponse(TypedDict, total=False):
-    Payload: Optional[Union[bytes, IO[bytes], Iterable[bytes]]]
-    StatusCode: Optional[int]
-    FunctionError: Optional[str]
-    LogResult: Optional[str]
-    ExecutedVersion: Optional[str]
+    Payload: bytes | IO[bytes] | Iterable[bytes] | None
+    StatusCode: int | None
+    FunctionError: str | None
+    LogResult: str | None
+    ExecutedVersion: str | None

--- a/moto/stepfunctions/parser/asl/antlt4utils/antlr4utils.py
+++ b/moto/stepfunctions/parser/asl/antlt4utils/antlr4utils.py
@@ -1,13 +1,12 @@
 import ast
-from typing import Optional
 
 from antlr4 import ParserRuleContext
 from antlr4.tree.Tree import ParseTree, TerminalNodeImpl
 
 
 def is_production(
-    pt: ParseTree, rule_index: Optional[int] = None
-) -> Optional[ParserRuleContext]:
+    pt: ParseTree, rule_index: int | None = None
+) -> ParserRuleContext | None:
     if isinstance(pt, ParserRuleContext):
         prc = pt.getRuleContext()  # noqa
         if rule_index is not None:
@@ -17,8 +16,8 @@ def is_production(
 
 
 def is_terminal(
-    pt: ParseTree, token_type: Optional[int] = None
-) -> Optional[TerminalNodeImpl]:
+    pt: ParseTree, token_type: int | None = None
+) -> TerminalNodeImpl | None:
     if isinstance(pt, TerminalNodeImpl):
         if token_type is not None:
             return pt if pt.getSymbol().type == token_type else None
@@ -26,7 +25,7 @@ def is_terminal(
     return None
 
 
-def from_string_literal(parser_rule_context: ParserRuleContext) -> Optional[str]:
+def from_string_literal(parser_rule_context: ParserRuleContext) -> str | None:
     string_literal = parser_rule_context.getText()
     if string_literal.startswith('"') and string_literal.endswith('"'):
         string_literal = string_literal[1:-1]

--- a/moto/stepfunctions/parser/asl/component/common/catch/catcher_decl.py
+++ b/moto/stepfunctions/parser/asl/component/common/catch/catcher_decl.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.assign.assign_decl import AssignDecl
 from moto.stepfunctions.parser.asl.component.common.catch.catcher_outcome import (
@@ -36,19 +36,19 @@ class CatcherDecl(EvalComponent):
 
     error_equals: Final[ErrorEqualsDecl]
     next_decl: Final[Next]
-    result_path: Final[Optional[ResultPath]]
-    assign: Final[Optional[AssignDecl]]
-    output: Final[Optional[Output]]
-    comment: Final[Optional[Comment]]
+    result_path: Final[ResultPath] | None
+    assign: Final[AssignDecl] | None
+    output: Final[Output] | None
+    comment: Final[Comment] | None
 
     def __init__(
         self,
         error_equals: ErrorEqualsDecl,
         next_decl: Next,
-        result_path: Optional[ResultPath],
-        assign: Optional[AssignDecl],
-        output: Optional[Output],
-        comment: Optional[Comment],
+        result_path: ResultPath | None,
+        assign: AssignDecl | None,
+        output: Output | None,
+        comment: Comment | None,
     ):
         self.error_equals = error_equals
         self.next_decl = next_decl

--- a/moto/stepfunctions/parser/asl/component/common/error_name/custom_error_name.py
+++ b/moto/stepfunctions/parser/asl/component/common/error_name/custom_error_name.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.error_name.error_name import (
     ErrorName,
@@ -12,7 +12,7 @@ class CustomErrorName(ErrorName):
     States MAY report errors with other names, which MUST NOT begin with the prefix "States.".
     """
 
-    def __init__(self, error_name: Optional[str]):
+    def __init__(self, error_name: str | None):
         if error_name is not None and error_name.startswith(
             ILLEGAL_CUSTOM_ERROR_PREFIX
         ):

--- a/moto/stepfunctions/parser/asl/component/common/error_name/error_name.py
+++ b/moto/stepfunctions/parser/asl/component/common/error_name/error_name.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import abc
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.component import Component
 
 
 class ErrorName(Component, abc.ABC):
-    error_name: Final[Optional[str]]
+    error_name: Final[str | None]
 
-    def __init__(self, error_name: Optional[str]):
+    def __init__(self, error_name: str | None):
         self.error_name = error_name
 
-    def matches(self, error_name: Optional[str]) -> bool:
+    def matches(self, error_name: str | None) -> bool:
         return self.error_name == error_name
 
     def __eq__(self, other):

--- a/moto/stepfunctions/parser/asl/component/common/error_name/failure_event.py
+++ b/moto/stepfunctions/parser/asl/component/common/error_name/failure_event.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import (
     EvaluationFailedEventDetails,
@@ -18,16 +18,16 @@ from moto.stepfunctions.parser.asl.eval.event.event_detail import EventDetails
 class FailureEvent:
     state_name: Final[str]
     source_event_id: Final[int]
-    error_name: Final[Optional[ErrorName]]
+    error_name: Final[ErrorName | None]
     event_type: Final[HistoryEventType]
-    event_details: Final[Optional[EventDetails]]
+    event_details: Final[EventDetails | None]
 
     def __init__(
         self,
         env: Environment,
-        error_name: Optional[ErrorName],
+        error_name: ErrorName | None,
         event_type: HistoryEventType,
-        event_details: Optional[EventDetails] = None,
+        event_details: EventDetails | None = None,
     ):
         self.state_name = env.next_state_name
         self.source_event_id = env.event_history_context.source_event_id
@@ -42,7 +42,7 @@ class FailureEventException(Exception):
     def __init__(self, failure_event: FailureEvent):
         self.failure_event = failure_event
 
-    def extract_error_cause_pair(self) -> Optional[tuple[Optional[str], Optional[str]]]:
+    def extract_error_cause_pair(self) -> tuple[str | None, str | None] | None:
         if self.failure_event.event_details is None:
             return None
 
@@ -58,7 +58,7 @@ class FailureEventException(Exception):
 
     def get_evaluation_failed_event_details(
         self,
-    ) -> Optional[EvaluationFailedEventDetails]:
+    ) -> EvaluationFailedEventDetails | None:
         original_failed_event_details = self.failure_event.event_details[
             "evaluationFailedEventDetails"
         ]
@@ -86,7 +86,7 @@ class FailureEventException(Exception):
 
     def get_execution_failed_event_details(
         self,
-    ) -> Optional[ExecutionFailedEventDetails]:
+    ) -> ExecutionFailedEventDetails | None:
         maybe_error_cause_pair = self.extract_error_cause_pair()
         if maybe_error_cause_pair is None:
             return None

--- a/moto/stepfunctions/parser/asl/component/common/jsonata/jsonata_template_binding.py
+++ b/moto/stepfunctions/parser/asl/component/common/jsonata/jsonata_template_binding.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.jsonata.jsonata_template_value import (
     JSONataTemplateValue,
@@ -17,7 +17,7 @@ class JSONataTemplateBinding(EvalComponent):
         self.identifier = identifier
         self.value = value
 
-    def _field_name(self) -> Optional[str]:
+    def _field_name(self) -> str | None:
         return self.identifier
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/path/input_path.py
+++ b/moto/stepfunctions/parser/asl/component/common/path/input_path.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskFailedEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
@@ -22,9 +22,9 @@ from moto.stepfunctions.parser.asl.utils.json_path import NoSuchJsonPathError
 
 
 class InputPath(EvalComponent):
-    string_sampler: Final[Optional[StringSampler]]
+    string_sampler: Final[StringSampler | None]
 
-    def __init__(self, string_sampler: Optional[StringSampler]):
+    def __init__(self, string_sampler: StringSampler | None):
         self.string_sampler = string_sampler
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/path/output_path.py
+++ b/moto/stepfunctions/parser/asl/component/common/path/output_path.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskFailedEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
@@ -21,9 +21,9 @@ from moto.stepfunctions.parser.asl.utils.json_path import NoSuchJsonPathError
 
 
 class OutputPath(EvalComponent):
-    string_sampler: Final[Optional[StringSampler]]
+    string_sampler: Final[StringSampler | None]
 
-    def __init__(self, string_sampler: Optional[StringSampler]):
+    def __init__(self, string_sampler: StringSampler | None):
         self.string_sampler = string_sampler
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/path/result_path.py
+++ b/moto/stepfunctions/parser/asl/component/common/path/result_path.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Final, Optional
+from typing import Final
 
 from jsonpath_ng import parse
 
@@ -10,9 +10,9 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 class ResultPath(EvalComponent):
     DEFAULT_PATH: Final[str] = "$"
 
-    result_path_src: Final[Optional[str]]
+    result_path_src: Final[str | None]
 
-    def __init__(self, result_path_src: Optional[str]):
+    def __init__(self, result_path_src: str | None):
         self.result_path_src = result_path_src
 
     def _eval_body(self, env: Environment) -> None:

--- a/moto/stepfunctions/parser/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding.py
+++ b/moto/stepfunctions/parser/asl/component/common/payload/payloadvalue/payloadbinding/payload_binding.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.common.payload.payloadvalue.payload_value import (
     PayloadValue,
@@ -16,7 +16,7 @@ class PayloadBinding(PayloadValue, abc.ABC):
     def __init__(self, field: str):
         self.field = field
 
-    def _field_name(self) -> Optional[str]:
+    def _field_name(self) -> str | None:
         return self.field
 
     @abc.abstractmethod
@@ -36,7 +36,7 @@ class PayloadBindingStringExpressionSimple(PayloadBinding):
         super().__init__(field=field)
         self.string_expression_simple = string_expression_simple
 
-    def _field_name(self) -> Optional[str]:
+    def _field_name(self) -> str | None:
         return f"{self.field}.$"
 
     def _eval_val(self, env: Environment) -> Any:

--- a/moto/stepfunctions/parser/asl/component/common/retry/retrier_decl.py
+++ b/moto/stepfunctions/parser/asl/component/common/retry/retrier_decl.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import time
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.comment import Comment
 from moto.stepfunctions.parser.asl.component.common.error_name.error_equals_decl import (
@@ -40,17 +40,17 @@ class RetrierDecl(EvalComponent):
     backoff_rate: Final[BackoffRateDecl]
     max_delay_seconds: Final[MaxDelaySecondsDecl]
     jitter_strategy: Final[JitterStrategyDecl]
-    comment: Final[Optional[Comment]]
+    comment: Final[Comment | None]
 
     def __init__(
         self,
         error_equals: ErrorEqualsDecl,
-        interval_seconds: Optional[IntervalSecondsDecl] = None,
-        max_attempts: Optional[MaxAttemptsDecl] = None,
-        backoff_rate: Optional[BackoffRateDecl] = None,
-        max_delay_seconds: Optional[MaxDelaySecondsDecl] = None,
-        jitter_strategy: Optional[JitterStrategyDecl] = None,
-        comment: Optional[Comment] = None,
+        interval_seconds: IntervalSecondsDecl | None = None,
+        max_attempts: MaxAttemptsDecl | None = None,
+        backoff_rate: BackoffRateDecl | None = None,
+        max_delay_seconds: MaxDelaySecondsDecl | None = None,
+        jitter_strategy: JitterStrategyDecl | None = None,
+        comment: Comment | None = None,
     ):
         self.error_equals = error_equals
         self.interval_seconds = interval_seconds or IntervalSecondsDecl()

--- a/moto/stepfunctions/parser/asl/component/common/string/string_expression.py
+++ b/moto/stepfunctions/parser/asl/component/common/string/string_expression.py
@@ -1,6 +1,6 @@
 import abc
 import copy
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskFailedEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
@@ -48,7 +48,7 @@ class StringExpression(EvalComponent, abc.ABC):
     def __init__(self, literal_value: str):
         self.literal_value = literal_value
 
-    def _field_name(self) -> Optional[str]:
+    def _field_name(self) -> str | None:
         return None
 
 

--- a/moto/stepfunctions/parser/asl/component/common/timeouts/timeout.py
+++ b/moto/stepfunctions/parser/asl/component/common/timeouts/timeout.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import (
     ExecutionFailedEventDetails,
@@ -44,13 +44,13 @@ class Timeout(EvalComponent, abc.ABC):
 class TimeoutSeconds(Timeout):
     DEFAULT_TIMEOUT_SECONDS: Final[int] = 99999999
 
-    def __init__(self, timeout_seconds: int, is_default: Optional[bool] = None):
+    def __init__(self, timeout_seconds: int, is_default: bool | None = None):
         if not isinstance(timeout_seconds, int) and timeout_seconds <= 0:
             raise ValueError(
                 f"Expected non-negative integer for TimeoutSeconds, got '{timeout_seconds}' instead."
             )
         self.timeout_seconds: Final[int] = timeout_seconds
-        self.is_default: Optional[bool] = is_default
+        self.is_default: bool | None = is_default
 
     def is_default_value(self) -> bool:
         if self.is_default is not None:

--- a/moto/stepfunctions/parser/asl/component/eval_component.py
+++ b/moto/stepfunctions/parser/asl/component/eval_component.py
@@ -1,6 +1,5 @@
 import abc
 import logging
-from typing import Optional
 
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
     FailureEventException,
@@ -14,7 +13,7 @@ LOG = logging.getLogger(__name__)
 
 
 class EvalComponent(Component, abc.ABC):
-    __heap_key: Optional[str] = None
+    __heap_key: str | None = None
 
     @property
     def heap_key(self) -> str:
@@ -86,5 +85,5 @@ class EvalComponent(Component, abc.ABC):
     def _eval_body(self, env: Environment) -> None:
         raise NotImplementedError()
 
-    def _field_name(self) -> Optional[str]:
+    def _field_name(self) -> str | None:
         return self.__class__.__name__

--- a/moto/stepfunctions/parser/asl/component/intrinsic/argument/argument.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/argument/argument.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.common.string.string_expression import (
     StringVariableSample,
@@ -32,9 +32,9 @@ class Argument(EvalComponent, abc.ABC):
 
 
 class ArgumentLiteral(Argument):
-    definition_value: Final[Optional[Any]]
+    definition_value: Final[Any]
 
-    def __init__(self, definition_value: Optional[Any]):
+    def __init__(self, definition_value: Any):
         self.definition_value = definition_value
 
     def _eval_argument(self, env: Environment) -> Any:

--- a/moto/stepfunctions/parser/asl/component/intrinsic/jsonata.py
+++ b/moto/stepfunctions/parser/asl/component/intrinsic/jsonata.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.jsonata.jsonata import (
     VariableDeclarations,
@@ -77,7 +77,7 @@ def get_intrinsic_functions_declarations(
 ) -> VariableDeclarations:
     declarations: list[str] = []
     for variable_reference in variable_references:
-        declaration: Optional[VariableDeclarations] = (
+        declaration: VariableDeclarations | None = (
             _DECLARATION_BY_VARIABLE_REFERENCE.get(variable_reference)
         )
         if declaration:

--- a/moto/stepfunctions/parser/asl/component/program/program.py
+++ b/moto/stepfunctions/parser/asl/component/program/program.py
@@ -1,6 +1,6 @@
 import logging
 import threading
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import (
     ExecutionAbortedEventDetails,
@@ -49,18 +49,18 @@ class Program(EvalComponent):
     query_language: Final[QueryLanguage]
     start_at: Final[StartAt]
     states: Final[States]
-    timeout_seconds: Final[Optional[TimeoutSeconds]]
-    comment: Final[Optional[Comment]]
-    version: Final[Optional[Version]]
+    timeout_seconds: Final[TimeoutSeconds | None]
+    comment: Final[Comment | None]
+    version: Final[Version | None]
 
     def __init__(
         self,
         query_language: QueryLanguage,
         start_at: StartAt,
         states: States,
-        timeout_seconds: Optional[TimeoutSeconds],
-        comment: Optional[Comment] = None,
-        version: Optional[Version] = None,
+        timeout_seconds: TimeoutSeconds | None,
+        comment: Comment | None = None,
+        version: Version | None = None,
     ):
         self.query_language = query_language
         self.start_at = start_at
@@ -70,7 +70,7 @@ class Program(EvalComponent):
         self.version = version
 
     def _get_state(self, state_name: str) -> CommonStateField:
-        state: Optional[CommonStateField] = self.states.states.get(state_name, None)
+        state: CommonStateField | None = self.states.states.get(state_name, None)
         if state is None:
             raise ValueError(f"No such state {state}.")
         return state

--- a/moto/stepfunctions/parser/asl/component/state/choice/choice_rule.py
+++ b/moto/stepfunctions/parser/asl/component/state/choice/choice_rule.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.assign.assign_decl import AssignDecl
 from moto.stepfunctions.parser.asl.component.common.comment import Comment
@@ -12,19 +12,19 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 
 class ChoiceRule(EvalComponent):
-    comparison: Final[Optional[Comparison]]
-    next_stmt: Final[Optional[Next]]
-    comment: Final[Optional[Comment]]
-    assign: Final[Optional[AssignDecl]]
-    output: Final[Optional[Output]]
+    comparison: Final[Comparison | None]
+    next_stmt: Final[Next | None]
+    comment: Final[Comment | None]
+    assign: Final[AssignDecl | None]
+    output: Final[Output | None]
 
     def __init__(
         self,
-        comparison: Optional[Comparison],
-        next_stmt: Optional[Next],
-        comment: Optional[Comment],
-        assign: Optional[AssignDecl],
-        output: Optional[Output],
+        comparison: Comparison | None,
+        next_stmt: Next | None,
+        comment: Comment | None,
+        assign: AssignDecl | None,
+        output: Output | None,
     ):
         self.comparison = comparison
         self.next_stmt = next_stmt

--- a/moto/stepfunctions/parser/asl/component/state/choice/comparison/operator/implementations/is_operator.py
+++ b/moto/stepfunctions/parser/asl/component/state/choice/comparison/operator/implementations/is_operator.py
@@ -1,6 +1,6 @@
 import datetime
 import logging
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.state.choice.comparison.comparison_operator_type import (
     ComparisonOperatorType,
@@ -90,7 +90,7 @@ class IsTimestamp(Operator):
         return str(ComparisonOperatorType.IsTimestamp)
 
     @staticmethod
-    def string_to_timestamp(string: str) -> Optional[datetime.datetime]:
+    def string_to_timestamp(string: str) -> datetime.datetime | None:
         try:
             return datetime.datetime.strptime(string, IsTimestamp.TIMESTAMP_FORMAT)
         except Exception:

--- a/moto/stepfunctions/parser/asl/component/state/choice/state_choice.py
+++ b/moto/stepfunctions/parser/asl/component/state/choice/state_choice.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.stepfunctions.parser.api import HistoryEventType
 from moto.stepfunctions.parser.asl.component.common.flow.end import End
 from moto.stepfunctions.parser.asl.component.common.flow.next import Next
@@ -16,7 +14,7 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 class StateChoice(CommonStateField):
     choices_decl: ChoicesDecl
-    default_state: Optional[DefaultDecl]
+    default_state: DefaultDecl | None
 
     def __init__(self):
         super().__init__(

--- a/moto/stepfunctions/parser/asl/component/state/exec/execute_state.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/execute_state.py
@@ -3,7 +3,7 @@ import copy
 import logging
 import threading
 from threading import Thread
-from typing import Any, Optional
+from typing import Any
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskFailedEventDetails
 from moto.stepfunctions.parser.asl.component.common.catch.catch_decl import CatchDecl
@@ -50,7 +50,7 @@ class ExecutionState(CommonStateField, abc.ABC):
     def __init__(
         self,
         state_entered_event_type: HistoryEventType,
-        state_exited_event_type: Optional[HistoryEventType],
+        state_exited_event_type: HistoryEventType | None,
     ):
         super().__init__(
             state_entered_event_type=state_entered_event_type,
@@ -60,20 +60,20 @@ class ExecutionState(CommonStateField, abc.ABC):
         # Specifies where (in the input) to place the results of executing the state_task that's specified in Resource.
         # The input is then filtered as specified by the OutputPath field (if present) before being used as the
         # state's output.
-        self.result_path: Optional[ResultPath] = None
+        self.result_path: ResultPath | None = None
 
         # ResultSelector (Optional)
         # Pass a collection of key value pairs, where the values are static or selected from the result.
-        self.result_selector: Optional[ResultSelector] = None
+        self.result_selector: ResultSelector | None = None
 
         # Retry (Optional)
         # An array of objects, called Retriers, that define a retry policy if the state encounters runtime errors.
-        self.retry: Optional[RetryDecl] = None
+        self.retry: RetryDecl | None = None
 
         # Catch (Optional)
         # An array of objects, called Catchers, that define a fallback state. This state is executed if the state
         # encounters runtime errors and its retry policy is exhausted or isn't defined.
-        self.catch: Optional[CatchDecl] = None
+        self.catch: CatchDecl | None = None
 
         # TimeoutSeconds (Optional)
         # If the state_task runs longer than the specified seconds, this state fails with a States.Timeout error name.
@@ -99,7 +99,7 @@ class ExecutionState(CommonStateField, abc.ABC):
         # HeartbeatSecondsPath. When resolved, the reference path must select fields whose values are positive integers.
         # A Task state cannot include both HeartbeatSeconds and HeartbeatSecondsPath
         # HeartbeatSeconds and HeartbeatSecondsPath fields are encoded by the Heartbeat type.
-        self.heartbeat: Optional[Heartbeat] = None
+        self.heartbeat: Heartbeat | None = None
 
     def from_state_props(self, state_props: StateProps) -> None:
         super().from_state_props(state_props=state_props)
@@ -185,7 +185,7 @@ class ExecutionState(CommonStateField, abc.ABC):
         frame.states.reset(input_value=env.states.get_input())
         frame.stack = copy.deepcopy(env.stack)
         execution_outputs: list[Any] = []
-        execution_exceptions: list[Optional[Exception]] = [None]
+        execution_exceptions: list[Exception | None] = [None]
         terminated_event = threading.Event()
 
         def _exec_and_notify():

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/item_reader/item_reader_decl.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/item_reader/item_reader_decl.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.parargs import Parargs
 from moto.stepfunctions.parser.asl.component.eval_component import EvalComponent
@@ -26,15 +26,15 @@ from moto.stepfunctions.parser.asl.eval.environment import Environment
 
 class ItemReader(EvalComponent):
     resource_eval: Final[ResourceEval]
-    parargs: Final[Optional[Parargs]]
-    reader_config: Final[Optional[ReaderConfig]]
-    resource_output_transformer: Optional[ResourceOutputTransformer]
+    parargs: Final[Parargs | None]
+    reader_config: Final[ReaderConfig | None]
+    resource_output_transformer: ResourceOutputTransformer | None
 
     def __init__(
         self,
         resource: Resource,
-        parargs: Optional[Parargs],
-        reader_config: Optional[ReaderConfig],
+        parargs: Parargs | None,
+        reader_config: ReaderConfig | None,
     ):
         self.resource_eval = resource_eval_for(resource=resource)
         self.parargs = parargs

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/item_reader/reader_config/reader_config_decl.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/item_reader/reader_config/reader_config_decl.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional, TypedDict
+from typing import Final, TypedDict
 
 from moto.stepfunctions.parser.asl.component.eval_component import EvalComponent
 from moto.stepfunctions.parser.asl.component.state.exec.state_map.item_reader.reader_config.csv_header_location import (
@@ -34,7 +34,7 @@ MaxItemsValueOutput = int
 class ReaderConfigOutput(TypedDict):
     InputType: InputTypeOutput
     CSVHeaderLocation: CSVHeaderLocationOutput
-    CSVHeaders: Optional[CSVHeadersOutput]
+    CSVHeaders: CSVHeadersOutput | None
     MaxItemsValue: MaxItemsValueOutput
 
 
@@ -42,14 +42,14 @@ class ReaderConfig(EvalComponent):
     input_type: Final[InputType]
     max_items_decl: Final[MaxItemsDecl]
     csv_header_location: Final[CSVHeaderLocation]
-    csv_headers: Optional[CSVHeaders]
+    csv_headers: CSVHeaders | None
 
     def __init__(
         self,
         input_type: InputType,
         csv_header_location: CSVHeaderLocation,
-        csv_headers: Optional[CSVHeaders],
-        max_items_decl: Optional[MaxItemsDecl],
+        csv_headers: CSVHeaders | None,
+        max_items_decl: MaxItemsDecl | None,
     ):
         self.input_type = input_type
         self.max_items_decl = max_items_decl or MaxItemsInt()

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/distributed_iteration_component.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/distributed_iteration_component.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 import json
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.api import (
     HistoryEventType,
@@ -50,8 +50,8 @@ from moto.stepfunctions.parser.asl.eval.event.event_manager import (
 
 
 class DistributedIterationComponentEvalInput(InlineIterationComponentEvalInput):
-    item_reader: Final[Optional[ItemReader]]
-    label: Final[Optional[str]]
+    item_reader: Final[ItemReader | None]
+    label: Final[str | None]
     map_run_record: Final[MapRunRecord]
 
     def __init__(
@@ -59,12 +59,12 @@ class DistributedIterationComponentEvalInput(InlineIterationComponentEvalInput):
         state_name: str,
         max_concurrency: int,
         input_items: list[json],
-        parameters: Optional[Parameters],
-        item_selector: Optional[ItemSelector],
-        item_reader: Optional[ItemReader],
+        parameters: Parameters | None,
+        item_selector: ItemSelector | None,
+        item_reader: ItemReader | None,
         tolerated_failure_count: int,
         tolerated_failure_percentage: float,
-        label: Optional[str],
+        label: str | None,
         map_run_record: MapRunRecord,
     ):
         super().__init__(
@@ -118,7 +118,7 @@ class DistributedIterationComponent(InlineIterationComponent, abc.ABC):
 
         job_pool.await_jobs()
 
-        worker_exception: Optional[Exception] = job_pool.get_worker_exception()
+        worker_exception: Exception | None = job_pool.get_worker_exception()
         if worker_exception is not None:
             raise worker_exception
 

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/inline_iteration_component.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/inline_iteration_component.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import json
 import threading
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.common.comment import Comment
 from moto.stepfunctions.parser.asl.component.common.flow.start_at import StartAt
@@ -38,16 +38,16 @@ class InlineIterationComponentEvalInput:
     state_name: Final[str]
     max_concurrency: Final[int]
     input_items: Final[list[json]]
-    parameters: Final[Optional[Parameters]]
-    item_selector: Final[Optional[ItemSelector]]
+    parameters: Final[Parameters | None]
+    item_selector: Final[ItemSelector | None]
 
     def __init__(
         self,
         state_name: str,
         max_concurrency: int,
         input_items: list[json],
-        parameters: Optional[Parameters],
-        item_selector: Optional[ItemSelector],
+        parameters: Parameters | None,
+        item_selector: ItemSelector | None,
     ):
         self.state_name = state_name
         self.max_concurrency = max_concurrency
@@ -65,7 +65,7 @@ class InlineIterationComponent(IterationComponent, abc.ABC):
         start_at: StartAt,
         states: States,
         processor_config: ProcessorConfig,
-        comment: Optional[Comment],
+        comment: Comment | None,
     ):
         super().__init__(
             query_language=query_language,
@@ -116,7 +116,7 @@ class InlineIterationComponent(IterationComponent, abc.ABC):
 
         job_pool.await_jobs()
 
-        worker_exception: Optional[Exception] = job_pool.get_worker_exception()
+        worker_exception: Exception | None = job_pool.get_worker_exception()
         if worker_exception is not None:
             raise worker_exception
 

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/itemprocessor/distributed_item_processor_worker.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/itemprocessor/distributed_item_processor_worker.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
     FailureEventException,
@@ -46,8 +46,8 @@ class DistributedItemProcessorWorker(InlineItemProcessorWorker):
         job_pool: JobPool,
         env: Environment,
         item_reader: ItemReader,
-        parameters: Optional[Parameters],
-        item_selector: Optional[ItemSelector],
+        parameters: Parameters | None,
+        item_selector: ItemSelector | None,
         map_run_record: MapRunRecord,
     ):
         super().__init__(
@@ -126,7 +126,7 @@ class DistributedItemProcessorWorker(InlineItemProcessorWorker):
             self._map_run_record.item_counter.running.offset(-1)
             job.job_output = job_output
 
-    def _eval_pool(self, job: Optional[Job], worker_frame: Environment) -> None:
+    def _eval_pool(self, job: Job | None, worker_frame: Environment) -> None:
         if job is None:
             self._env.delete_frame(worker_frame)
             return

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/itemprocessor/inline_item_processor_worker.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/itemprocessor/inline_item_processor_worker.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.parargs import Parameters
 from moto.stepfunctions.parser.asl.component.state.exec.state_map.item_selector import (
@@ -17,16 +17,16 @@ LOG = logging.getLogger(__name__)
 
 
 class InlineItemProcessorWorker(IterationWorker):
-    _parameters: Final[Optional[Parameters]]
-    _item_selector: Final[Optional[ItemSelector]]
+    _parameters: Final[Parameters | None]
+    _item_selector: Final[ItemSelector | None]
 
     def __init__(
         self,
         work_name: str,
         job_pool: JobPool,
         env: Environment,
-        item_selector: Optional[ItemSelector],
-        parameters: Optional[Parameters],
+        item_selector: ItemSelector | None,
+        parameters: Parameters | None,
     ):
         super().__init__(work_name=work_name, job_pool=job_pool, env=env)
         self._item_selector = item_selector

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/itemprocessor/map_run_record.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/itemprocessor/map_run_record.py
@@ -2,7 +2,7 @@ import abc
 import datetime
 import threading
 from collections import OrderedDict
-from typing import Final, Optional
+from typing import Final
 
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.stepfunctions.parser.api import (
@@ -99,7 +99,7 @@ class MapRunRecord:
     item_counter: Final[ItemCounter]
     start_date: Timestamp
     status: MapRunStatus
-    stop_date: Optional[Timestamp]
+    stop_date: Timestamp | None
     # TODO: add support for failure toleration fields.
     tolerated_failure_count: int
     tolerated_failure_percentage: float
@@ -111,7 +111,7 @@ class MapRunRecord:
         max_concurrency: int,
         tolerated_failure_count: int,
         tolerated_failure_percentage: float,
-        label: Optional[str],
+        label: str | None,
     ):
         self.update_event = threading.Event()
         (
@@ -134,7 +134,7 @@ class MapRunRecord:
 
     @staticmethod
     def _generate_map_run_arns(
-        state_machine_arn: Arn, label: Optional[str]
+        state_machine_arn: Arn, label: str | None
     ) -> tuple[LongArn, LongArn]:
         # Generate a new MapRunArn given the StateMachineArn, such that:
         # inp: arn:aws:states:<region>:111111111111:stateMachine:<ArnPart_0idx>
@@ -181,9 +181,9 @@ class MapRunRecord:
 
     def update(
         self,
-        max_concurrency: Optional[int],
-        tolerated_failure_count: Optional[int],
-        tolerated_failure_percentage: Optional[float],
+        max_concurrency: int | None,
+        tolerated_failure_count: int | None,
+        tolerated_failure_percentage: float | None,
     ) -> None:
         if max_concurrency is not None:
             self.max_concurrency = max_concurrency
@@ -203,7 +203,7 @@ class MapRunRecordPoolManager:
     def add(self, map_run_record: MapRunRecord) -> None:
         self._pool[map_run_record.map_run_arn] = map_run_record
 
-    def get(self, map_run_arn: LongArn) -> Optional[MapRunRecord]:
+    def get(self, map_run_arn: LongArn) -> MapRunRecord | None:
         return self._pool.get(map_run_arn)
 
     def get_all(self) -> list[MapRunRecord]:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iteration_component.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iteration_component.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.comment import Comment
 from moto.stepfunctions.parser.asl.component.common.flow.start_at import StartAt
@@ -18,14 +18,14 @@ class IterationComponent(EvalComponent, abc.ABC):
     _query_language: Final[QueryLanguage]
     _start_at: Final[StartAt]
     _states: Final[States]
-    _comment: Final[Optional[Comment]]
+    _comment: Final[Comment | None]
 
     def __init__(
         self,
         query_language: QueryLanguage,
         start_at: StartAt,
         states: States,
-        comment: Optional[Comment],
+        comment: Comment | None,
     ):
         self._query_language = query_language
         self._start_at = start_at

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iteration_declaration.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iteration_declaration.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.comment import Comment
 from moto.stepfunctions.parser.asl.component.common.flow.start_at import StartAt
@@ -11,7 +11,7 @@ from moto.stepfunctions.parser.asl.component.state.exec.state_map.iteration.item
 
 
 class IterationDecl(Component):
-    comment: Final[Optional[Comment]]
+    comment: Final[Comment | None]
     query_language: Final[QueryLanguage]
     start_at: Final[StartAt]
     states: Final[States]
@@ -19,7 +19,7 @@ class IterationDecl(Component):
 
     def __init__(
         self,
-        comment: Optional[Comment],
+        comment: Comment | None,
         query_language: QueryLanguage,
         start_at: StartAt,
         states: States,

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iteration_worker.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iteration_worker.py
@@ -1,6 +1,6 @@
 import abc
 import logging
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import HistoryEventType, MapIterationEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.custom_error_name import (
@@ -176,7 +176,7 @@ class IterationWorker(abc.ABC):
         finally:
             job.job_output = job_output
 
-    def _eval_pool(self, job: Optional[Job], worker_frame: Environment) -> None:
+    def _eval_pool(self, job: Job | None, worker_frame: Environment) -> None:
         # Note: the frame has to be closed before the job, to ensure the owner environment is correctly updated
         #  before the evaluation continues; map states await for job termination not workers termination.
         if job is None:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iterator/distributed_iterator_worker.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iterator/distributed_iterator_worker.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
     FailureEventException,
 )
@@ -37,9 +35,9 @@ class DistributedIteratorWorker(InlineIteratorWorker):
         work_name: str,
         job_pool: JobPool,
         env: Environment,
-        parameters: Optional[Parameters],
+        parameters: Parameters | None,
         map_run_record: MapRunRecord,
-        item_selector: Optional[ItemSelector],
+        item_selector: ItemSelector | None,
     ):
         super().__init__(
             work_name=work_name,
@@ -101,7 +99,7 @@ class DistributedIteratorWorker(InlineIteratorWorker):
             self._map_run_record.item_counter.running.offset(-1)
             job.job_output = job_output
 
-    def _eval_pool(self, job: Optional[Job], worker_frame: Environment) -> None:
+    def _eval_pool(self, job: Job | None, worker_frame: Environment) -> None:
         # Note: the frame has to be closed before the job, to ensure the owner environment is correctly updated
         #  before the evaluation continues; map states await for job termination not workers termination.
         if job is None:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iterator/inline_iterator.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iterator/inline_iterator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
 
 from moto.stepfunctions.parser.asl.component.state.exec.state_map.iteration.inline_iteration_component import (
     InlineIterationComponent,
@@ -26,7 +25,7 @@ class InlineIteratorEvalInput(InlineIterationComponentEvalInput):
 
 
 class InlineIterator(InlineIterationComponent):
-    _eval_input: Optional[InlineIteratorEvalInput]
+    _eval_input: InlineIteratorEvalInput | None
 
     def _create_worker(
         self, env: Environment, eval_input: InlineIteratorEvalInput, job_pool: JobPool

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iterator/inline_iterator_worker.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/iterator/inline_iterator_worker.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.common.parargs import Parameters
 from moto.stepfunctions.parser.asl.component.state.exec.state_map.item_selector import (
@@ -17,16 +17,16 @@ LOG = logging.getLogger(__name__)
 
 
 class InlineIteratorWorker(IterationWorker):
-    _parameters: Final[Optional[Parameters]]
-    _item_selector: Final[Optional[ItemSelector]]
+    _parameters: Final[Parameters | None]
+    _item_selector: Final[ItemSelector | None]
 
     def __init__(
         self,
         work_name: str,
         job_pool: JobPool,
         env: Environment,
-        item_selector: Optional[ItemSelector],
-        parameters: Optional[Parameters],
+        item_selector: ItemSelector | None,
+        parameters: Parameters | None,
     ):
         super().__init__(work_name=work_name, job_pool=job_pool, env=env)
         self._item_selector = item_selector

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/job.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/iteration/job.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import threading
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.program.program import Program
 from moto.stepfunctions.parser.asl.utils.encoding import to_json_str
@@ -12,10 +12,10 @@ LOG = logging.getLogger(__name__)
 class Job:
     job_index: Final[int]
     job_program: Final[Program]
-    job_input: Final[Optional[Any]]
-    job_output: Optional[Any]
+    job_input: Final[Any]
+    job_output: Any | None
 
-    def __init__(self, job_index: int, job_program: Program, job_input: Optional[Any]):
+    def __init__(self, job_index: int, job_program: Program, job_input: Any):
         self.job_index = job_index
         self.job_program = job_program
         self.job_input = job_input
@@ -24,9 +24,9 @@ class Job:
 
 class JobClosed:
     job_index: Final[int]
-    job_output: Optional[Any]
+    job_output: Any | None
 
-    def __init__(self, job_index: int, job_output: Optional[Any]):
+    def __init__(self, job_index: int, job_output: Any):
         self.job_index = job_index
         self.job_output = job_output
 
@@ -37,7 +37,7 @@ class JobClosed:
 class JobPool:
     _mutex: Final[threading.Lock]
     _termination_event: Final[threading.Event]
-    _worker_exception: Optional[Exception]
+    _worker_exception: Exception | None
 
     _jobs_number: Final[int]
     _open_jobs: Final[list[Job]]
@@ -56,7 +56,7 @@ class JobPool:
         self._open_jobs.reverse()
         self._closed_jobs = set()
 
-    def next_job(self) -> Optional[Any]:
+    def next_job(self) -> Any:
         with self._mutex:
             if self._worker_exception is not None:
                 return None
@@ -75,7 +75,7 @@ class JobPool:
         if self._is_terminated():
             self._termination_event.set()
 
-    def get_worker_exception(self) -> Optional[Exception]:
+    def get_worker_exception(self) -> Exception | None:
         return self._worker_exception
 
     def close_job(self, job: Job) -> None:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_map/state_map.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_map/state_map.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Optional
 
 from moto.stepfunctions.parser.api import (
     EvaluationFailedEventDetails,
@@ -105,21 +104,21 @@ from moto.stepfunctions.parser.asl.eval.event.event_detail import EventDetails
 
 
 class StateMap(ExecutionState):
-    items: Optional[Items]
-    items_path: Optional[ItemsPath]
+    items: Items | None
+    items_path: ItemsPath | None
     iteration_component: IterationComponent
-    item_reader: Optional[ItemReader]
-    item_selector: Optional[ItemSelector]
-    parameters: Optional[Parameters]
+    item_reader: ItemReader | None
+    item_selector: ItemSelector | None
+    parameters: Parameters | None
     max_concurrency_decl: MaxConcurrencyDecl
     tolerated_failure_count_decl: ToleratedFailureCountDecl
     tolerated_failure_percentage_decl: ToleratedFailurePercentage
-    result_path: Optional[ResultPath]
+    result_path: ResultPath | None
     result_selector: ResultSelector
-    retry: Optional[RetryDecl]
-    catch: Optional[CatchDecl]
-    label: Optional[Label]
-    result_writer: Optional[ResultWriter]
+    retry: RetryDecl | None
+    catch: CatchDecl | None
+    label: Label | None
+    result_writer: ResultWriter | None
 
     def __init__(self):
         super().__init__(

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/branch_worker.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/branch_worker.py
@@ -1,7 +1,7 @@
 import abc
 import logging
 import threading
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import Timestamp
 from moto.stepfunctions.parser.asl.component.program.program import Program
@@ -18,7 +18,7 @@ class BranchWorker:
 
     _branch_worker_comm: Final[BranchWorkerComm]
     _program: Final[Program]
-    _worker_thread: Optional[threading.Thread]
+    _worker_thread: threading.Thread | None
     env: Final[Environment]
 
     def __init__(
@@ -49,9 +49,7 @@ class BranchWorker:
         TMP_THREADS.append(self._worker_thread)
         self._worker_thread.start()
 
-    def stop(
-        self, stop_date: Timestamp, cause: Optional[str], error: Optional[str]
-    ) -> None:
+    def stop(self, stop_date: Timestamp, cause: str | None, error: str | None) -> None:
         env = self.env
         if env:
             try:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/branches_decl.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/branches_decl.py
@@ -1,6 +1,6 @@
 import datetime
 import threading
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import ExecutionFailedEventDetails, HistoryEventType
 from moto.stepfunctions.parser.asl.component.common.error_name.custom_error_name import (
@@ -26,7 +26,7 @@ class BranchWorkerPool(BranchWorker.BranchWorkerComm):
     _termination_event: Final[threading.Event]
     _active_workers_num: int
 
-    _terminated_with_error: Optional[ExecutionFailedEventDetails]
+    _terminated_with_error: ExecutionFailedEventDetails | None
 
     def __init__(self, workers_num: int):
         self._mutex = threading.Lock()
@@ -54,7 +54,7 @@ class BranchWorkerPool(BranchWorker.BranchWorkerComm):
     def wait(self):
         self._termination_event.wait()
 
-    def get_exit_event_details(self) -> Optional[ExecutionFailedEventDetails]:
+    def get_exit_event_details(self) -> ExecutionFailedEventDetails | None:
         return self._terminated_with_error
 
 
@@ -85,7 +85,7 @@ class BranchesDecl(EvalComponent):
         branch_worker_pool.wait()
 
         # Propagate exception if parallel task failed.
-        exit_event_details: Optional[ExecutionFailedEventDetails] = (
+        exit_event_details: ExecutionFailedEventDetails | None = (
             branch_worker_pool.get_exit_event_details()
         )
         if exit_event_details is not None:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/state_parallel.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_parallel/state_parallel.py
@@ -1,5 +1,4 @@
 import copy
-from typing import Optional
 
 from moto.stepfunctions.parser.api import HistoryEventType
 from moto.stepfunctions.parser.asl.component.common.catch.catch_outcome import (
@@ -29,7 +28,7 @@ class StateParallel(ExecutionState):
     # machine object must have fields named States and StartAt, whose meanings are exactly
     # like those in the top level of a state machine.
     branches: BranchesDecl
-    parargs: Optional[Parargs]
+    parargs: Parargs | None
 
     def __init__(self):
         super().__init__(

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/lambda_eval_utils.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/lambda_eval_utils.py
@@ -1,6 +1,6 @@
 import json
 from json import JSONDecodeError
-from typing import IO, Any, Final, Optional, Union
+from typing import IO, Any, Final
 
 from moto.stepfunctions.parser.api import InvocationResponse
 from moto.stepfunctions.parser.asl.component.state.exec.state_task.credentials import (
@@ -17,15 +17,15 @@ from moto.utilities.collections import select_from_typed_dict
 
 
 class LambdaFunctionErrorException(Exception):
-    function_error: Final[Optional[str]]
+    function_error: Final[str | None]
     payload: Final[str]
 
-    def __init__(self, function_error: Optional[str], payload: str):
+    def __init__(self, function_error: str | None, payload: str):
         self.function_error = function_error
         self.payload = payload
 
 
-def _from_payload(payload_streaming_body: IO[bytes]) -> Union[dict, str]:
+def _from_payload(payload_streaming_body: IO[bytes]) -> dict | str:
     """
     This method extracts the lambda payload. The payload may be a string or a JSON stringified object.
     In the first case, this function converts the output into a UTF-8 string, otherwise it parses the
@@ -77,7 +77,7 @@ def exec_lambda_function(
 
     invocation_resp = lambda_client.invoke(**parameters)
 
-    func_error: Optional[str] = invocation_resp.get("FunctionError")
+    func_error: str | None = invocation_resp.get("FunctionError")
     payload_json = json.load(invocation_resp["Payload"])
     if func_error:
         payload_str = json.dumps(payload_json, separators=(",", ":"))
@@ -98,7 +98,7 @@ def execute_lambda_function_integration(
             parameters=parameters, region=region, state_credentials=state_credentials
         )
 
-    function_error: Optional[str] = invocation_response.get("FunctionError")
+    function_error: str | None = invocation_response.get("FunctionError")
     if function_error:
         payload_json = invocation_response["Payload"]
         payload_str = json.dumps(payload_json, separators=(",", ":"))
@@ -110,7 +110,7 @@ def execute_lambda_function_integration(
     env.stack.append(response)
 
 
-def to_payload_type(payload: Any) -> Optional[bytes]:
+def to_payload_type(payload: Any) -> bytes | None:
     if isinstance(payload, bytes):
         return payload
 

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/resource.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/resource.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from itertools import takewhile
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.asl.component.eval_component import EvalComponent
 from moto.stepfunctions.parser.asl.eval.environment import Environment
@@ -33,7 +33,7 @@ class ResourceARN:
         account: str,
         task_type: str,
         name: str,
-        option: Optional[str],
+        option: str | None,
     ):
         self.arn = arn
         self.partition = partition
@@ -136,7 +136,7 @@ class ServiceResource(Resource):
     service_name: Final[str]
     api_name: Final[str]
     api_action: Final[str]
-    condition: Final[Optional[str]]
+    condition: Final[str | None]
 
     def __init__(self, resource_arn: ResourceARN):
         super().__init__(resource_arn=resource_arn)

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import copy
 import logging
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from botocore.model import ListShape, Shape, StringShape, StructureShape
 from botocore.response import StreamingBody
@@ -135,7 +135,7 @@ class StateTaskService(StateTask, abc.ABC):
         parameters_bind_keys: list[str] = list(parameters.keys())
         for parameter_key in parameters_bind_keys:
             norm_parameter_key = camel_to_snake_case(parameter_key)
-            norm_member_bind: Optional[tuple[str, Optional[StructureShape]]] = (
+            norm_member_bind: tuple[str, StructureShape | None] | None = (
                 norm_member_binds.get(norm_parameter_key)
             )
             if norm_member_bind is not None:
@@ -197,29 +197,27 @@ class StateTaskService(StateTask, abc.ABC):
 
                 response[norm_response_key] = response_value
 
-    def _get_boto_service_name(self, boto_service_name: Optional[str] = None) -> str:
+    def _get_boto_service_name(self, boto_service_name: str | None = None) -> str:
         api_name = boto_service_name or self.resource.api_name
         return self._SERVICE_NAME_SFN_TO_BOTO_OVERRIDES.get(api_name, api_name)
 
-    def _get_boto_service_action(
-        self, service_action_name: Optional[str] = None
-    ) -> str:
+    def _get_boto_service_action(self, service_action_name: str | None = None) -> str:
         api_action = service_action_name or self.resource.api_action
         return camel_to_snake_case(api_action)
 
     def _normalise_parameters(
         self,
         parameters: dict,
-        boto_service_name: Optional[str] = None,
-        service_action_name: Optional[str] = None,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
     ) -> None:
         pass
 
     def _normalise_response(
         self,
         response: Any,
-        boto_service_name: Optional[str] = None,
-        service_action_name: Optional[str] = None,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
     ) -> None:
         pass
 

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_api_gateway.py
@@ -4,7 +4,7 @@ import http
 import json
 import logging
 from json import JSONDecodeError
-from typing import Any, Final, Optional, TypedDict, Union
+from typing import Any, Final, TypedDict
 from urllib.parse import urlencode, urljoin
 
 import requests
@@ -43,8 +43,8 @@ Headers = dict
 Stage = str
 Path = str
 QueryParameters = dict
-RequestBody = Union[dict, str]
-ResponseBody = Union[dict, str]
+RequestBody = dict | str
+ResponseBody = dict | str
 StatusCode = int
 StatusText = str
 AllowNullValues = bool
@@ -69,13 +69,13 @@ class AuthType(str):
 class TaskParameters(TypedDict):
     ApiEndpoint: ApiEndpoint
     Method: Method
-    Headers: Optional[Headers]
-    Stage: Optional[Stage]
-    Path: Optional[Path]
-    QueryParameters: Optional[QueryParameters]
-    RequestBody: Optional[RequestBody]
-    AllowNullValues: Optional[AllowNullValues]
-    AuthType: Optional[AuthType]
+    Headers: Headers | None
+    Stage: Stage | None
+    Path: Path | None
+    QueryParameters: QueryParameters | None
+    RequestBody: RequestBody | None
+    AllowNullValues: AllowNullValues | None
+    AuthType: AuthType | None
 
 
 class InvokeOutput(TypedDict):
@@ -124,14 +124,14 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return self._SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _normalise_parameters(
         self,
         parameters: dict[str, Any],
-        boto_service_name: Optional[str] = None,
-        service_action_name: Optional[str] = None,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
     ) -> None:
         # ApiGateway does not support botocore request relay.
         pass
@@ -139,14 +139,14 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
     def _normalise_response(
         self,
         response: Any,
-        boto_service_name: Optional[str] = None,
-        service_action_name: Optional[str] = None,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
     ) -> None:
         # ApiGateway does not support botocore request relay.
         pass
 
     @staticmethod
-    def _query_parameters_of(parameters: TaskParameters) -> Optional[str]:
+    def _query_parameters_of(parameters: TaskParameters) -> str | None:
         query_str = None
         query_parameters = parameters.get("QueryParameters")
         # TODO: add support for AllowNullValues.
@@ -160,7 +160,7 @@ class StateTaskServiceApiGateway(StateTaskServiceCallback):
         return query_str
 
     @staticmethod
-    def _headers_of(parameters: TaskParameters) -> Optional[dict]:
+    def _headers_of(parameters: TaskParameters) -> dict | None:
         headers = parameters.get("Headers", {})
         if headers:
             for key in headers.keys():

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_batch.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_batch.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from botocore.exceptions import ClientError
 
@@ -66,7 +66,7 @@ class StateTaskServiceBatch(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     @staticmethod
@@ -143,7 +143,7 @@ class StateTaskServiceBatch(StateTaskServiceCallback):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         batch_client = boto_client_for(
             service="batch",
             region=resource_runtime_part.region,
@@ -152,7 +152,7 @@ class StateTaskServiceBatch(StateTaskServiceCallback):
         submission_output: dict = env.stack.pop()
         job_id = submission_output["JobId"]
 
-        def _sync_resolver() -> Optional[dict]:
+        def _sync_resolver() -> dict | None:
             describe_jobs_response = batch_client.describe_jobs(jobs=[job_id])
             describe_jobs = describe_jobs_response["jobs"]
             if describe_jobs:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_callback.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_callback.py
@@ -3,7 +3,7 @@ import json
 import threading
 import time
 from collections.abc import Callable
-from typing import Any, Final, Optional, Union
+from typing import Any, Final
 
 from moto.stepfunctions.parser.api import (
     HistoryEventExecutionDataDetails,
@@ -68,7 +68,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         raise RuntimeError(
             f"Unsupported .sync callback procedure in resource {self.resource.resource_arn}"
         )
@@ -79,7 +79,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         raise RuntimeError(
             f"Unsupported .sync2 callback procedure in resource {self.resource.resource_arn}"
         )
@@ -89,9 +89,9 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         env: Environment,
         timeout_seconds: int,
         callback_endpoint: CallbackEndpoint,
-        heartbeat_endpoint: Optional[HeartbeatEndpoint],
+        heartbeat_endpoint: HeartbeatEndpoint | None,
     ) -> CallbackOutcome:
-        outcome: Optional[CallbackOutcome]
+        outcome: CallbackOutcome | None
         if heartbeat_endpoint is not None:
             outcome = self._wait_for_task_token_heartbeat(
                 env, callback_endpoint, heartbeat_endpoint
@@ -107,12 +107,12 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
     def _eval_sync(
         self,
         env: Environment,
-        sync_resolver: Callable[[], Optional[Any]],
-        timeout_seconds: Optional[int],
-        callback_endpoint: Optional[CallbackEndpoint],
-        heartbeat_endpoint: Optional[HeartbeatEndpoint],
-    ) -> Union[CallbackOutcome, Any]:
-        callback_output: Optional[CallbackOutcome] = None
+        sync_resolver: Callable[[], Any] | None,
+        timeout_seconds: int | None,
+        callback_endpoint: CallbackEndpoint | None,
+        heartbeat_endpoint: HeartbeatEndpoint | None,
+    ) -> CallbackOutcome | Any:
+        callback_output: CallbackOutcome | None = None
 
         # Listen for WaitForTaskToken signals if an endpoint is provided.
         if callback_endpoint is not None:
@@ -137,7 +137,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
             #       an exception in this thread will invalidate env, and therefore the worker thread.
             #       hence why here there are no explicit stopping logic for thread_wait_for_task_token.
 
-        sync_result: Optional[Any] = None
+        sync_result: Any | None = None
         while env.is_running():
             sync_result = sync_resolver()
             if callback_output or sync_result:
@@ -157,7 +157,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         task_output = env.stack.pop()
 
         # Initialise the waitForTaskToken Callback endpoint for this task if supported.
-        callback_endpoint: Optional[CallbackEndpoint] = None
+        callback_endpoint: CallbackEndpoint | None = None
         if ResourceCondition.WaitForTaskToken in self._supported_integration_patterns:
             callback_id = env.states.context_object.context_object_data["Task"]["Token"]
             callback_endpoint = env.callback_pool_manager.get(callback_id)
@@ -167,7 +167,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         timeout_seconds = env.stack.pop()
 
         # Setup resources for heartbeat workloads if necessary.
-        heartbeat_endpoint: Optional[HeartbeatEndpoint] = None
+        heartbeat_endpoint: HeartbeatEndpoint | None = None
         if self.heartbeat:
             self.heartbeat.eval(env=env)
             heartbeat_seconds = env.stack.pop()
@@ -178,7 +178,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
             )
 
         # Collect the output of the integration pattern.
-        outcome: Union[CallbackOutcome, Any]
+        outcome: CallbackOutcome | Any
         try:
             if self.resource.condition == ResourceCondition.WaitForTaskToken:
                 outcome = self._eval_wait_for_task_token(
@@ -245,7 +245,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         self,
         timeout_seconds: int,
         callback_endpoint: CallbackEndpoint,
-    ) -> Optional[CallbackOutcome]:
+    ) -> CallbackOutcome | None:
         # Awaits a callback notification and returns the outcome received.
         # If the operation times out or is interrupted it returns None.
 
@@ -254,7 +254,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         # discarded by the main process.
         # Note: although this is the same timeout value, this can only decay strictly after the first timeout
         #       started as it is invoked strictly later.
-        outcome: Optional[CallbackOutcome] = callback_endpoint.wait(
+        outcome: CallbackOutcome | None = callback_endpoint.wait(
             timeout=timeout_seconds
         )
         return outcome
@@ -264,7 +264,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         env: Environment,
         callback_endpoint: CallbackEndpoint,
         heartbeat_endpoint: HeartbeatEndpoint,
-    ) -> Optional[CallbackOutcome]:
+    ) -> CallbackOutcome | None:
         outcome = None
         while (
             env.is_running()
@@ -292,7 +292,7 @@ class StateTaskServiceCallback(StateTaskService, abc.ABC):
         self, env: Environment, ex: CallbackOutcomeFailureError
     ) -> FailureEvent:
         callback_outcome_failure: CallbackOutcomeFailure = ex.callback_outcome_failure
-        error: Optional[str] = callback_outcome_failure.error
+        error: str | None = callback_outcome_failure.error
         return FailureEvent(
             env=env,
             error_name=CustomErrorName(error_name=error),

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_dynamodb.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_dynamodb.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from botocore.exceptions import ClientError
 
@@ -76,7 +76,7 @@ _SUPPORTED_API_PARAM_BINDINGS: Final[dict[str, set[str]]] = {
 
 
 class StateTaskServiceDynamoDB(StateTaskService):
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     @staticmethod

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_ecs.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_ecs.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.component.state.exec.state_task.credentials import (
     StateCredentials,
@@ -43,7 +43,7 @@ class StateTaskServiceEcs(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _before_eval_execution(
@@ -102,7 +102,7 @@ class StateTaskServiceEcs(StateTaskServiceCallback):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         ecs_client = boto_client_for(
             service="ecs",
             region=resource_runtime_part.region,
@@ -112,7 +112,7 @@ class StateTaskServiceEcs(StateTaskServiceCallback):
         task_arn: str = submission_output["Tasks"][0]["TaskArn"]
         cluster_arn: str = submission_output["Tasks"][0]["ClusterArn"]
 
-        def _sync_resolver() -> Optional[dict]:
+        def _sync_resolver() -> dict | None:
             describe_tasks_output = ecs_client.describe_tasks(
                 cluster=cluster_arn, tasks=[task_arn]
             )

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_events.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_events.py
@@ -1,5 +1,5 @@
 import json
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskFailedEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.custom_error_name import (
@@ -37,9 +37,9 @@ _SUPPORTED_API_PARAM_BINDINGS: Final[dict[str, set[str]]] = {"putevents": {"Entr
 
 
 class SfnFailedEntryCountException(RuntimeError):
-    cause: Final[Optional[dict]]
+    cause: Final[dict | None]
 
-    def __init__(self, cause: Optional[dict]):
+    def __init__(self, cause: dict | None):
         super().__init__(json.dumps(cause))
         self.cause = cause
 
@@ -48,7 +48,7 @@ class StateTaskServiceEvents(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_glue.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_glue.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 import boto3
 from botocore.exceptions import ClientError
@@ -75,7 +75,7 @@ _API_ACTION_HANDLER_TYPE = Callable[
 # The type of (sync)handler builder function for StateTaskServiceGlue objects.
 _API_ACTION_HANDLER_BUILDER_TYPE = Callable[
     [Environment, ResourceRuntimePart, dict, StateCredentials],
-    Callable[[], Optional[Any]],
+    Callable[[], Any] | None,
 ]
 
 
@@ -83,7 +83,7 @@ class StateTaskServiceGlue(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _get_api_action_handler(self) -> _API_ACTION_HANDLER_TYPE:
@@ -179,7 +179,7 @@ class StateTaskServiceGlue(StateTaskServiceCallback):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         # Poll the job run state from glue, using GetJobRun until the job has terminated. Hence, append the output
         # of GetJobRun to the state.
 
@@ -194,7 +194,7 @@ class StateTaskServiceGlue(StateTaskServiceCallback):
             state_credentials=state_credentials,
         )
 
-        def _sync_resolver() -> Optional[Any]:
+        def _sync_resolver() -> Any | None:
             # Sample GetJobRun until completion.
             get_job_run_response: dict = glue_client.get_job_run(
                 JobName=job_name, RunId=job_run_id
@@ -244,7 +244,7 @@ class StateTaskServiceGlue(StateTaskServiceCallback):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         sync_resolver_builder = self._get_api_action_sync_builder_handler()
         sync_resolver = sync_resolver_builder(
             env, resource_runtime_part, normalised_parameters, state_credentials

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_lambda.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_lambda.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Final, Optional
+from typing import Final
 
 from botocore.exceptions import ClientError
 
@@ -49,7 +49,7 @@ class StateTaskServiceLambda(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     @staticmethod
@@ -104,8 +104,8 @@ class StateTaskServiceLambda(StateTaskServiceCallback):
     def _normalise_parameters(
         self,
         parameters: dict,
-        boto_service_name: Optional[str] = None,
-        service_action_name: Optional[str] = None,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
     ) -> None:
         # Run Payload value casting before normalisation.
         if "Payload" in parameters:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sfn.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sfn.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Callable
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from botocore.exceptions import ClientError
 
@@ -53,7 +53,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
@@ -92,8 +92,8 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
     def _normalise_parameters(
         self,
         parameters: dict,
-        boto_service_name: Optional[str] = None,
-        service_action_name: Optional[str] = None,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
     ) -> None:
         if service_action_name is None:
             if self._get_boto_service_action() == "start_execution":
@@ -118,7 +118,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         sfn_client = boto_client_for(
             service="stepfunctions",
             region=resource_runtime_part.region,
@@ -127,7 +127,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
         submission_output: dict = env.stack.pop()
         execution_arn: str = submission_output["ExecutionArn"]
 
-        def _sync_resolver() -> Optional[Any]:
+        def _sync_resolver() -> Any | None:
             describe_execution_output = sfn_client.describe_execution(
                 executionArn=execution_arn
             )
@@ -183,7 +183,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
         resource_runtime_part: ResourceRuntimePart,
         normalised_parameters: dict,
         state_credentials: StateCredentials,
-    ) -> Callable[[], Optional[Any]]:
+    ) -> Callable[[], Any] | None:
         sfn_client = boto_client_for(
             region=resource_runtime_part.region,
             service="stepfunctions",
@@ -192,7 +192,7 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
         submission_output: dict = env.stack.pop()
         execution_arn: str = submission_output["ExecutionArn"]
 
-        def _sync2_resolver() -> Optional[Any]:
+        def _sync2_resolver() -> Any | None:
             describe_execution_output = sfn_client.describe_execution(
                 executionArn=execution_arn
             )

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sns.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sns.py
@@ -1,4 +1,4 @@
-from typing import Final, Optional
+from typing import Final
 
 from botocore.exceptions import ClientError
 
@@ -46,7 +46,7 @@ class StateTaskServiceSns(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sqs.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sqs.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from botocore.exceptions import ClientError
 
@@ -45,7 +45,7 @@ class StateTaskServiceSqs(StateTaskServiceCallback):
     def __init__(self):
         super().__init__(supported_integration_patterns=_SUPPORTED_INTEGRATION_PATTERNS)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:
+    def _get_supported_parameters(self) -> set[str] | None:
         return _SUPPORTED_API_PARAM_BINDINGS.get(self.resource.api_action.lower())
 
     def _from_error(self, env: Environment, ex: Exception) -> FailureEvent:
@@ -70,8 +70,8 @@ class StateTaskServiceSqs(StateTaskServiceCallback):
     def _normalise_response(
         self,
         response: Any,
-        boto_service_name: Optional[str] = None,
-        service_action_name: Optional[str] = None,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
     ) -> None:
         super()._normalise_response(
             response=response,

--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/state_task.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/state_task.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-from typing import Optional
 
 from moto.stepfunctions.parser.api import HistoryEventType, TaskTimedOutEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
@@ -31,8 +30,8 @@ from moto.stepfunctions.parser.asl.eval.event.event_detail import EventDetails
 
 class StateTask(ExecutionState, abc.ABC):
     resource: Resource
-    parargs: Optional[Parargs]
-    credentials: Optional[Credentials]
+    parargs: Parargs | None
+    credentials: Credentials | None
 
     def __init__(self):
         super().__init__(
@@ -46,7 +45,7 @@ class StateTask(ExecutionState, abc.ABC):
         self.parargs = state_props.get(Parargs)
         self.credentials = state_props.get(Credentials)
 
-    def _get_supported_parameters(self) -> Optional[set[str]]:  # noqa
+    def _get_supported_parameters(self) -> set[str] | None:  # noqa
         return None
 
     def _eval_parameters(self, env: Environment) -> dict:

--- a/moto/stepfunctions/parser/asl/component/state/fail/state_fail.py
+++ b/moto/stepfunctions/parser/asl/component/state/fail/state_fail.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.stepfunctions.parser.api import HistoryEventType, TaskFailedEventDetails
 from moto.stepfunctions.parser.asl.component.common.error_name.custom_error_name import (
     CustomErrorName,
@@ -22,8 +20,8 @@ class StateFail(CommonStateField):
             state_entered_event_type=HistoryEventType.FailStateEntered,
             state_exited_event_type=None,
         )
-        self.cause: Optional[CauseDecl] = None
-        self.error: Optional[ErrorDecl] = None
+        self.cause: CauseDecl | None = None
+        self.error: ErrorDecl | None = None
 
     def from_state_props(self, state_props: StateProps) -> None:
         super().from_state_props(state_props)

--- a/moto/stepfunctions/parser/asl/component/state/state.py
+++ b/moto/stepfunctions/parser/asl/component/state/state.py
@@ -4,7 +4,7 @@ import abc
 import datetime
 import logging
 from abc import ABC
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.api import (
     ExecutionFailedEventDetails,
@@ -73,27 +73,27 @@ class CommonStateField(EvalComponent, ABC):
     continue_with: ContinueWith
 
     # Holds a human-readable description of the state.
-    comment: Optional[Comment]
+    comment: Comment | None
 
     # A path that selects a portion of the state's input to be passed to the state's state_task for processing.
     # If omitted, it has the value $ which designates the entire input.
-    input_path: Optional[InputPath]
+    input_path: InputPath | None
 
     # A path that selects a portion of the state's output to be passed to the next state.
     # If omitted, it has the value $ which designates the entire output.
-    output_path: Optional[OutputPath]
+    output_path: OutputPath | None
 
-    assign_decl: Optional[AssignDecl]
+    assign_decl: AssignDecl | None
 
-    output: Optional[Output]
+    output: Output | None
 
     state_entered_event_type: Final[HistoryEventType]
-    state_exited_event_type: Final[Optional[HistoryEventType]]
+    state_exited_event_type: Final[HistoryEventType] | None
 
     def __init__(
         self,
         state_entered_event_type: HistoryEventType,
-        state_exited_event_type: Optional[HistoryEventType],
+        state_exited_event_type: HistoryEventType | None,
     ):
         self.state_entered_event_type = state_entered_event_type
         self.state_exited_event_type = state_exited_event_type

--- a/moto/stepfunctions/parser/asl/component/state/state_pass/state_pass.py
+++ b/moto/stepfunctions/parser/asl/component/state/state_pass/state_pass.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.stepfunctions.parser.api import (
     HistoryEventType,
 )
@@ -21,17 +19,17 @@ class StatePass(CommonStateField):
         # Result (Optional)
         # Refers to the output of a virtual state_task that is passed on to the next state. If you include the ResultPath
         # field in your state machine definition, Result is placed as specified by ResultPath and passed on to the
-        self.result: Optional[Result] = None
+        self.result: Result | None = None
 
         # ResultPath (Optional)
         # Specifies where to place the output (relative to the input) of the virtual state_task specified in Result. The input
         # is further filtered as specified by the OutputPath field (if present) before being used as the state's output.
-        self.result_path: Optional[ResultPath] = None
+        self.result_path: ResultPath | None = None
 
         # Parameters (Optional)
         # Creates a collection of key-value pairs that will be passed as input. You can specify Parameters as a static
         # value or select from the input using a path.
-        self.parameters: Optional[Parameters] = None
+        self.parameters: Parameters | None = None
 
     def from_state_props(self, state_props: StateProps) -> None:
         super().from_state_props(state_props)

--- a/moto/stepfunctions/parser/asl/component/state/wait/wait_function/timestamp.py
+++ b/moto/stepfunctions/parser/asl/component/state/wait/wait_function/timestamp.py
@@ -1,6 +1,6 @@
 import datetime
 import re
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import ExecutionFailedEventDetails, HistoryEventType
 from moto.stepfunctions.parser.asl.component.common.error_name.failure_event import (
@@ -47,7 +47,7 @@ class Timestamp(WaitFunction):
         return re.match(TIMESTAMP_PATTERN, timestamp) is not None
 
     @staticmethod
-    def _from_timestamp_string(timestamp: str) -> Optional[datetime.datetime]:
+    def _from_timestamp_string(timestamp: str) -> datetime.datetime | None:
         if not Timestamp._is_valid_timestamp_pattern(timestamp):
             return None
         try:

--- a/moto/stepfunctions/parser/asl/eval/callback/callback.py
+++ b/moto/stepfunctions/parser/asl/eval/callback/callback.py
@@ -1,7 +1,7 @@
 import abc
 from collections import OrderedDict
 from threading import Event, Lock
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import ActivityDoesNotExist, Arn
 from moto.stepfunctions.parser.backend.activity import Activity, ActivityTask
@@ -26,12 +26,10 @@ class CallbackOutcomeSuccess(CallbackOutcome):
 
 
 class CallbackOutcomeFailure(CallbackOutcome):
-    error: Final[Optional[str]]
-    cause: Final[Optional[str]]
+    error: Final[str | None]
+    cause: Final[str | None]
 
-    def __init__(
-        self, callback_id: CallbackId, error: Optional[str], cause: Optional[str]
-    ):
+    def __init__(self, callback_id: CallbackId, error: str | None, cause: str | None):
         super().__init__(callback_id=callback_id)
         self.error = error
         self.cause = cause
@@ -87,20 +85,20 @@ class HeartbeatTimedOut(CallbackConsumerError):
 
 
 class ActivityTaskStartOutcome:
-    worker_name: Optional[str]
+    worker_name: str | None
 
-    def __init__(self, worker_name: Optional[str] = None):
+    def __init__(self, worker_name: str | None = None):
         self.worker_name = worker_name
 
 
 class ActivityTaskStartEndpoint:
     _next_activity_task_start_event: Final[Event]
-    _outcome: Optional[ActivityTaskStartOutcome]
+    _outcome: ActivityTaskStartOutcome | None
 
     def __init__(self):
         self._next_activity_task_start_event = Event()
 
-    def wait(self, timeout_seconds: float) -> Optional[ActivityTaskStartOutcome]:
+    def wait(self, timeout_seconds: float) -> ActivityTaskStartOutcome | None:
         self._next_activity_task_start_event.wait(timeout=timeout_seconds)
         return self._outcome
 
@@ -112,9 +110,9 @@ class ActivityTaskStartEndpoint:
 class CallbackEndpoint:
     callback_id: Final[CallbackId]
     _notify_event: Final[Event]
-    _outcome: Optional[CallbackOutcome]
-    consumer_error: Optional[CallbackConsumerError]
-    _heartbeat_endpoint: Optional[HeartbeatEndpoint]
+    _outcome: CallbackOutcome | None
+    consumer_error: CallbackConsumerError | None
+    _heartbeat_endpoint: HeartbeatEndpoint | None
 
     def __init__(self, callback_id: CallbackId):
         self.callback_id = callback_id
@@ -148,11 +146,11 @@ class CallbackEndpoint:
         self._heartbeat_endpoint.notify()
         return True
 
-    def wait(self, timeout: Optional[float] = None) -> Optional[CallbackOutcome]:
+    def wait(self, timeout: float | None = None) -> CallbackOutcome | None:
         self._notify_event.wait(timeout=timeout)
         return self._outcome
 
-    def get_outcome(self) -> Optional[CallbackOutcome]:
+    def get_outcome(self) -> CallbackOutcome | None:
         return self._outcome
 
     def report(self, consumer_error: CallbackConsumerError) -> None:
@@ -174,7 +172,7 @@ class ActivityCallbackEndpoint(CallbackEndpoint):
     def get_activity_task_start_endpoint(self) -> ActivityTaskStartEndpoint:
         return self._activity_task_start_endpoint
 
-    def notify_activity_task_start(self, worker_name: Optional[str]) -> None:
+    def notify_activity_task_start(self, worker_name: str | None) -> None:
         self._activity_task_start_endpoint.notify(
             ActivityTaskStartOutcome(worker_name=worker_name)
         )
@@ -202,7 +200,7 @@ class CallbackPoolManager:
         self._activity_store = activity_store
         self._pool = OrderedDict()
 
-    def get(self, callback_id: CallbackId) -> Optional[CallbackEndpoint]:
+    def get(self, callback_id: CallbackId) -> CallbackEndpoint | None:
         return self._pool.get(callback_id)
 
     def add(self, callback_id: CallbackId) -> CallbackEndpoint:
@@ -218,7 +216,7 @@ class CallbackPoolManager:
         if callback_id in self._pool:
             raise ValueError("Duplicate callback token id value.")
 
-        maybe_activity: Optional[Activity] = self._activity_store.get(activity_arn)
+        maybe_activity: Activity | None = self._activity_store.get(activity_arn)
         if maybe_activity is None:
             raise ActivityDoesNotExist()
 
@@ -240,9 +238,7 @@ class CallbackPoolManager:
         if callback_endpoint is None:
             return False
 
-        consumer_error: Optional[CallbackConsumerError] = (
-            callback_endpoint.consumer_error
-        )
+        consumer_error: CallbackConsumerError | None = callback_endpoint.consumer_error
         if consumer_error is not None:
             raise CallbackNotifyConsumerError(callback_consumer_error=consumer_error)
 
@@ -254,9 +250,7 @@ class CallbackPoolManager:
         if callback_endpoint is None:
             return False
 
-        consumer_error: Optional[CallbackConsumerError] = (
-            callback_endpoint.consumer_error
-        )
+        consumer_error: CallbackConsumerError | None = callback_endpoint.consumer_error
         if consumer_error is not None:
             raise CallbackNotifyConsumerError(callback_consumer_error=consumer_error)
 

--- a/moto/stepfunctions/parser/asl/eval/environment.py
+++ b/moto/stepfunctions/parser/asl/eval/environment.py
@@ -41,18 +41,18 @@ LOG = logging.getLogger(__name__)
 
 class Environment:
     _state_mutex: Final[threading.RLock()]
-    _program_state: Optional[ProgramState]
+    _program_state: ProgramState | None
     program_state_event: Final[threading.Event()]
 
     event_manager: EventManager
     event_history_context: Final[EventHistoryContext]
-    cloud_watch_logging_session: Final[Optional[CloudWatchLoggingSession]]
+    cloud_watch_logging_session: Final[CloudWatchLoggingSession | None]
     aws_execution_details: Final[AWSExecutionDetails]
     execution_type: Final[StateMachineType]
     callback_pool_manager: CallbackPoolManager
     map_run_record_pool_manager: MapRunRecordPoolManager
     activity_store: Final[dict[Arn, Activity]]
-    mock_test_case: Optional[MockTestCase] = None
+    mock_test_case: MockTestCase | None = None
 
     _frames: Final[list[Environment]]
     _is_frame: bool = False
@@ -68,10 +68,10 @@ class Environment:
         execution_type: StateMachineType,
         context: ContextObjectData,
         event_history_context: EventHistoryContext,
-        cloud_watch_logging_session: Optional[CloudWatchLoggingSession],
+        cloud_watch_logging_session: CloudWatchLoggingSession | None,
         activity_store: dict[Arn, Activity],
-        variable_store: Optional[VariableStore] = None,
-        mock_test_case: Optional[MockTestCase] = None,
+        variable_store: VariableStore | None = None,
+        mock_test_case: MockTestCase | None = None,
     ):
         super().__init__()
         self._state_mutex = threading.RLock()
@@ -105,7 +105,7 @@ class Environment:
     def as_frame_of(
         cls,
         env: Environment,
-        event_history_frame_cache: Optional[EventHistoryContext] = None,
+        event_history_frame_cache: EventHistoryContext | None = None,
     ) -> Environment:
         return Environment.as_inner_frame_of(
             env=env,
@@ -118,7 +118,7 @@ class Environment:
         cls,
         env: Environment,
         variable_store: VariableStore,
-        event_history_frame_cache: Optional[EventHistoryContext] = None,
+        event_history_frame_cache: EventHistoryContext | None = None,
     ) -> Environment:
         # Construct the frame's context object data.
         context = ContextObjectData(
@@ -157,8 +157,8 @@ class Environment:
         return frame
 
     @property
-    def next_state_name(self) -> Optional[str]:
-        next_state_name: Optional[str] = None
+    def next_state_name(self) -> str | None:
+        next_state_name: str | None = None
         program_state = self._program_state
         if isinstance(program_state, ProgramRunning):
             next_state_name = program_state.next_state_name
@@ -177,8 +177,8 @@ class Environment:
             )
 
     @property
-    def next_field_name(self) -> Optional[str]:
-        next_field_name: Optional[str] = None
+    def next_field_name(self) -> str | None:
+        next_field_name: str | None = None
         program_state = self._program_state
         if isinstance(program_state, ProgramRunning):
             next_field_name = program_state.next_field_name
@@ -225,7 +225,7 @@ class Environment:
             self.program_state_event.clear()
 
     def set_stop(
-        self, stop_date: Timestamp, cause: Optional[str], error: Optional[str]
+        self, stop_date: Timestamp, cause: str | None, error: str | None
     ) -> None:
         with self._state_mutex:
             if isinstance(self._program_state, ProgramRunning):
@@ -238,7 +238,7 @@ class Environment:
                 self.program_state_event.clear()
 
     def open_frame(
-        self, event_history_context: Optional[EventHistoryContext] = None
+        self, event_history_context: EventHistoryContext | None = None
     ) -> Environment:
         with self._state_mutex:
             frame = self.as_frame_of(
@@ -248,7 +248,7 @@ class Environment:
             return frame
 
     def open_inner_frame(
-        self, event_history_context: Optional[EventHistoryContext] = None
+        self, event_history_context: EventHistoryContext | None = None
     ) -> Environment:
         with self._state_mutex:
             variable_store = VariableStore.as_inner_scope_of(

--- a/moto/stepfunctions/parser/asl/eval/evaluation_details.py
+++ b/moto/stepfunctions/parser/asl/eval/evaluation_details.py
@@ -1,4 +1,4 @@
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.api import Arn, Definition, LongArn, StateMachineType
 
@@ -18,7 +18,7 @@ class ExecutionDetails:
     arn: Final[LongArn]
     name: Final[str]
     role_arn: Final[Arn]
-    inpt: Final[Optional[Any]]
+    inpt: Final[Any]
     start_time: Final[str]
 
     def __init__(
@@ -26,7 +26,7 @@ class ExecutionDetails:
         arn: LongArn,
         name: str,
         role_arn: Arn,
-        inpt: Optional[Any],
+        inpt: Any,
         start_time: str,
     ):
         self.arn = arn

--- a/moto/stepfunctions/parser/asl/eval/event/event_detail.py
+++ b/moto/stepfunctions/parser/asl/eval/event/event_detail.py
@@ -37,42 +37,42 @@ from moto.stepfunctions.parser.api import (
 
 
 class EventDetails(TypedDict):
-    activityFailedEventDetails: Optional[ActivityFailedEventDetails]
-    activityScheduleFailedEventDetails: Optional[ActivityScheduleFailedEventDetails]
-    activityScheduledEventDetails: Optional[ActivityScheduledEventDetails]
-    activityStartedEventDetails: Optional[ActivityStartedEventDetails]
-    activitySucceededEventDetails: Optional[ActivitySucceededEventDetails]
-    activityTimedOutEventDetails: Optional[ActivityTimedOutEventDetails]
-    taskFailedEventDetails: Optional[TaskFailedEventDetails]
-    taskScheduledEventDetails: Optional[TaskScheduledEventDetails]
-    taskStartFailedEventDetails: Optional[TaskStartFailedEventDetails]
-    taskStartedEventDetails: Optional[TaskStartedEventDetails]
-    taskSubmitFailedEventDetails: Optional[TaskSubmitFailedEventDetails]
-    taskSubmittedEventDetails: Optional[TaskSubmittedEventDetails]
-    taskSucceededEventDetails: Optional[TaskSucceededEventDetails]
-    taskTimedOutEventDetails: Optional[TaskTimedOutEventDetails]
-    evaluationFailedEventDetails: Optional[EvaluationFailedEventDetails]
-    executionFailedEventDetails: Optional[ExecutionFailedEventDetails]
-    executionStartedEventDetails: Optional[ExecutionStartedEventDetails]
-    executionSucceededEventDetails: Optional[ExecutionSucceededEventDetails]
-    executionAbortedEventDetails: Optional[ExecutionAbortedEventDetails]
-    executionTimedOutEventDetails: Optional[ExecutionTimedOutEventDetails]
-    mapStateStartedEventDetails: Optional[MapStateStartedEventDetails]
-    mapIterationStartedEventDetails: Optional[MapIterationEventDetails]
-    mapIterationSucceededEventDetails: Optional[MapIterationEventDetails]
-    mapIterationFailedEventDetails: Optional[MapIterationEventDetails]
-    mapIterationAbortedEventDetails: Optional[MapIterationEventDetails]
-    lambdaFunctionFailedEventDetails: Optional[LambdaFunctionFailedEventDetails]
+    activityFailedEventDetails: ActivityFailedEventDetails | None
+    activityScheduleFailedEventDetails: ActivityScheduleFailedEventDetails | None
+    activityScheduledEventDetails: ActivityScheduledEventDetails | None
+    activityStartedEventDetails: ActivityStartedEventDetails | None
+    activitySucceededEventDetails: ActivitySucceededEventDetails | None
+    activityTimedOutEventDetails: ActivityTimedOutEventDetails | None
+    taskFailedEventDetails: TaskFailedEventDetails | None
+    taskScheduledEventDetails: TaskScheduledEventDetails | None
+    taskStartFailedEventDetails: TaskStartFailedEventDetails | None
+    taskStartedEventDetails: TaskStartedEventDetails | None
+    taskSubmitFailedEventDetails: TaskSubmitFailedEventDetails | None
+    taskSubmittedEventDetails: TaskSubmittedEventDetails | None
+    taskSucceededEventDetails: TaskSucceededEventDetails | None
+    taskTimedOutEventDetails: TaskTimedOutEventDetails | None
+    evaluationFailedEventDetails: EvaluationFailedEventDetails | None
+    executionFailedEventDetails: ExecutionFailedEventDetails | None
+    executionStartedEventDetails: ExecutionStartedEventDetails | None
+    executionSucceededEventDetails: ExecutionSucceededEventDetails | None
+    executionAbortedEventDetails: ExecutionAbortedEventDetails | None
+    executionTimedOutEventDetails: ExecutionTimedOutEventDetails | None
+    mapStateStartedEventDetails: MapStateStartedEventDetails | None
+    mapIterationStartedEventDetails: MapIterationEventDetails | None
+    mapIterationSucceededEventDetails: MapIterationEventDetails | None
+    mapIterationFailedEventDetails: MapIterationEventDetails | None
+    mapIterationAbortedEventDetails: MapIterationEventDetails | None
+    lambdaFunctionFailedEventDetails: LambdaFunctionFailedEventDetails | None
     lambdaFunctionScheduleFailedEventDetails: Optional[
         LambdaFunctionScheduleFailedEventDetails
     ]
-    lambdaFunctionScheduledEventDetails: Optional[LambdaFunctionScheduledEventDetails]
+    lambdaFunctionScheduledEventDetails: LambdaFunctionScheduledEventDetails | None
     lambdaFunctionStartFailedEventDetails: Optional[
         LambdaFunctionStartFailedEventDetails
     ]
-    lambdaFunctionSucceededEventDetails: Optional[LambdaFunctionSucceededEventDetails]
-    lambdaFunctionTimedOutEventDetails: Optional[LambdaFunctionTimedOutEventDetails]
-    stateEnteredEventDetails: Optional[StateEnteredEventDetails]
-    stateExitedEventDetails: Optional[StateExitedEventDetails]
-    mapRunStartedEventDetails: Optional[MapRunStartedEventDetails]
-    mapRunFailedEventDetails: Optional[MapRunFailedEventDetails]
+    lambdaFunctionSucceededEventDetails: LambdaFunctionSucceededEventDetails | None
+    lambdaFunctionTimedOutEventDetails: LambdaFunctionTimedOutEventDetails | None
+    stateEnteredEventDetails: StateEnteredEventDetails | None
+    stateExitedEventDetails: StateExitedEventDetails | None
+    mapRunStartedEventDetails: MapRunStartedEventDetails | None
+    mapRunFailedEventDetails: MapRunFailedEventDetails | None

--- a/moto/stepfunctions/parser/asl/eval/event/event_manager.py
+++ b/moto/stepfunctions/parser/asl/eval/event/event_manager.py
@@ -4,7 +4,7 @@ import copy
 import datetime
 import logging
 import threading
-from typing import Final, Optional
+from typing import Final
 
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.stepfunctions.parser.api import (
@@ -62,10 +62,10 @@ class EventManager:
     _mutex: Final[threading.Lock]
     _event_id_gen: EventIdGenerator
     _history_event_list: Final[HistoryEventList]
-    _cloud_watch_logging_session: Final[Optional[CloudWatchLoggingSession]]
+    _cloud_watch_logging_session: Final[CloudWatchLoggingSession | None]
 
     def __init__(
-        self, cloud_watch_logging_session: Optional[CloudWatchLoggingSession] = None
+        self, cloud_watch_logging_session: CloudWatchLoggingSession | None = None
     ):
         self._mutex = threading.Lock()
         self._event_id_gen = EventIdGenerator()
@@ -76,7 +76,7 @@ class EventManager:
         self,
         context: EventHistoryContext,
         event_type: HistoryEventType,
-        event_details: Optional[EventDetails] = None,
+        event_details: EventDetails | None = None,
         timestamp: Timestamp = None,
         update_source_event_id: bool = True,
     ) -> int:
@@ -117,7 +117,7 @@ class EventManager:
         source_event_id: int,
         event_type: HistoryEventType,
         timestamp: datetime.datetime,
-        event_details: Optional[EventDetails],
+        event_details: EventDetails | None,
     ) -> HistoryEvent:
         history_event = HistoryEvent()
         if event_details is not None:
@@ -134,7 +134,7 @@ class EventManager:
         source_event_id: int,
         event_type: HistoryEventType,
         timestamp: datetime.datetime,
-        event_details: Optional[EventDetails],
+        event_details: EventDetails | None,
     ):
         history_event = self._create_history_event(
             event_id=event_id,
@@ -158,7 +158,7 @@ class EventManager:
         event_type: HistoryEventType,
         timestamp: datetime.datetime,
         execution_arn: LongArn,
-        event_details: Optional[EventDetails],
+        event_details: EventDetails | None,
         include_execution_data: bool,
     ) -> HistoryLog:
         log = HistoryLog(
@@ -188,7 +188,7 @@ class EventManager:
         source_event_id: int,
         event_type: HistoryEventType,
         timestamp: datetime.datetime,
-        event_details: Optional[EventDetails],
+        event_details: EventDetails | None,
     ):
         # No logging session for this execution.
         if self._cloud_watch_logging_session is None:

--- a/moto/stepfunctions/parser/asl/eval/event/logging.py
+++ b/moto/stepfunctions/parser/asl/eval/event/logging.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Final, Optional, TypedDict
+from typing import Any, Final, TypedDict
 
 from botocore.client import BaseClient
 from botocore.exceptions import ClientError
@@ -109,7 +109,7 @@ class CloudWatchLoggingConfiguration:
     @staticmethod
     def extract_log_arn_parts_from(
         logging_configuration: LoggingConfiguration,
-    ) -> Optional[tuple[str, str, str]]:
+    ) -> tuple[str, str, str] | None:
         # Returns a tuple with: account_id, region, and log group name if the logging configuration
         # specifies a valid cloud watch log group arn, none otherwise.
 
@@ -155,7 +155,7 @@ class CloudWatchLoggingConfiguration:
     def from_logging_configuration(
         state_machine_arn: LongArn,
         logging_configuration: LoggingConfiguration,
-    ) -> Optional[CloudWatchLoggingConfiguration]:
+    ) -> CloudWatchLoggingConfiguration | None:
         log_level = logging_configuration.get("level", LogLevel.OFF)
         if log_level == LogLevel.OFF:
             return None
@@ -188,7 +188,7 @@ class HistoryLog(TypedDict):
     event_timestamp: datetime
     type: HistoryEventType
     execution_arn: LongArn
-    details: Optional[ExecutionEventLogDetails]
+    details: ExecutionEventLogDetails | None
 
 
 class CloudWatchLoggingSession:

--- a/moto/stepfunctions/parser/asl/eval/program_state.py
+++ b/moto/stepfunctions/parser/asl/eval/program_state.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import ExecutionFailedEventDetails, Timestamp
 
@@ -12,18 +12,16 @@ class ProgramEnded(ProgramState):
 
 
 class ProgramStopped(ProgramState):
-    def __init__(
-        self, stop_date: Timestamp, error: Optional[str], cause: Optional[str]
-    ):
+    def __init__(self, stop_date: Timestamp, error: str | None, cause: str | None):
         super().__init__()
         self.stop_date: Timestamp = stop_date
-        self.error: Optional[str] = error
-        self.cause: Optional[str] = cause
+        self.error: str | None = error
+        self.cause: str | None = cause
 
 
 class ProgramRunning(ProgramState):
-    _next_state_name: Optional[str]
-    _next_field_name: Optional[str]
+    _next_state_name: str | None
+    _next_field_name: str | None
 
     def __init__(self):
         super().__init__()
@@ -59,9 +57,9 @@ class ProgramRunning(ProgramState):
 
 
 class ProgramError(ProgramState):
-    error: Final[Optional[ExecutionFailedEventDetails]]
+    error: Final[ExecutionFailedEventDetails | None]
 
-    def __init__(self, error: Optional[ExecutionFailedEventDetails]):
+    def __init__(self, error: ExecutionFailedEventDetails | None):
         super().__init__()
         self.error = error
 

--- a/moto/stepfunctions/parser/asl/eval/states.py
+++ b/moto/stepfunctions/parser/asl/eval/states.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Any, Final, Optional, TypedDict
+from typing import Any, Final, TypedDict
 
 from moto.stepfunctions.parser.asl.jsonata.jsonata import (
     VariableDeclarations,
@@ -18,7 +18,7 @@ _STATES_ERROR_OUTPUT_PREFIX: Final[str] = "$states.errorOutput"
 
 class ExecutionData(TypedDict):
     Id: str
-    Input: Optional[Any]
+    Input: Any | None
     Name: str
     RoleArn: str
     StartTime: str  # Format: ISO 8601.
@@ -43,7 +43,7 @@ class ItemData(TypedDict):
     # Contains the index number for the array item that is being currently processed.
     Index: int
     # Contains the array item being processed.
-    Value: Optional[Any]
+    Value: Any | None
 
 
 class MapData(TypedDict):
@@ -52,10 +52,10 @@ class MapData(TypedDict):
 
 class ContextObjectData(TypedDict):
     Execution: ExecutionData
-    State: Optional[StateData]
+    State: StateData | None
     StateMachine: StateMachineData
-    Task: Optional[TaskData]  # Null if the Parameters field is outside a task state.
-    Map: Optional[MapData]  # Only available when processing a Map state.
+    Task: TaskData | None  # Null if the Parameters field is outside a task state.
+    Map: MapData | None  # Only available when processing a Map state.
 
 
 class ContextObject:
@@ -73,8 +73,8 @@ class ContextObject:
 class StatesData(TypedDict):
     input: Any
     context: ContextObjectData
-    result: Optional[Optional[Any]]
-    errorOutput: Optional[Optional[Any]]
+    result: Any
+    errorOutput: Any
 
 
 class States:
@@ -87,7 +87,7 @@ class States:
         self.context_object = ContextObject(context_object=context)
 
     @staticmethod
-    def _extract(query: Optional[str], data: Any) -> Any:
+    def _extract(query: str | None, data: Any) -> Any:
         if query is None:
             result = data
         else:
@@ -100,7 +100,7 @@ class States:
         jsonpath_states_query = "$." + query[1:]
         return self._extract(jsonpath_states_query, self._states_data)
 
-    def get_input(self, query: Optional[str] = None) -> Any:
+    def get_input(self, query: str | None = None) -> Any:
         return self._extract(query, self._states_data["input"])
 
     def reset(self, input_value: Any) -> None:
@@ -109,10 +109,10 @@ class States:
         self._states_data["result"] = None
         self._states_data["errorOutput"] = None
 
-    def get_context(self, query: Optional[str] = None) -> Any:
+    def get_context(self, query: str | None = None) -> Any:
         return self._extract(query, self._states_data["context"])
 
-    def get_result(self, query: Optional[str] = None) -> Any:
+    def get_result(self, query: str | None = None) -> Any:
         if "result" not in self._states_data:
             raise RuntimeError("Illegal access to $states.result")
         return self._extract(query, self._states_data["result"])
@@ -121,7 +121,7 @@ class States:
         clone_result = copy.deepcopy(result)
         self._states_data["result"] = clone_result
 
-    def get_error_output(self, query: Optional[str] = None) -> Any:
+    def get_error_output(self, query: str | None = None) -> Any:
         if "errorOutput" not in self._states_data:
             raise RuntimeError("Illegal access to $states.errorOutput")
         return self._extract(query, self._states_data["errorOutput"])
@@ -131,7 +131,7 @@ class States:
         self._states_data["errorOutput"] = clone_error_output
 
     def to_variable_declarations(
-        self, variable_references: Optional[set[VariableReference]] = None
+        self, variable_references: set[VariableReference] | None = None
     ) -> VariableDeclarations:
         if not variable_references or _STATES_PREFIX in variable_references:
             return encode_jsonata_variable_declarations(

--- a/moto/stepfunctions/parser/asl/eval/test_state/environment.py
+++ b/moto/stepfunctions/parser/asl/eval/test_state/environment.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional
-
 from moto.stepfunctions.parser.api import Arn, InspectionData, StateMachineType
 from moto.stepfunctions.parser.asl.eval.environment import Environment
 from moto.stepfunctions.parser.asl.eval.evaluation_details import AWSExecutionDetails
@@ -32,7 +30,7 @@ class TestStateEnvironment(Environment):
         context: ContextObjectData,
         event_history_context: EventHistoryContext,
         activity_store: dict[Arn, Activity],
-        cloud_watch_logging_session: Optional[CloudWatchLoggingSession] = None,
+        cloud_watch_logging_session: CloudWatchLoggingSession | None = None,
     ):
         super().__init__(
             aws_execution_details=aws_execution_details,
@@ -47,7 +45,7 @@ class TestStateEnvironment(Environment):
     def as_frame_of(
         cls,
         env: TestStateEnvironment,
-        event_history_frame_cache: Optional[EventHistoryContext] = None,
+        event_history_frame_cache: EventHistoryContext | None = None,
     ) -> Environment:
         frame = super().as_frame_of(
             env=env, event_history_frame_cache=event_history_frame_cache
@@ -59,7 +57,7 @@ class TestStateEnvironment(Environment):
         cls,
         env: TestStateEnvironment,
         variable_store: VariableStore,
-        event_history_frame_cache: Optional[EventHistoryContext] = None,
+        event_history_frame_cache: EventHistoryContext | None = None,
     ) -> Environment:
         frame = super().as_inner_frame_of(
             env=env,

--- a/moto/stepfunctions/parser/asl/eval/variable_store.py
+++ b/moto/stepfunctions/parser/asl/eval/variable_store.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.jsonata.jsonata import (
     VariableDeclarations,
@@ -53,8 +53,8 @@ class VariableStore:
 
     _declaration_tracing: Final[set[str]]
 
-    _outer_variable_declaration_cache: Optional[VariableDeclarations]
-    _variable_declarations_cache: Optional[VariableDeclarations]
+    _outer_variable_declaration_cache: VariableDeclarations | None
+    _variable_declarations_cache: VariableDeclarations | None
 
     def __init__(self):
         self._outer_scope = {}

--- a/moto/stepfunctions/parser/asl/jsonata/jsonata.py
+++ b/moto/stepfunctions/parser/asl/jsonata/jsonata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Callable
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from moto.stepfunctions.parser.asl.utils.encoding import to_json_str
 
@@ -40,9 +40,9 @@ _EXPRESSION_CLOSE_SYMBOL: Final[str] = ")"
 
 class JSONataException(Exception):
     error: Final[str]
-    details: Optional[str]
+    details: str | None
 
-    def __init__(self, error: str, details: Optional[str]):
+    def __init__(self, error: str, details: str | None):
         self.error = error
         self.details = details
 
@@ -83,7 +83,7 @@ class _JSONataJVMBridge:
 
 # Lazy initialization of the `eval_jsonata` function pointer.
 # This ensures the JVM is only started when JSONata functionality is needed.
-_eval_jsonata: Optional[Callable[[JSONataExpression], Any]] = None
+_eval_jsonata: Callable[[JSONataExpression], Any] | None = None
 
 
 def eval_jsonata_expression(jsonata_expression: JSONataExpression) -> Any:

--- a/moto/stepfunctions/parser/asl/parse/intrinsic/preprocessor.py
+++ b/moto/stepfunctions/parser/asl/parse/intrinsic/preprocessor.py
@@ -1,5 +1,4 @@
 import re
-from typing import Optional
 
 from antlr4.tree.Tree import ParseTree, TerminalNodeImpl
 
@@ -100,7 +99,7 @@ class Preprocessor(ASLIntrinsicParserVisitor):
     ) -> ArgumentList:
         arguments: list[Argument] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, Argument):
                 arguments.append(cmp)
         return ArgumentList(arguments=arguments)

--- a/moto/stepfunctions/parser/asl/parse/preprocessor.py
+++ b/moto/stepfunctions/parser/asl/parse/preprocessor.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from antlr4 import ParserRuleContext
 from antlr4.tree.Tree import ParseTree, TerminalNodeImpl
@@ -396,7 +396,7 @@ class Preprocessor(ASLParserVisitor):
             )
 
     @staticmethod
-    def _inner_string_of(parser_rule_context: ParserRuleContext) -> Optional[str]:
+    def _inner_string_of(parser_rule_context: ParserRuleContext) -> str | None:
         if is_terminal(parser_rule_context, ASLLexer.NULL):
             return None
         inner_str = parser_rule_context.getText()
@@ -430,7 +430,7 @@ class Preprocessor(ASLParserVisitor):
     def visitStates_decl(self, ctx: ASLParser.States_declContext) -> States:
         states = States()
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, CommonStateField):
                 # TODO move check to setter or checker layer?
                 if cmp.name in states.states:
@@ -451,7 +451,7 @@ class Preprocessor(ASLParserVisitor):
 
     def visitEnd_decl(self, ctx: ASLParser.End_declContext) -> End:
         bool_child: ParseTree = ctx.children[-1]
-        bool_term: Optional[TerminalNodeImpl] = is_terminal(bool_child)
+        bool_term: TerminalNodeImpl | None = is_terminal(bool_child)
         if bool_term is None:
             raise ValueError(
                 f"Could not derive End from declaration context '{ctx.getText()}'"
@@ -474,7 +474,7 @@ class Preprocessor(ASLParserVisitor):
         return ResultPath(result_path_src=inner_str)
 
     def visitInput_path_decl(self, ctx: ASLParser.Input_path_declContext) -> InputPath:
-        string_sampler: Optional[StringSampler] = None
+        string_sampler: StringSampler | None = None
         if not is_terminal(pt=ctx.children[-1], token_type=ASLLexer.NULL):
             string_sampler: StringSampler = self.visitString_sampler(
                 ctx.string_sampler()
@@ -487,7 +487,7 @@ class Preprocessor(ASLParserVisitor):
         self._raise_if_query_language_is_not(
             query_language_mode=QueryLanguageMode.JSONPath, ctx=ctx
         )
-        string_sampler: Optional[StringSampler] = None
+        string_sampler: StringSampler | None = None
         if is_production(ctx.children[-1], ASLParser.RULE_string_sampler):
             string_sampler: StringSampler = self.visitString_sampler(ctx.children[-1])
         return OutputPath(string_sampler=string_sampler)
@@ -559,7 +559,7 @@ class Preprocessor(ASLParserVisitor):
     def visitBranches_decl(self, ctx: ASLParser.Branches_declContext) -> BranchesDecl:
         programs: list[Program] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, Program):
                 programs.append(cmp)
         return BranchesDecl(programs=programs)
@@ -568,7 +568,7 @@ class Preprocessor(ASLParserVisitor):
         self._open_query_language_scope(ctx)
         state_props = StateProps()
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             state_props.add(cmp)
         if state_props.get(QueryLanguage) is None:
             state_props.add(self._get_current_query_language())
@@ -619,7 +619,7 @@ class Preprocessor(ASLParserVisitor):
             query_language_mode=QueryLanguageMode.JSONata, ctx=ctx
         )
         bool_child: ParseTree = ctx.children[-1]
-        bool_term: Optional[TerminalNodeImpl] = is_terminal(bool_child)
+        bool_term: TerminalNodeImpl | None = is_terminal(bool_child)
         if bool_term is None:
             raise ValueError(
                 f"Could not derive boolean literal from declaration context '{ctx.getText()}'."
@@ -695,7 +695,7 @@ class Preprocessor(ASLParserVisitor):
         self._raise_if_query_language_is_not(
             query_language_mode=QueryLanguageMode.JSONPath, ctx=ctx
         )
-        pt: Optional[TerminalNodeImpl] = is_terminal(ctx.children[0])
+        pt: TerminalNodeImpl | None = is_terminal(ctx.children[0])
         if not pt:
             raise ValueError(
                 f"Could not derive ChoiceOperator in block '{ctx.getText()}'."
@@ -708,7 +708,7 @@ class Preprocessor(ASLParserVisitor):
         choice_op: ComparisonComposite.ChoiceOp = self.visit(ctx.choice_operator())
         rules: list[ChoiceRule] = []
         for child in ctx.children[1:]:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if not cmp:
                 continue
             elif isinstance(cmp, ChoiceRule):
@@ -730,7 +730,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> ChoiceRule:
         composite_stmts = ComparisonCompositeProps()
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             composite_stmts.add(cmp)
         return ChoiceRule(
             comparison=composite_stmts.get(
@@ -750,7 +750,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> ChoiceRule:
         comparison_stmts = StateProps()
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             comparison_stmts.add(cmp)
         if self._is_query_language(query_language_mode=QueryLanguageMode.JSONPath):
             variable: Variable = comparison_stmts.get(
@@ -797,7 +797,7 @@ class Preprocessor(ASLParserVisitor):
     def visitChoices_decl(self, ctx: ASLParser.Choices_declContext) -> ChoicesDecl:
         rules: list[ChoiceRule] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if not cmp:
                 continue
             elif isinstance(cmp, ChoiceRule):
@@ -1168,7 +1168,7 @@ class Preprocessor(ASLParserVisitor):
     def visitRetry_decl(self, ctx: ASLParser.Retry_declContext) -> RetryDecl:
         retriers: list[RetrierDecl] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, RetrierDecl):
                 retriers.append(cmp)
         return RetryDecl(retriers=retriers)
@@ -1176,7 +1176,7 @@ class Preprocessor(ASLParserVisitor):
     def visitRetrier_decl(self, ctx: ASLParser.Retrier_declContext) -> RetrierDecl:
         props = RetrierProps()
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             props.add(cmp)
         return RetrierDecl.from_retrier_props(props=props)
 
@@ -1197,7 +1197,7 @@ class Preprocessor(ASLParserVisitor):
         pt = ctx.children[0]
 
         # Case: StatesErrorName.
-        prc: Optional[ParserRuleContext] = is_production(
+        prc: ParserRuleContext | None = is_production(
             pt=pt, rule_index=ASLParser.RULE_states_error_name
         )
         if prc:
@@ -1210,7 +1210,7 @@ class Preprocessor(ASLParserVisitor):
     def visitStates_error_name(
         self, ctx: ASLParser.States_error_nameContext
     ) -> StatesErrorName:
-        pt: Optional[TerminalNodeImpl] = is_terminal(ctx.children[0])
+        pt = is_terminal(ctx.children[0])
         if not pt:
             raise ValueError(f"Could not derive ErrorName in block '{ctx.getText()}'.")
         states_error_name_type = StatesErrorNameType(pt.symbol.type)
@@ -1240,7 +1240,7 @@ class Preprocessor(ASLParserVisitor):
         self, ctx: ASLParser.Jitter_strategy_declContext
     ) -> JitterStrategyDecl:
         last_child: ParseTree = ctx.children[-1]
-        strategy_child: Optional[TerminalNodeImpl] = is_terminal(last_child)
+        strategy_child: TerminalNodeImpl | None = is_terminal(last_child)
         strategy_value = strategy_child.getSymbol().type
         jitter_strategy = JitterStrategy(strategy_value)
         return JitterStrategyDecl(jitter_strategy=jitter_strategy)
@@ -1248,7 +1248,7 @@ class Preprocessor(ASLParserVisitor):
     def visitCatch_decl(self, ctx: ASLParser.Catch_declContext) -> CatchDecl:
         catchers: list[CatcherDecl] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, CatcherDecl):
                 catchers.append(cmp)
         return CatchDecl(catchers=catchers)
@@ -1256,7 +1256,7 @@ class Preprocessor(ASLParserVisitor):
     def visitCatcher_decl(self, ctx: ASLParser.Catcher_declContext) -> CatcherDecl:
         props = CatcherProps()
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             props.add(cmp)
         if self._is_query_language(QueryLanguageMode.JSONPath) and not props.get(
             ResultPath
@@ -1278,7 +1278,7 @@ class Preprocessor(ASLParserVisitor):
         self, ctx: ASLParser.Payload_value_boolContext
     ) -> PayloadValueBool:
         bool_child: ParseTree = ctx.children[0]
-        bool_term: Optional[TerminalNodeImpl] = is_terminal(bool_child)
+        bool_term: TerminalNodeImpl | None = is_terminal(bool_child)
         if bool_term is None:
             raise ValueError(
                 f"Could not derive PayloadValueBool from declaration context '{ctx.getText()}'."
@@ -1330,7 +1330,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> PayloadArr:
         payload_values: list[PayloadValue] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, PayloadValue):
                 payload_values.append(cmp)
         return PayloadArr(payload_values=payload_values)
@@ -1340,7 +1340,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> PayloadTmpl:
         payload_bindings: list[PayloadBinding] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, PayloadBinding):
                 payload_bindings.append(cmp)
         return PayloadTmpl(payload_bindings=payload_bindings)
@@ -1355,7 +1355,7 @@ class Preprocessor(ASLParserVisitor):
         self._open_query_language_scope(ctx)
         props = TypedProps()
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             props.add(cmp)
         if props.get(QueryLanguage) is None:
             props.add(self._get_current_query_language())
@@ -1446,7 +1446,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> AssignTemplateValueArray:
         values: list[AssignTemplateValue] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, AssignTemplateValue):
                 values.append(cmp)
         return AssignTemplateValueArray(values=values)
@@ -1456,7 +1456,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> AssignTemplateValueObject:
         bindings: list[AssignTemplateBinding] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, AssignTemplateBinding):
                 bindings.append(cmp)
         return AssignTemplateValueObject(bindings=bindings)
@@ -1495,7 +1495,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> list[AssignDeclBinding]:
         bindings: list[AssignDeclBinding] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, AssignDeclBinding):
                 bindings.append(cmp)
         return bindings
@@ -1552,7 +1552,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> JSONataTemplateValueArray:
         values: list[JSONataTemplateValue] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, JSONataTemplateValue):
                 values.append(cmp)
         return JSONataTemplateValueArray(values=values)
@@ -1562,7 +1562,7 @@ class Preprocessor(ASLParserVisitor):
     ) -> JSONataTemplateValueObject:
         bindings: list[JSONataTemplateBinding] = []
         for child in ctx.children:
-            cmp: Optional[Component] = self.visit(child)
+            cmp: Component | None = self.visit(child)
             if isinstance(cmp, JSONataTemplateBinding):
                 bindings.append(cmp)
         return JSONataTemplateValueObject(bindings=bindings)

--- a/moto/stepfunctions/parser/asl/parse/typed_props.py
+++ b/moto/stepfunctions/parser/asl/parse/typed_props.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Any, Optional
+from typing import Any
 
 
 class TypedProps:
@@ -18,9 +18,7 @@ class TypedProps:
             )
         self._instance_by_type[typ] = instance
 
-    def get(
-        self, typ: type, raise_on_missing: Optional[Exception] = None
-    ) -> Optional[Any]:
+    def get(self, typ: type, raise_on_missing: Exception | None = None) -> Any | None:
         if raise_on_missing and typ not in self._instance_by_type:
             raise raise_on_missing
         return self._instance_by_type.get(typ)

--- a/moto/stepfunctions/parser/asl/utils/encoding.py
+++ b/moto/stepfunctions/parser/asl/utils/encoding.py
@@ -1,7 +1,7 @@
 import datetime
 import json
 from json import JSONEncoder
-from typing import Any, Optional
+from typing import Any
 
 
 class _DateTimeEncoder(JSONEncoder):
@@ -12,5 +12,5 @@ class _DateTimeEncoder(JSONEncoder):
             return str(o)
 
 
-def to_json_str(obj: Any, separators: Optional[tuple[str, str]] = None) -> str:
+def to_json_str(obj: Any, separators: tuple[str, str] | None = None) -> str:
     return json.dumps(obj, cls=_DateTimeEncoder, separators=separators)

--- a/moto/stepfunctions/parser/asl/utils/json_path.py
+++ b/moto/stepfunctions/parser/asl/utils/json_path.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 from jsonpath_ng.ext import parse
 from jsonpath_ng.jsonpath import Index
@@ -26,7 +26,7 @@ def _contains_slice_or_wildcard_array(path: str) -> bool:
 class NoSuchJsonPathError(Exception):
     json_path: Final[str]
     data: Final[Any]
-    _message: Optional[str]
+    _message: str | None
 
     def __init__(self, json_path: str, data: Any):
         self.json_path = json_path

--- a/moto/stepfunctions/parser/backend/activity.py
+++ b/moto/stepfunctions/parser/backend/activity.py
@@ -1,6 +1,6 @@
 import datetime
 from collections import deque
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import (
     ActivityListItem,
@@ -26,7 +26,7 @@ class Activity:
     creation_date: Final[Timestamp]
     _tasks: Final[deque[ActivityTask]]
 
-    def __init__(self, arn: Arn, name: Name, creation_date: Optional[Timestamp] = None):
+    def __init__(self, arn: Arn, name: Name, creation_date: Timestamp | None = None):
         self.arn = arn
         self.name = name
         self.creation_date = creation_date or datetime.datetime.now(
@@ -37,7 +37,7 @@ class Activity:
     def add_task(self, task: ActivityTask):
         self._tasks.append(task)
 
-    def get_task(self) -> Optional[ActivityTask]:
+    def get_task(self) -> ActivityTask | None:
         return self._tasks.popleft()
 
     def to_describe_activity_output(self) -> DescribeActivityOutput:

--- a/moto/stepfunctions/parser/backend/alias.py
+++ b/moto/stepfunctions/parser/backend/alias.py
@@ -4,7 +4,7 @@ import copy
 import datetime
 import random
 import threading
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import (
     AliasDescription,
@@ -20,9 +20,9 @@ from moto.stepfunctions.parser.utils import token_generator
 
 class Alias:
     _mutex: Final[threading.Lock]
-    update_date: Optional[datetime.datetime]
+    update_date: datetime.datetime | None
     name: Final[CharacterRestrictedName]
-    _description: Optional[AliasDescription]
+    _description: AliasDescription | None
     _routing_configuration_list: RoutingConfigurationList
     _state_machine_version_arns: list[Arn]
     _execution_probability_distribution: list[int]
@@ -34,7 +34,7 @@ class Alias:
         self,
         state_machine_arn: Arn,
         name: CharacterRestrictedName,
-        description: Optional[AliasDescription],
+        description: AliasDescription | None,
         routing_configuration_list: RoutingConfigurationList,
     ):
         self._mutex = threading.Lock()
@@ -82,7 +82,7 @@ class Alias:
 
     def update(
         self,
-        description: Optional[AliasDescription],
+        description: AliasDescription | None,
         routing_configuration_list: RoutingConfigurationList,
     ) -> None:
         with self._mutex:

--- a/moto/stepfunctions/parser/backend/execution.py
+++ b/moto/stepfunctions/parser/backend/execution.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-from typing import Optional
 
 from moto.stepfunctions.parser.api import (
     Arn,
@@ -103,21 +102,21 @@ class Execution:
 
     state_machine: StateMachineInstance
     start_date: Timestamp
-    input_data: Optional[json]
-    input_details: Optional[CloudWatchEventsExecutionDataDetails]
-    trace_header: Optional[TraceHeader]
-    _cloud_watch_logging_session: Optional[CloudWatchLoggingSession]
+    input_data: json | None
+    input_details: CloudWatchEventsExecutionDataDetails | None
+    trace_header: TraceHeader | None
+    _cloud_watch_logging_session: CloudWatchLoggingSession | None
 
-    exec_status: Optional[ExecutionStatus]
-    stop_date: Optional[Timestamp]
+    exec_status: ExecutionStatus | None
+    stop_date: Timestamp | None
 
-    output: Optional[json]
-    output_details: Optional[CloudWatchEventsExecutionDataDetails]
+    output: json | None
+    output_details: CloudWatchEventsExecutionDataDetails | None
 
-    error: Optional[SensitiveError]
-    cause: Optional[SensitiveCause]
+    error: SensitiveError | None
+    cause: SensitiveCause | None
 
-    exec_worker: Optional[ExecutionWorker]
+    exec_worker: ExecutionWorker | None
 
     _activity_store: dict[Arn, Activity]
 
@@ -131,10 +130,10 @@ class Execution:
         region_name: str,
         state_machine: StateMachineInstance,
         start_date: Timestamp,
-        cloud_watch_logging_session: Optional[CloudWatchLoggingSession],
+        cloud_watch_logging_session: CloudWatchLoggingSession | None,
         activity_store: dict[Arn, Activity],
         input_data: str,
-        trace_header: Optional[TraceHeader] = None,
+        trace_header: TraceHeader | None = None,
     ):
         self.name = name
         self.sm_type = sm_type
@@ -295,10 +294,8 @@ class Execution:
         self.exec_status = ExecutionStatus.RUNNING
         self.exec_worker.start()
 
-    def stop(
-        self, stop_date: datetime.datetime, error: Optional[str], cause: Optional[str]
-    ):
-        exec_worker: Optional[ExecutionWorker] = self.exec_worker
+    def stop(self, stop_date: datetime.datetime, error: str | None, cause: str | None):
+        exec_worker: ExecutionWorker | None = self.exec_worker
         if exec_worker:
             exec_worker.stop(stop_date=stop_date, cause=cause, error=error)
 
@@ -318,7 +315,7 @@ class SyncExecutionWorkerCommunication(BaseExecutionWorkerCommunication):
 
 
 class SyncExecution(Execution):
-    sync_execution_status: Optional[SyncExecutionStatus] = None
+    sync_execution_status: SyncExecutionStatus | None = None
 
     def _get_start_execution_worker(self) -> SyncExecutionWorker:
         return SyncExecutionWorker(

--- a/moto/stepfunctions/parser/backend/execution_worker.py
+++ b/moto/stepfunctions/parser/backend/execution_worker.py
@@ -1,6 +1,6 @@
 import datetime
 from threading import Thread
-from typing import Final, Optional
+from typing import Final
 
 from moto.stepfunctions.parser.api import (
     Arn,
@@ -36,19 +36,19 @@ from moto.stepfunctions.parser.utils import TMP_THREADS
 class ExecutionWorker:
     _evaluation_details: Final[EvaluationDetails]
     _execution_communication: Final[ExecutionWorkerCommunication]
-    _cloud_watch_logging_session: Final[Optional[CloudWatchLoggingSession]]
-    _mock_test_case: Final[Optional[MockTestCase]]
+    _cloud_watch_logging_session: Final[CloudWatchLoggingSession | None]
+    _mock_test_case: Final[MockTestCase | None]
     _activity_store: dict[Arn, Activity]
 
-    env: Optional[Environment]
+    env: Environment | None
 
     def __init__(
         self,
         evaluation_details: EvaluationDetails,
         exec_comm: ExecutionWorkerCommunication,
-        cloud_watch_logging_session: Optional[CloudWatchLoggingSession],
+        cloud_watch_logging_session: CloudWatchLoggingSession | None,
         activity_store: dict[Arn, Activity],
-        mock_test_case: Optional[MockTestCase] = None,
+        mock_test_case: MockTestCase | None = None,
     ):
         self._evaluation_details = evaluation_details
         self._execution_communication = exec_comm
@@ -113,9 +113,7 @@ class ExecutionWorker:
         TMP_THREADS.append(execution_logic_thread)
         execution_logic_thread.start()
 
-    def stop(
-        self, stop_date: datetime.datetime, error: Optional[str], cause: Optional[str]
-    ):
+    def stop(self, stop_date: datetime.datetime, error: str | None, cause: str | None):
         self.env.set_stop(stop_date=stop_date, cause=cause, error=error)
 
 

--- a/moto/stepfunctions/parser/backend/state_machine.py
+++ b/moto/stepfunctions/parser/backend/state_machine.py
@@ -37,15 +37,15 @@ from moto.stepfunctions.parser.utils import long_uid
 class StateMachineInstance:
     name: Name
     arn: Arn
-    revision_id: Optional[RevisionId]
+    revision_id: RevisionId | None
     definition: Definition
     role_arn: Arn
     create_date: datetime.datetime
     sm_type: StateMachineType
     logging_config: LoggingConfiguration
-    cloud_watch_logging_configuration: Optional[CloudWatchLoggingConfiguration]
-    tags: Optional[TagList]
-    tracing_config: Optional[TracingConfiguration]
+    cloud_watch_logging_configuration: CloudWatchLoggingConfiguration | None
+    tags: TagList | None
+    tracing_config: TracingConfiguration | None
 
     def __init__(
         self,
@@ -57,10 +57,10 @@ class StateMachineInstance:
         cloud_watch_logging_configuration: Optional[
             CloudWatchLoggingConfiguration
         ] = None,
-        create_date: Optional[datetime.datetime] = None,
-        sm_type: Optional[StateMachineType] = None,
-        tags: Optional[TagList] = None,
-        tracing_config: Optional[TracingConfiguration] = None,
+        create_date: datetime.datetime | None = None,
+        sm_type: StateMachineType | None = None,
+        tags: TagList | None = None,
+        tracing_config: TracingConfiguration | None = None,
     ):
         self.name = name
         self.arn = arn
@@ -110,7 +110,7 @@ class TestStateMachine(StateMachineInstance):
         arn: Arn,
         definition: Definition,
         role_arn: Arn,
-        create_date: Optional[datetime.datetime] = None,
+        create_date: datetime.datetime | None = None,
     ):
         super().__init__(
             name,
@@ -129,7 +129,7 @@ class TestStateMachine(StateMachineInstance):
 
 
 class TagManager:
-    _tags: Final[dict[str, Optional[str]]]
+    _tags: Final[dict[str, str | None]]
 
     def __init__(self):
         self._tags = OrderedDict()
@@ -177,11 +177,11 @@ class StateMachineRevision(StateMachineInstance):
         definition: Definition,
         role_arn: Arn,
         logging_config: LoggingConfiguration,
-        cloud_watch_logging_configuration: Optional[CloudWatchLoggingConfiguration],
-        create_date: Optional[datetime.datetime] = None,
-        sm_type: Optional[StateMachineType] = None,
-        tags: Optional[TagList] = None,
-        tracing_config: Optional[TracingConfiguration] = None,
+        cloud_watch_logging_configuration: CloudWatchLoggingConfiguration | None,
+        create_date: datetime.datetime | None = None,
+        sm_type: StateMachineType | None = None,
+        tags: TagList | None = None,
+        tracing_config: TracingConfiguration | None = None,
     ):
         super().__init__(
             name,
@@ -204,10 +204,10 @@ class StateMachineRevision(StateMachineInstance):
 
     def create_revision(
         self,
-        definition: Optional[str],
-        role_arn: Optional[Arn],
-        logging_configuration: Optional[LoggingConfiguration],
-    ) -> Optional[RevisionId]:
+        definition: str | None,
+        role_arn: Arn | None,
+        logging_configuration: LoggingConfiguration | None,
+    ) -> RevisionId | None:
         update_definition = definition and json.loads(definition) != json.loads(
             self.definition
         )
@@ -235,9 +235,7 @@ class StateMachineRevision(StateMachineInstance):
 
         return self.revision_id
 
-    def create_version(
-        self, description: Optional[str]
-    ) -> Optional[StateMachineVersion]:
+    def create_version(self, description: str | None) -> StateMachineVersion | None:
         if self.revision_id not in self.versions:
             self._version_number += 1
             version = StateMachineVersion(
@@ -268,13 +266,13 @@ class StateMachineRevision(StateMachineInstance):
 class StateMachineVersion(StateMachineInstance):
     source_arn: Arn
     version: int
-    description: Optional[str]
+    description: str | None
 
     def __init__(
         self,
         state_machine_revision: StateMachineRevision,
         version: int,
-        description: Optional[str],
+        description: str | None,
     ):
         version_arn = f"{state_machine_revision.arn}:{version}"
         super().__init__(

--- a/moto/stepfunctions/parser/backend/test_state/execution.py
+++ b/moto/stepfunctions/parser/backend/test_state/execution.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Optional
 
 from moto.stepfunctions.parser.api import (
     Arn,
@@ -37,8 +36,8 @@ LOG = logging.getLogger(__name__)
 
 
 class TestStateExecution(Execution):
-    exec_worker: Optional[TestStateExecutionWorker]
-    next_state: Optional[str]
+    exec_worker: TestStateExecutionWorker | None
+    next_state: str | None
 
     class TestCaseExecutionWorkerCommunication(BaseExecutionWorkerCommunication):
         _execution: TestStateExecution
@@ -66,7 +65,7 @@ class TestStateExecution(Execution):
         state_machine: StateMachineInstance,
         start_date: Timestamp,
         activity_store: dict[Arn, Activity],
-        input_data: Optional[dict] = None,
+        input_data: dict | None = None,
     ):
         super().__init__(
             name=name,

--- a/moto/stepfunctions/parser/backend/test_state/execution_worker.py
+++ b/moto/stepfunctions/parser/backend/test_state/execution_worker.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.stepfunctions.parser.asl.component.eval_component import EvalComponent
 from moto.stepfunctions.parser.asl.eval.environment import Environment
 from moto.stepfunctions.parser.asl.eval.event.event_manager import (
@@ -20,7 +18,7 @@ from moto.stepfunctions.parser.backend.execution_worker import SyncExecutionWork
 
 
 class TestStateExecutionWorker(SyncExecutionWorker):
-    env: Optional[TestStateEnvironment]
+    env: TestStateEnvironment | None
 
     def _get_evaluation_entrypoint(self) -> EvalComponent:
         return TestStateAmazonStateLanguageParser.parse(

--- a/moto/stepfunctions/parser/mocking/mock_config.py
+++ b/moto/stepfunctions/parser/mocking/mock_config.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Final, Optional
+from typing import Any, Final
 
 
 class MockedResponse(abc.ABC):
@@ -203,7 +203,7 @@ def _mock_test_case_from_raw(
 
 def load_mock_test_case_for(
     state_machine_name: str, test_case_name: str
-) -> Optional[MockTestCase]:
+) -> MockTestCase | None:
     raw_mock_config = None
     if raw_mock_config is None:
         return None

--- a/moto/stepfunctions/parser/models.py
+++ b/moto/stepfunctions/parser/models.py
@@ -1,7 +1,7 @@
 import copy
 import datetime
 import json
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import BackendDict
 from moto.stepfunctions.models import StateMachine, StepFunctionBackend
@@ -46,7 +46,7 @@ from moto.stepfunctions.parser.backend.execution import Execution
 
 
 class StepFunctionsParserBackend(StepFunctionBackend):
-    def _get_executions(self, execution_status: Optional[ExecutionStatus] = None):
+    def _get_executions(self, execution_status: ExecutionStatus | None = None):
         executions = []
         for sm in self.state_machines:
             for execution in sm.executions:
@@ -54,7 +54,7 @@ class StepFunctionsParserBackend(StepFunctionBackend):
                     executions.append(execution)
         return executions
 
-    def _revision_by_name(self, name: str) -> Optional[StateMachine]:
+    def _revision_by_name(self, name: str) -> StateMachine | None:
         for state_machine in self.state_machines:
             if state_machine.name == name:
                 return state_machine
@@ -80,12 +80,12 @@ class StepFunctionsParserBackend(StepFunctionBackend):
         name: str,
         definition: str,
         roleArn: str,
-        tags: Optional[list[dict[str, str]]] = None,
-        publish: Optional[bool] = None,
-        loggingConfiguration: Optional[LoggingConfiguration] = None,
-        tracingConfiguration: Optional[TracingConfiguration] = None,
-        encryptionConfiguration: Optional[EncryptionConfiguration] = None,
-        version_description: Optional[str] = None,
+        tags: list[dict[str, str]] | None = None,
+        publish: bool | None = None,
+        loggingConfiguration: LoggingConfiguration | None = None,
+        tracingConfiguration: TracingConfiguration | None = None,
+        encryptionConfiguration: EncryptionConfiguration | None = None,
+        version_description: str | None = None,
     ) -> StateMachine:
         StepFunctionsParserBackend._validate_definition(definition=definition)
 
@@ -225,7 +225,7 @@ class StepFunctionsParserBackend(StepFunctionBackend):
         logging_configuration: LoggingConfiguration = None,
         tracing_configuration: TracingConfiguration = None,
         encryption_configuration: EncryptionConfiguration = None,
-        publish: Optional[bool] = None,
+        publish: bool | None = None,
         version_description: str = None,
     ) -> StateMachine:
         if not any(
@@ -257,7 +257,7 @@ class StepFunctionsParserBackend(StepFunctionBackend):
 
     def describe_map_run(self, map_run_arn: str) -> dict[str, Any]:
         for execution in self._get_executions():
-            map_run_record: Optional[MapRunRecord] = (
+            map_run_record: MapRunRecord | None = (
                 execution.exec_worker.env.map_run_record_pool_manager.get(map_run_arn)
             )
             if map_run_record is not None:

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 import localstack.services.cloudformation.provider_utils as util
 from localstack.services.cloudformation.resource_provider import (
@@ -14,14 +14,14 @@ from localstack.services.cloudformation.resource_provider import (
 
 
 class StepFunctionsActivityProperties(TypedDict):
-    Name: Optional[str]
-    Arn: Optional[str]
-    Tags: Optional[list[TagsEntry]]
+    Name: str | None
+    Arn: str | None
+    Tags: list[TagsEntry] | None
 
 
 class TagsEntry(TypedDict):
-    Key: Optional[str]
-    Value: Optional[str]
+    Key: str | None
+    Value: str | None
 
 
 REPEATED_INVOCATION = "repeated_invocation"

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity_plugin.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_activity_plugin.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from localstack.services.cloudformation.resource_provider import (
     CloudFormationResourceProviderPlugin,
     ResourceProvider,
@@ -10,7 +8,7 @@ class StepFunctionsActivityProviderPlugin(CloudFormationResourceProviderPlugin):
     name = "AWS::StepFunctions::Activity"
 
     def __init__(self):
-        self.factory: Optional[type[ResourceProvider]] = None
+        self.factory: type[ResourceProvider] | None = None
 
     def load(self):
         from localstack.services.stepfunctions.resource_providers.aws_stepfunctions_activity import (

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import re
 from pathlib import Path
-from typing import Optional, TypedDict
+from typing import TypedDict
 
 import localstack.services.cloudformation.provider_utils as util
 from localstack.services.cloudformation.resource_provider import (
@@ -18,55 +18,55 @@ from localstack.utils.strings import to_str
 
 
 class StepFunctionsStateMachineProperties(TypedDict):
-    RoleArn: Optional[str]
-    Arn: Optional[str]
-    Definition: Optional[dict]
-    DefinitionS3Location: Optional[S3Location]
-    DefinitionString: Optional[str]
-    DefinitionSubstitutions: Optional[dict]
-    LoggingConfiguration: Optional[LoggingConfiguration]
-    Name: Optional[str]
-    StateMachineName: Optional[str]
-    StateMachineRevisionId: Optional[str]
-    StateMachineType: Optional[str]
-    Tags: Optional[list[TagsEntry]]
-    TracingConfiguration: Optional[TracingConfiguration]
-    EncryptionConfiguration: Optional[EncryptionConfiguration]
+    RoleArn: str | None
+    Arn: str | None
+    Definition: dict | None
+    DefinitionS3Location: S3Location | None
+    DefinitionString: str | None
+    DefinitionSubstitutions: dict | None
+    LoggingConfiguration: LoggingConfiguration | None
+    Name: str | None
+    StateMachineName: str | None
+    StateMachineRevisionId: str | None
+    StateMachineType: str | None
+    Tags: list[TagsEntry] | None
+    TracingConfiguration: TracingConfiguration | None
+    EncryptionConfiguration: EncryptionConfiguration | None
 
 
 class CloudWatchLogsLogGroup(TypedDict):
-    LogGroupArn: Optional[str]
+    LogGroupArn: str | None
 
 
 class LogDestination(TypedDict):
-    CloudWatchLogsLogGroup: Optional[CloudWatchLogsLogGroup]
+    CloudWatchLogsLogGroup: CloudWatchLogsLogGroup | None
 
 
 class LoggingConfiguration(TypedDict):
-    Destinations: Optional[list[LogDestination]]
-    IncludeExecutionData: Optional[bool]
-    Level: Optional[str]
+    Destinations: list[LogDestination] | None
+    IncludeExecutionData: bool | None
+    Level: str | None
 
 
 class TracingConfiguration(TypedDict):
-    Enabled: Optional[bool]
+    Enabled: bool | None
 
 
 class EncryptionConfiguration(TypedDict):
-    Type: Optional[str]
-    KmsKeyID: Optional[str]
-    KmsDataKeyReusePeriodSeconds: Optional[int]
+    Type: str | None
+    KmsKeyID: str | None
+    KmsDataKeyReusePeriodSeconds: int | None
 
 
 class S3Location(TypedDict):
-    Bucket: Optional[str]
-    Key: Optional[str]
-    Version: Optional[str]
+    Bucket: str | None
+    Key: str | None
+    Version: str | None
 
 
 class TagsEntry(TypedDict):
-    Key: Optional[str]
-    Value: Optional[str]
+    Key: str | None
+    Value: str | None
 
 
 REPEATED_INVOCATION = "repeated_invocation"

--- a/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine_plugin.py
+++ b/moto/stepfunctions/parser/resource_providers/aws_stepfunctions_statemachine_plugin.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from localstack.services.cloudformation.resource_provider import (
     CloudFormationResourceProviderPlugin,
     ResourceProvider,
@@ -10,7 +8,7 @@ class StepFunctionsStateMachineProviderPlugin(CloudFormationResourceProviderPlug
     name = "AWS::StepFunctions::StateMachine"
 
     def __init__(self):
-        self.factory: Optional[type[ResourceProvider]] = None
+        self.factory: type[ResourceProvider] | None = None
 
     def load(self):
         from localstack.services.stepfunctions.resource_providers.aws_stepfunctions_statemachine import (

--- a/moto/stepfunctions/parser/utils.py
+++ b/moto/stepfunctions/parser/utils.py
@@ -1,6 +1,5 @@
 import base64
 import re
-from typing import Union
 from uuid import uuid4
 
 TMP_THREADS = []
@@ -60,7 +59,7 @@ def to_str(obj, encoding: str = "utf-8", errors="strict") -> str:
     return obj.decode(encoding, errors) if isinstance(obj, bytes) else obj
 
 
-def to_bytes(obj: Union[str, bytes], encoding: str = "utf-8", errors="strict") -> bytes:
+def to_bytes(obj: str | bytes, encoding: str = "utf-8", errors="strict") -> bytes:
     """If ``obj`` is an instance of ``text_type``, return
     ``obj.encode(encoding, errors)``, otherwise return ``obj``"""
     return obj.encode(encoding, errors) if isinstance(obj, str) else obj

--- a/moto/sts/models.py
+++ b/moto/sts/models.py
@@ -1,7 +1,7 @@
 import datetime
 import re
 from base64 import b64decode
-from typing import Any, Optional
+from typing import Any
 
 import xmltodict
 
@@ -18,7 +18,7 @@ from moto.utilities.utils import ARN_PARTITION_REGEX, PARTITION_NAMES, get_parti
 
 
 class Token(BaseModel):
-    def __init__(self, duration: int, name: Optional[str] = None):
+    def __init__(self, duration: int, name: str | None = None):
         now = utcnow()
         self.expiration = now + datetime.timedelta(seconds=duration)
         self.name = name
@@ -74,7 +74,7 @@ class STSBackend(BaseBackend):
     def get_session_token(self, duration: int) -> Token:
         return Token(duration=duration)
 
-    def get_federation_token(self, name: Optional[str], duration: int) -> Token:
+    def get_federation_token(self, name: str | None, duration: int) -> Token:
         return Token(duration=duration, name=name)
 
     def assume_role(
@@ -107,7 +107,7 @@ class STSBackend(BaseBackend):
 
     def get_assumed_role_from_access_key(
         self, access_key_id: str
-    ) -> Optional[AssumedRole]:
+    ) -> AssumedRole | None:
         for assumed_role in self.assumed_roles:
             if assumed_role.access_key_id == access_key_id:
                 return assumed_role

--- a/moto/support/models.py
+++ b/moto/support/models.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.moto_api._internal import mock_random as random
@@ -131,7 +131,7 @@ class SupportBackend(BaseBackend):
         elif self.cases[case_id].severity_code == "critical":
             self.cases[case_id].severity_code = "low"
 
-    def resolve_case(self, case_id: str) -> dict[str, Optional[str]]:
+    def resolve_case(self, case_id: str) -> dict[str, str | None]:
         self.advance_case_status(case_id)
 
         return {
@@ -178,7 +178,7 @@ class SupportBackend(BaseBackend):
         self,
         case_id_list: list[str],
         include_resolved_cases: bool,
-        next_token: Optional[str],
+        next_token: str | None,
         include_communications: bool,
     ) -> dict[str, Any]:
         """

--- a/moto/swf/exceptions.py
+++ b/moto/swf/exceptions.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.exceptions import JsonRESTError
 
@@ -11,7 +11,7 @@ class SWFClientError(JsonRESTError):
 
 
 class SWFUnknownResourceFault(SWFClientError):
-    def __init__(self, resource_type: str, resource_name: Optional[str] = None):
+    def __init__(self, resource_type: str, resource_name: str | None = None):
         if resource_name:
             message = f"Unknown {resource_type}: {resource_name}"
         else:

--- a/moto/swf/models/__init__.py
+++ b/moto/swf/models/__init__.py
@@ -1,5 +1,5 @@
 from time import sleep
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.utilities.tagging_service import TaggingService
@@ -46,7 +46,7 @@ class SWFBackend(BaseBackend):
                 wfe._process_timeouts()
 
     def list_domains(
-        self, status: str, reverse_order: Optional[bool] = None
+        self, status: str, reverse_order: bool | None = None
     ) -> list[Domain]:
         domains = [domain for domain in self.domains if domain.status == status]
         domains = sorted(domains, key=lambda domain: domain.name)
@@ -110,8 +110,8 @@ class SWFBackend(BaseBackend):
         self,
         name: str,
         workflow_execution_retention_period_in_days: int,
-        description: Optional[str] = None,
-        tags: Optional[list[dict[str, str]]] = None,
+        description: str | None = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> None:
         if self._get_domain(name, ignore_empty=True):
             raise SWFDomainAlreadyExistsFault(name)
@@ -138,7 +138,7 @@ class SWFBackend(BaseBackend):
             raise SWFDomainAlreadyExistsFault(name)
         domain.status = "REGISTERED"
 
-    def describe_domain(self, name: str) -> Optional[Domain]:
+    def describe_domain(self, name: str) -> Domain | None:
         return self._get_domain(name)
 
     def list_types(
@@ -146,7 +146,7 @@ class SWFBackend(BaseBackend):
         kind: str,
         domain_name: str,
         status: str,
-        reverse_order: Optional[bool] = None,
+        reverse_order: bool | None = None,
     ) -> list[GenericType]:
         domain = self._get_domain(domain_name)
         _types: list[GenericType] = domain.find_types(kind, status)
@@ -196,8 +196,8 @@ class SWFBackend(BaseBackend):
         workflow_id: str,
         workflow_name: str,
         workflow_version: str,
-        tag_list: Optional[dict[str, str]] = None,
-        workflow_input: Optional[str] = None,
+        tag_list: dict[str, str] | None = None,
+        workflow_input: str | None = None,
         **kwargs: Any,
     ) -> WorkflowExecution:
         domain = self._get_domain(domain_name)
@@ -221,15 +221,15 @@ class SWFBackend(BaseBackend):
 
     def describe_workflow_execution(
         self, domain_name: str, run_id: str, workflow_id: str
-    ) -> Optional[WorkflowExecution]:
+    ) -> WorkflowExecution | None:
         # process timeouts on all objects
         self._process_timeouts()
         domain = self._get_domain(domain_name)
         return domain.get_workflow_execution(workflow_id, run_id=run_id)
 
     def poll_for_decision_task(
-        self, domain_name: str, task_list: list[str], identity: Optional[str] = None
-    ) -> Optional[DecisionTask]:
+        self, domain_name: str, task_list: list[str], identity: str | None = None
+    ) -> DecisionTask | None:
         # process timeouts on all objects
         self._process_timeouts()
         domain = self._get_domain(domain_name)
@@ -296,8 +296,8 @@ class SWFBackend(BaseBackend):
     def respond_decision_task_completed(
         self,
         task_token: str,
-        decisions: Optional[list[dict[str, Any]]] = None,
-        execution_context: Optional[str] = None,
+        decisions: list[dict[str, Any]] | None = None,
+        execution_context: str | None = None,
     ) -> None:
         # process timeouts on all objects
         self._process_timeouts()
@@ -350,8 +350,8 @@ class SWFBackend(BaseBackend):
             )
 
     def poll_for_activity_task(
-        self, domain_name: str, task_list: list[str], identity: Optional[str] = None
-    ) -> Optional[ActivityTask]:
+        self, domain_name: str, task_list: list[str], identity: str | None = None
+    ) -> ActivityTask | None:
         # process timeouts on all objects
         self._process_timeouts()
         domain = self._get_domain(domain_name)
@@ -444,7 +444,7 @@ class SWFBackend(BaseBackend):
         wfe.complete_activity_task(activity_task.task_token, result=result)
 
     def respond_activity_task_failed(
-        self, task_token: str, reason: Optional[str] = None, details: Any = None
+        self, task_token: str, reason: str | None = None, details: Any = None
     ) -> None:
         # process timeouts on all objects
         self._process_timeouts()
@@ -458,8 +458,8 @@ class SWFBackend(BaseBackend):
         workflow_id: str,
         child_policy: Any = None,
         details: Any = None,
-        reason: Optional[str] = None,
-        run_id: Optional[str] = None,
+        reason: str | None = None,
+        run_id: str | None = None,
     ) -> None:
         # process timeouts on all objects
         self._process_timeouts()
@@ -485,7 +485,7 @@ class SWFBackend(BaseBackend):
         signal_name: str,
         workflow_id: str,
         workflow_input: Any = None,
-        run_id: Optional[str] = None,
+        run_id: str | None = None,
     ) -> None:
         # process timeouts on all objects
         self._process_timeouts()

--- a/moto/swf/models/activity_task.py
+++ b/moto/swf/models/activity_task.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
@@ -28,11 +28,11 @@ class ActivityTask(BaseModel):
         self.input = workflow_input
         self.last_heartbeat_timestamp = unix_time()
         self.scheduled_event_id = scheduled_event_id
-        self.started_event_id: Optional[int] = None
+        self.started_event_id: int | None = None
         self.state = "SCHEDULED"
         self.task_token = str(mock_random.uuid4())
         self.timeouts = timeouts
-        self.timeout_type: Optional[str] = None
+        self.timeout_type: str | None = None
         self.workflow_execution = workflow_execution
         # this is *not* necessarily coherent with workflow execution history,
         # but that shouldn't be a problem for tests
@@ -73,7 +73,7 @@ class ActivityTask(BaseModel):
     def reset_heartbeat_clock(self) -> None:
         self.last_heartbeat_timestamp = unix_time()
 
-    def first_timeout(self) -> Optional[Timeout]:
+    def first_timeout(self) -> Timeout | None:
         if not self.open or not self.workflow_execution.open:
             return None
 

--- a/moto/swf/models/decision_task.py
+++ b/moto/swf/models/decision_task.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import unix_time, utcnow
@@ -19,9 +19,9 @@ class DecisionTask(BaseModel):
         self.workflow_type = workflow_execution.workflow_type
         self.task_token = str(mock_random.uuid4())
         self.scheduled_event_id = scheduled_event_id
-        self.previous_started_event_id: Optional[int] = None
-        self.started_event_id: Optional[int] = None
-        self.started_timestamp: Optional[float] = None
+        self.previous_started_event_id: int | None = None
+        self.started_event_id: int | None = None
+        self.started_timestamp: float | None = None
         self.start_to_close_timeout = (
             self.workflow_execution.task_start_to_close_timeout
         )
@@ -29,7 +29,7 @@ class DecisionTask(BaseModel):
         # this is *not* necessarily coherent with workflow execution history,
         # but that shouldn't be a problem for tests
         self.scheduled_at = utcnow()
-        self.timeout_type: Optional[str] = None
+        self.timeout_type: str | None = None
 
     @property
     def started(self) -> bool:
@@ -54,7 +54,7 @@ class DecisionTask(BaseModel):
         return hsh
 
     def start(
-        self, started_event_id: int, previous_started_event_id: Optional[int] = None
+        self, started_event_id: int, previous_started_event_id: int | None = None
     ) -> None:
         self.state = "STARTED"
         self.started_timestamp = unix_time()
@@ -65,7 +65,7 @@ class DecisionTask(BaseModel):
         self._check_workflow_execution_open()
         self.state = "COMPLETED"
 
-    def first_timeout(self) -> Optional[Timeout]:
+    def first_timeout(self) -> Timeout | None:
         if not self.started or not self.workflow_execution.open:
             return None
         # TODO: handle the "NONE" case

--- a/moto/swf/models/domain.py
+++ b/moto/swf/models/domain.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from moto.core.common_models import BaseModel
 from moto.utilities.utils import get_partition
@@ -23,7 +25,7 @@ class Domain(BaseModel):
         retention: int,
         account_id: str,
         region_name: str,
-        description: Optional[str] = None,
+        description: str | None = None,
     ):
         self.name = name
         self.retention = retention
@@ -64,7 +66,7 @@ class Domain(BaseModel):
 
     def get_type(  # type: ignore
         self, kind: str, name: str, version: str, ignore_empty: bool = False
-    ) -> "GenericType":
+    ) -> GenericType:
         try:
             return self.types[kind][name][version]
         except KeyError:
@@ -74,10 +76,10 @@ class Domain(BaseModel):
                     f"{kind.capitalize()}Type=[name={name}, version={version}]",
                 )
 
-    def add_type(self, _type: "TGenericType") -> None:
+    def add_type(self, _type: TGenericType) -> None:
         self.types[_type.kind][_type.name][_type.version] = _type
 
-    def find_types(self, kind: str, status: str) -> list["GenericType"]:
+    def find_types(self, kind: str, status: str) -> list[GenericType]:
         _all = []
         for family in self.types[kind].values():
             for _type in family.values():
@@ -85,7 +87,7 @@ class Domain(BaseModel):
                     _all.append(_type)
         return _all
 
-    def add_workflow_execution(self, workflow_execution: "WorkflowExecution") -> None:
+    def add_workflow_execution(self, workflow_execution: WorkflowExecution) -> None:
         _id = workflow_execution.workflow_id
         if self.get_workflow_execution(_id, raise_if_none=False):
             raise SWFWorkflowExecutionAlreadyStartedFault()
@@ -94,10 +96,10 @@ class Domain(BaseModel):
     def get_workflow_execution(
         self,
         workflow_id: str,
-        run_id: Optional[str] = None,
+        run_id: str | None = None,
         raise_if_none: bool = True,
         raise_if_closed: bool = False,
-    ) -> Optional["WorkflowExecution"]:
+    ) -> WorkflowExecution | None:
         # query
         if run_id:
             _all = [
@@ -129,26 +131,26 @@ class Domain(BaseModel):
         return wfe
 
     def add_to_activity_task_list(
-        self, task_list: list[str], obj: "ActivityTask"
+        self, task_list: list[str], obj: ActivityTask
     ) -> None:
         if task_list not in self.activity_task_lists:
             self.activity_task_lists[task_list] = []
         self.activity_task_lists[task_list].append(obj)
 
     @property
-    def activity_tasks(self) -> list["ActivityTask"]:
+    def activity_tasks(self) -> list[ActivityTask]:
         _all: list[ActivityTask] = []
         for tasks in self.activity_task_lists.values():
             _all += tasks
         return _all
 
-    def add_to_decision_task_list(self, task_list: str, obj: "DecisionTask") -> None:
+    def add_to_decision_task_list(self, task_list: str, obj: DecisionTask) -> None:
         if task_list not in self.decision_task_lists:
             self.decision_task_lists[task_list] = []
         self.decision_task_lists[task_list].append(obj)
 
     @property
-    def decision_tasks(self) -> list["DecisionTask"]:
+    def decision_tasks(self) -> list[DecisionTask]:
         _all: list[DecisionTask] = []
         for tasks in self.decision_task_lists.values():
             _all += tasks

--- a/moto/swf/models/history_event.py
+++ b/moto/swf/models/history_event.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import underscores_to_camelcase, unix_time
@@ -41,7 +41,7 @@ class HistoryEvent(BaseModel):
         self,
         event_id: int,
         event_type: str,
-        event_timestamp: Optional[float] = None,
+        event_timestamp: float | None = None,
         **kwargs: Any,
     ):
         if event_type not in SUPPORTED_HISTORY_EVENT_TYPES:

--- a/moto/swf/models/workflow_execution.py
+++ b/moto/swf/models/workflow_execution.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from threading import Lock
 from threading import Timer as ThreadingTimer
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.common_models import BaseModel
 from moto.core.utils import camelcase_to_underscores, unix_time
@@ -59,16 +59,16 @@ class WorkflowExecution(BaseModel):
         # TODO: check valid values among:
         # COMPLETED | FAILED | CANCELED | TERMINATED | CONTINUED_AS_NEW | TIMED_OUT
         # TODO: implement them all
-        self.close_cause: Optional[str] = None
-        self.close_status: Optional[str] = None
-        self.close_timestamp: Optional[float] = None
+        self.close_cause: str | None = None
+        self.close_status: str | None = None
+        self.close_timestamp: float | None = None
         self.execution_status = "OPEN"
-        self.latest_activity_task_timestamp: Optional[float] = None
-        self.latest_execution_context: Optional[str] = None
+        self.latest_activity_task_timestamp: float | None = None
+        self.latest_execution_context: str | None = None
         self.parent = None
-        self.start_timestamp: Optional[float] = None
+        self.start_timestamp: float | None = None
         self.tag_list = kwargs.get("tag_list", None) or []
-        self.timeout_type: Optional[str] = None
+        self.timeout_type: str | None = None
         self.workflow_type = workflow_type
         # args processing
         # NB: the order follows boto/SWF order of exceptions appearance (if no
@@ -99,7 +99,7 @@ class WorkflowExecution(BaseModel):
         self._events: list[HistoryEvent] = []
         # child workflows
         self.child_workflow_executions: list[WorkflowExecution] = []
-        self._previous_started_event_id: Optional[int] = None
+        self._previous_started_event_id: int | None = None
         # timers/thread utils
         self.threading_lock = Lock()
         self._timers: dict[str, Timer] = {}
@@ -111,7 +111,7 @@ class WorkflowExecution(BaseModel):
         self,
         kwargs: dict[str, Any],
         local_key: str,
-        workflow_type_key: Optional[str] = None,
+        workflow_type_key: str | None = None,
     ) -> Any:
         if workflow_type_key is None:
             workflow_type_key = "default_" + local_key
@@ -306,7 +306,7 @@ class WorkflowExecution(BaseModel):
         self._schedule_decision_task()
 
     # Shortcut for tests: helps having auto-starting decision tasks when needed
-    def schedule_and_start_decision_task(self, identity: Optional[str] = None) -> None:
+    def schedule_and_start_decision_task(self, identity: str | None = None) -> None:
         self._schedule_decision_task()
         decision_task = self.decision_tasks[-1]
         self.start_decision_task(decision_task.task_token, identity=identity)
@@ -325,9 +325,7 @@ class WorkflowExecution(BaseModel):
                 return dt
         raise ValueError(f"No decision task with token: {task_token}")
 
-    def start_decision_task(
-        self, task_token: str, identity: Optional[str] = None
-    ) -> None:
+    def start_decision_task(self, task_token: str, identity: str | None = None) -> None:
         dt = self._find_decision_task(task_token)
         evt = self._add_event(
             "DecisionTaskStarted",
@@ -340,8 +338,8 @@ class WorkflowExecution(BaseModel):
     def complete_decision_task(
         self,
         task_token: str,
-        decisions: Optional[list[dict[str, Any]]] = None,
-        execution_context: Optional[str] = None,
+        decisions: list[dict[str, Any]] | None = None,
+        execution_context: str | None = None,
     ) -> None:
         # 'decisions' can be None per boto.swf defaults, so replace it with something iterable
         if not decisions:
@@ -475,7 +473,7 @@ class WorkflowExecution(BaseModel):
         )
 
     def fail(
-        self, event_id: int, details: Any = None, reason: Optional[str] = None
+        self, event_id: int, details: Any = None, reason: str | None = None
     ) -> None:
         # TODO: implement length constraints on details/reason
         self.execution_status = "CLOSED"
@@ -631,7 +629,7 @@ class WorkflowExecution(BaseModel):
         self.schedule_decision_task()
 
     def fail_activity_task(
-        self, task_token: str, reason: Optional[str] = None, details: Any = None
+        self, task_token: str, reason: str | None = None, details: Any = None
     ) -> None:
         task = self._find_activity_task(task_token)
         self._add_event(
@@ -648,9 +646,9 @@ class WorkflowExecution(BaseModel):
 
     def terminate(
         self,
-        child_policy: Optional[str] = None,
-        details: Optional[dict[str, Any]] = None,
-        reason: Optional[str] = None,
+        child_policy: str | None = None,
+        details: dict[str, Any] | None = None,
+        reason: str | None = None,
     ) -> None:
         # TODO: handle child policy for child workflows here
         # TODO: handle cause="CHILD_POLICY_APPLIED"
@@ -675,7 +673,7 @@ class WorkflowExecution(BaseModel):
         )
         self.schedule_decision_task()
 
-    def first_timeout(self) -> Optional[Timeout]:
+    def first_timeout(self) -> Timeout | None:
         if not self.open or not self.start_timestamp:
             return None
         start_to_close_at = self.start_timestamp + int(

--- a/moto/synthetics/models.py
+++ b/moto/synthetics/models.py
@@ -1,7 +1,6 @@
 """SyntheticsBackend class with methods for supported APIs."""
 
 import uuid
-from typing import Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -24,12 +23,12 @@ class Canary(BaseModel):
         success_retention_period_in_days: int,
         failure_retention_period_in_days: int,
         runtime_version: str,
-        vpc_config: Optional[dict[str, object]],
-        resources_to_replicate_tags: Optional[list[str]],
-        provisioned_resource_cleanup: Optional[str],
-        browser_configs: Optional[list[dict[str, object]]],
-        tags: Optional[dict[str, str]],
-        artifact_config: Optional[dict[str, object]],
+        vpc_config: dict[str, object] | None,
+        resources_to_replicate_tags: list[str] | None,
+        provisioned_resource_cleanup: str | None,
+        browser_configs: list[dict[str, object]] | None,
+        tags: dict[str, str] | None,
+        artifact_config: dict[str, object] | None,
     ):
         self.name = name
         self.id = str(uuid.uuid4())
@@ -116,12 +115,12 @@ class SyntheticsBackend(BaseBackend):
         success_retention_period_in_days: int,
         failure_retention_period_in_days: int,
         runtime_version: str,
-        vpc_config: Optional[dict[str, object]],
-        resources_to_replicate_tags: Optional[list[str]],
-        provisioned_resource_cleanup: Optional[str],
-        browser_configs: Optional[list[dict[str, object]]],
-        tags: Optional[dict[str, str]],
-        artifact_config: Optional[dict[str, object]],
+        vpc_config: dict[str, object] | None,
+        resources_to_replicate_tags: list[str] | None,
+        provisioned_resource_cleanup: str | None,
+        browser_configs: list[dict[str, object]] | None,
+        tags: dict[str, str] | None,
+        artifact_config: dict[str, object] | None,
     ) -> Canary:
         canary = Canary(
             name,
@@ -143,7 +142,7 @@ class SyntheticsBackend(BaseBackend):
         self.canaries[name] = canary
         return canary
 
-    def get_canary(self, name: str, dry_run_id: Optional[str] = None) -> Canary:
+    def get_canary(self, name: str, dry_run_id: str | None = None) -> Canary:
         """
         The dry-run_id-parameter is not yet supported
         """
@@ -152,9 +151,9 @@ class SyntheticsBackend(BaseBackend):
 
     def describe_canaries(
         self,
-        next_token: Optional[str],
-        max_results: Optional[int],
-        names: Optional[list[str]],
+        next_token: str | None,
+        max_results: int | None,
+        names: list[str] | None,
     ) -> tuple[list[Canary], None]:
         """
         Pagination is not yet supported

--- a/moto/textract/models.py
+++ b/moto/textract/models.py
@@ -1,7 +1,7 @@
 import json
 import time
 from collections import defaultdict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -21,7 +21,7 @@ class TextractJobStatus:
 
 class TextractJob(BaseModel):
     def __init__(
-        self, job: dict[str, Any], notification_channel: Optional[dict[str, str]] = None
+        self, job: dict[str, Any], notification_channel: dict[str, str] | None = None
     ):
         self.job = job
         self.notification_channel = notification_channel
@@ -99,7 +99,7 @@ class TextractBackend(BaseBackend):
     def start_document_text_detection(
         self,
         document_location: dict[str, Any],
-        notification_channel: Optional[dict[str, str]] = None,
+        notification_channel: dict[str, str] | None = None,
     ) -> str:
         """
         The following parameters have not yet been implemented: ClientRequestToken, JobTag, OutputConfig, KmsKeyID
@@ -146,7 +146,7 @@ class TextractBackend(BaseBackend):
         return job_id
 
     def get_document_analysis(
-        self, job_id: str, max_results: Optional[int], next_token: Optional[str] = None
+        self, job_id: str, max_results: int | None, next_token: str | None = None
     ) -> TextractJob:
         job = self.async_document_analysis_jobs.get(job_id)
         if not job:

--- a/moto/timestreaminfluxdb/models.py
+++ b/moto/timestreaminfluxdb/models.py
@@ -1,7 +1,7 @@
 """TimestreamInfluxDBBackend class with methods for supported APIs."""
 
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -74,8 +74,8 @@ class ParameterGroup(BaseModel):
     def __init__(
         self,
         name: str,
-        description: Optional[str] = None,
-        parameters: Optional[dict[str, Any]] = None,
+        description: str | None = None,
+        parameters: dict[str, Any] | None = None,
         region_name: str = "",
         account_id: str = "",
     ):
@@ -108,21 +108,21 @@ class Cluster(BaseModel):
         self,
         name: str,
         password: str,
-        username: Optional[str] = None,
-        organization: Optional[str] = None,
-        bucket: Optional[str] = None,
-        port: Optional[int] = None,
-        db_parameter_group_identifier: Optional[str] = None,
-        db_instance_type: Optional[str] = None,
-        db_storage_type: Optional[str] = None,
-        allocated_storage: Optional[int] = None,
-        network_type: Optional[str] = None,
-        publicly_accessible: Optional[bool] = None,
-        vpc_subnet_ids: Optional[list[str]] = None,
-        vpc_security_group_ids: Optional[list[str]] = None,
-        deployment_type: Optional[str] = None,
-        failover_mode: Optional[str] = None,
-        log_delivery_configuration: Optional[dict[str, Any]] = None,
+        username: str | None = None,
+        organization: str | None = None,
+        bucket: str | None = None,
+        port: int | None = None,
+        db_parameter_group_identifier: str | None = None,
+        db_instance_type: str | None = None,
+        db_storage_type: str | None = None,
+        allocated_storage: int | None = None,
+        network_type: str | None = None,
+        publicly_accessible: bool | None = None,
+        vpc_subnet_ids: list[str] | None = None,
+        vpc_security_group_ids: list[str] | None = None,
+        deployment_type: str | None = None,
+        failover_mode: str | None = None,
+        log_delivery_configuration: dict[str, Any] | None = None,
         region_name: str = "",
         account_id: str = "",
         endpoint_id: str = "",
@@ -199,7 +199,7 @@ class DBInstance(BaseModel):
     def __init__(
         self,
         name: str,
-        username: Optional[str],
+        username: str | None,
         password: str,
         organization: str,
         bucket: str,
@@ -209,10 +209,10 @@ class DBInstance(BaseModel):
         publiclyAccessible: bool,
         dbStorageType: str,
         allocatedStorage: int,
-        dbParameterGroupIdentifier: Optional[str],
+        dbParameterGroupIdentifier: str | None,
         deploymentType: str,
-        logDeliveryConfiguration: Optional[dict[str, Any]],
-        tags: Optional[dict[str, Any]],
+        logDeliveryConfiguration: dict[str, Any] | None,
+        tags: dict[str, Any] | None,
         port: int,
         networkType: str,
         region_name: str,
@@ -292,7 +292,7 @@ class TimestreamInfluxDBBackend(BaseBackend):
     def create_db_instance(
         self,
         name: str,
-        username: Optional[str],  # required if using InfluxDB UI though
+        username: str | None,  # required if using InfluxDB UI though
         password: str,
         organization: str,
         bucket: str,
@@ -304,8 +304,8 @@ class TimestreamInfluxDBBackend(BaseBackend):
         allocated_storage: int,
         db_parameter_group_identifier: str,
         deployment_type: str,
-        log_delivery_configuration: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        log_delivery_configuration: dict[str, Any] | None,
+        tags: dict[str, str] | None,
         port: int,
         network_type: str,
     ) -> DBInstance:
@@ -416,9 +416,9 @@ class TimestreamInfluxDBBackend(BaseBackend):
     def create_db_parameter_group(
         self,
         name: str,
-        description: Optional[str] = None,
-        parameters: Optional[dict[str, Any]] = None,
-        tags: Optional[dict[str, str]] = None,
+        description: str | None = None,
+        parameters: dict[str, Any] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> ParameterGroup:
         validate_name(name)
 
@@ -486,22 +486,22 @@ class TimestreamInfluxDBBackend(BaseBackend):
         self,
         name: str,
         password: str,
-        username: Optional[str] = None,
-        organization: Optional[str] = None,
-        bucket: Optional[str] = None,
-        port: Optional[int] = None,
-        db_parameter_group_identifier: Optional[str] = None,
-        db_instance_type: Optional[str] = None,
-        db_storage_type: Optional[str] = None,
-        allocated_storage: Optional[int] = None,
-        network_type: Optional[str] = None,
-        publicly_accessible: Optional[bool] = None,
-        vpc_subnet_ids: Optional[list[str]] = None,
-        vpc_security_group_ids: Optional[list[str]] = None,
-        deployment_type: Optional[str] = None,
-        failover_mode: Optional[str] = None,
-        log_delivery_configuration: Optional[dict[str, Any]] = None,
-        tags: Optional[dict[str, str]] = None,
+        username: str | None = None,
+        organization: str | None = None,
+        bucket: str | None = None,
+        port: int | None = None,
+        db_parameter_group_identifier: str | None = None,
+        db_instance_type: str | None = None,
+        db_storage_type: str | None = None,
+        allocated_storage: int | None = None,
+        network_type: str | None = None,
+        publicly_accessible: bool | None = None,
+        vpc_subnet_ids: list[str] | None = None,
+        vpc_security_group_ids: list[str] | None = None,
+        deployment_type: str | None = None,
+        failover_mode: str | None = None,
+        log_delivery_configuration: dict[str, Any] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> tuple[str, str]:
         validate_name(name)
 

--- a/moto/timestreamquery/models.py
+++ b/moto/timestreamquery/models.py
@@ -1,6 +1,6 @@
 """TimestreamQueryBackend class with methods for supported APIs."""
 
-from typing import Any, Optional, Union
+from typing import Any
 from uuid import uuid4
 
 from moto.core.base_backend import BackendDict, BaseBackend
@@ -20,11 +20,11 @@ class ScheduledQuery(BaseModel):
         query_string: str,
         schedule_configuration: dict[str, str],
         notification_configuration: dict[str, dict[str, str]],
-        target_configuration: Optional[dict[str, Any]],
+        target_configuration: dict[str, Any] | None,
         scheduled_query_execution_role_arn: str,
-        tags: Optional[list[dict[str, str]]],
-        kms_key_id: Optional[str],
-        error_report_configuration: Optional[dict[str, dict[str, str]]],
+        tags: list[dict[str, str]] | None,
+        kms_key_id: str | None,
+        error_report_configuration: dict[str, dict[str, str]] | None,
     ):
         self.account_id = account_id
         self.region_name = region_name
@@ -67,7 +67,7 @@ class TimestreamQueryBackend(BaseBackend):
         super().__init__(region_name, account_id)
         self.scheduled_queries: dict[str, ScheduledQuery] = {}
 
-        self.query_result_queue: dict[Optional[str], list[dict[str, Any]]] = {}
+        self.query_result_queue: dict[str | None, list[dict[str, Any]]] = {}
         self.query_results: dict[str, dict[str, Any]] = {}
 
     def create_scheduled_query(
@@ -76,10 +76,10 @@ class TimestreamQueryBackend(BaseBackend):
         query_string: str,
         schedule_configuration: dict[str, str],
         notification_configuration: dict[str, dict[str, str]],
-        target_configuration: Optional[dict[str, Any]],
+        target_configuration: dict[str, Any] | None,
         scheduled_query_execution_role_arn: str,
-        tags: Optional[list[dict[str, str]]],
-        kms_key_id: Optional[str],
+        tags: list[dict[str, str]] | None,
+        kms_key_id: str | None,
         error_report_configuration: dict[str, dict[str, str]],
     ) -> ScheduledQuery:
         query = ScheduledQuery(
@@ -165,7 +165,7 @@ class TimestreamQueryBackend(BaseBackend):
             return self.query_results[query_string]
         return {"QueryId": str(uuid4()), "Rows": [], "ColumnInfo": []}
 
-    def describe_endpoints(self) -> list[dict[str, Union[str, int]]]:
+    def describe_endpoints(self) -> list[dict[str, str | int]]:
         # https://docs.aws.amazon.com/timestream/latest/developerguide/Using-API.endpoint-discovery.how-it-works.html
         # Usually, the address look like this:
         # query-cell1.timestream.us-east-1.amazonaws.com

--- a/moto/transcribe/models.py
+++ b/moto/transcribe/models.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -38,21 +38,21 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
         account_id: str,
         region_name: str,
         transcription_job_name: str,
-        language_code: Optional[str],
-        media_sample_rate_hertz: Optional[int],
-        media_format: Optional[str],
+        language_code: str | None,
+        media_sample_rate_hertz: int | None,
+        media_format: str | None,
         media: dict[str, str],
-        output_bucket_name: Optional[str],
-        output_key: Optional[str],
-        output_encryption_kms_key_id: Optional[str],
-        settings: Optional[dict[str, Any]],
-        model_settings: Optional[dict[str, Optional[str]]],
-        job_execution_settings: Optional[dict[str, Any]],
-        content_redaction: Optional[dict[str, Any]],
-        identify_language: Optional[bool],
-        identify_multiple_languages: Optional[bool],
-        language_options: Optional[list[str]],
-        subtitles: Optional[dict[str, Any]],
+        output_bucket_name: str | None,
+        output_key: str | None,
+        output_encryption_kms_key_id: str | None,
+        settings: dict[str, Any] | None,
+        model_settings: dict[str, str | None] | None,
+        job_execution_settings: dict[str, Any] | None,
+        content_redaction: dict[str, Any] | None,
+        identify_language: bool | None,
+        identify_multiple_languages: bool | None,
+        language_options: list[str] | None,
+        subtitles: dict[str, Any] | None,
     ):
         ManagedState.__init__(
             self,
@@ -67,13 +67,13 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
         self._region_name = region_name
         self.transcription_job_name = transcription_job_name
         self.language_code = language_code
-        self.language_codes: Optional[list[dict[str, Any]]] = None
+        self.language_codes: list[dict[str, Any]] | None = None
         self.media_sample_rate_hertz = media_sample_rate_hertz
         self.media_format = media_format
         self.media = media
-        self.transcript: Optional[dict[str, str]] = None
-        self.start_time: Optional[datetime] = None
-        self.completion_time: Optional[datetime] = None
+        self.transcript: dict[str, str] | None = None
+        self.start_time: datetime | None = None
+        self.completion_time: datetime | None = None
         self.creation_time = utcnow()
         self.failure_reason = None
         self.settings = settings or {
@@ -93,7 +93,7 @@ class FakeTranscriptionJob(BaseObject, ManagedState):
         self.identify_language = identify_language
         self.identify_multiple_languages = identify_multiple_languages
         self.language_options = language_options
-        self.identified_language_score: Optional[float] = None
+        self.identified_language_score: float | None = None
         self._output_bucket_name = output_bucket_name
         self.output_key = output_key
         self._output_encryption_kms_key_id = output_encryption_kms_key_id
@@ -254,8 +254,8 @@ class FakeVocabulary(BaseObject, ManagedState):
         region_name: str,
         vocabulary_name: str,
         language_code: str,
-        phrases: Optional[list[str]],
-        vocabulary_file_uri: Optional[str],
+        phrases: list[str] | None,
+        vocabulary_file_uri: str | None,
     ):
         # Configured ManagedState
         super().__init__(
@@ -268,7 +268,7 @@ class FakeVocabulary(BaseObject, ManagedState):
         self.language_code = language_code
         self.phrases = phrases
         self.vocabulary_file_uri = vocabulary_file_uri
-        self.last_modified_time: Optional[datetime] = None
+        self.last_modified_time: datetime | None = None
         self.failure_reason = None
         self.download_uri = f"https://s3.{region_name}.amazonaws.com/aws-transcribe-dictionary-model-{region_name}-prod/{account_id}/{vocabulary_name}/{mock_random.uuid4()}/input.txt"
 
@@ -320,12 +320,12 @@ class FakeMedicalTranscriptionJob(BaseObject, ManagedState):
         region_name: str,
         medical_transcription_job_name: str,
         language_code: str,
-        media_sample_rate_hertz: Optional[int],
-        media_format: Optional[str],
+        media_sample_rate_hertz: int | None,
+        media_format: str | None,
         media: dict[str, str],
         output_bucket_name: str,
-        output_encryption_kms_key_id: Optional[str],
-        settings: Optional[dict[str, Any]],
+        output_encryption_kms_key_id: str | None,
+        settings: dict[str, Any] | None,
         specialty: str,
         job_type: str,
     ):
@@ -344,9 +344,9 @@ class FakeMedicalTranscriptionJob(BaseObject, ManagedState):
         self.media_sample_rate_hertz = media_sample_rate_hertz
         self.media_format = media_format
         self.media = media
-        self.transcript: Optional[dict[str, str]] = None
-        self.start_time: Optional[datetime] = None
-        self.completion_time: Optional[datetime] = None
+        self.transcript: dict[str, str] | None = None
+        self.start_time: datetime | None = None
+        self.completion_time: datetime | None = None
         self.creation_time = utcnow()
         self.failure_reason = None
         self.settings = settings or {
@@ -449,7 +449,7 @@ class FakeMedicalVocabulary(FakeVocabulary):
         region_name: str,
         vocabulary_name: str,
         language_code: str,
-        vocabulary_file_uri: Optional[str],
+        vocabulary_file_uri: str | None,
     ):
         super().__init__(
             account_id,
@@ -480,21 +480,21 @@ class TranscribeBackend(BaseBackend):
     def start_transcription_job(
         self,
         transcription_job_name: str,
-        language_code: Optional[str],
-        media_sample_rate_hertz: Optional[int],
-        media_format: Optional[str],
+        language_code: str | None,
+        media_sample_rate_hertz: int | None,
+        media_format: str | None,
         media: dict[str, str],
-        output_bucket_name: Optional[str],
-        output_key: Optional[str],
-        output_encryption_kms_key_id: Optional[str],
-        settings: Optional[dict[str, Any]],
-        model_settings: Optional[dict[str, Optional[str]]],
-        job_execution_settings: Optional[dict[str, Any]],
-        content_redaction: Optional[dict[str, Any]],
-        identify_language: Optional[bool],
-        identify_multiple_languages: Optional[bool],
-        language_options: Optional[list[str]],
-        subtitles: Optional[dict[str, Any]],
+        output_bucket_name: str | None,
+        output_key: str | None,
+        output_encryption_kms_key_id: str | None,
+        settings: dict[str, Any] | None,
+        model_settings: dict[str, str | None] | None,
+        job_execution_settings: dict[str, Any] | None,
+        content_redaction: dict[str, Any] | None,
+        identify_language: bool | None,
+        identify_multiple_languages: bool | None,
+        language_options: list[str] | None,
+        subtitles: dict[str, Any] | None,
     ) -> dict[str, Any]:
         if transcription_job_name in self.transcriptions:
             raise ConflictException(
@@ -536,12 +536,12 @@ class TranscribeBackend(BaseBackend):
         self,
         medical_transcription_job_name: str,
         language_code: str,
-        media_sample_rate_hertz: Optional[int],
-        media_format: Optional[str],
+        media_sample_rate_hertz: int | None,
+        media_format: str | None,
         media: dict[str, str],
         output_bucket_name: str,
-        output_encryption_kms_key_id: Optional[str],
-        settings: Optional[dict[str, Any]],
+        output_encryption_kms_key_id: str | None,
+        settings: dict[str, Any] | None,
         specialty: str,
         type_: str,
     ) -> dict[str, Any]:
@@ -691,8 +691,8 @@ class TranscribeBackend(BaseBackend):
         self,
         vocabulary_name: str,
         language_code: str,
-        phrases: Optional[list[str]],
-        vocabulary_file_uri: Optional[str],
+        phrases: list[str] | None,
+        vocabulary_file_uri: str | None,
     ) -> dict[str, Any]:
         if (
             phrases is not None
@@ -732,7 +732,7 @@ class TranscribeBackend(BaseBackend):
         self,
         vocabulary_name: str,
         language_code: str,
-        vocabulary_file_uri: Optional[str],
+        vocabulary_file_uri: str | None,
     ) -> dict[str, Any]:
         if vocabulary_name in self.medical_vocabularies:
             raise ConflictException(

--- a/moto/transfer/models.py
+++ b/moto/transfer/models.py
@@ -1,6 +1,6 @@
 """TransferBackend class with methods for supported APIs."""
 
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.utils import camelcase_to_underscores, unix_time
@@ -33,23 +33,23 @@ class TransferBackend(BaseBackend):
 
     def create_server(
         self,
-        certificate: Optional[str],
-        domain: Optional[ServerDomain],
-        endpoint_details: Optional[dict[str, Any]],
-        endpoint_type: Optional[ServerEndpointType],
+        certificate: str | None,
+        domain: ServerDomain | None,
+        endpoint_details: dict[str, Any] | None,
+        endpoint_type: ServerEndpointType | None,
         host_key: str,
-        identity_provider_details: Optional[dict[str, Any]],
-        identity_provider_type: Optional[ServerIdentityProviderType],
-        logging_role: Optional[str],
-        post_authentication_login_banner: Optional[str],
-        pre_authentication_login_banner: Optional[str],
-        protocols: Optional[list[ServerProtocols]],
-        protocol_details: Optional[dict[str, Any]],
-        security_policy_name: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        workflow_details: Optional[dict[str, Any]],
-        structured_log_destinations: Optional[list[str]],
-        s3_storage_options: Optional[dict[str, Optional[str]]],
+        identity_provider_details: dict[str, Any] | None,
+        identity_provider_type: ServerIdentityProviderType | None,
+        logging_role: str | None,
+        post_authentication_login_banner: str | None,
+        pre_authentication_login_banner: str | None,
+        protocols: list[ServerProtocols] | None,
+        protocol_details: dict[str, Any] | None,
+        security_policy_name: str | None,
+        tags: list[dict[str, str]] | None,
+        workflow_details: dict[str, Any] | None,
+        structured_log_destinations: list[str] | None,
+        s3_storage_options: dict[str, str | None] | None,
     ) -> str:
         server = Server(
             region_name=self.region_name,
@@ -138,15 +138,15 @@ class TransferBackend(BaseBackend):
 
     def create_user(
         self,
-        home_directory: Optional[str],
-        home_directory_type: Optional[UserHomeDirectoryType],
-        home_directory_mappings: Optional[list[dict[str, Optional[str]]]],
-        policy: Optional[str],
-        posix_profile: Optional[dict[str, Any]],
+        home_directory: str | None,
+        home_directory_type: UserHomeDirectoryType | None,
+        home_directory_mappings: list[dict[str, str | None]] | None,
+        policy: str | None,
+        posix_profile: dict[str, Any] | None,
         role: str,
         server_id: str,
-        ssh_public_key_body: Optional[str],
-        tags: Optional[list[dict[str, str]]],
+        ssh_public_key_body: str | None,
+        tags: list[dict[str, str]] | None,
         user_name: str,
     ) -> tuple[str, str]:
         if server_id not in self.servers:
@@ -259,11 +259,11 @@ class TransferBackend(BaseBackend):
         self,
         url: str,
         access_role: str,
-        logging_role: Optional[str],
-        tags: Optional[list[dict[str, str]]],
-        as2_config: Optional[dict[str, Any]],
-        sftp_config: Optional[dict[str, Any]],
-        security_policy_name: Optional[str],
+        logging_role: str | None,
+        tags: list[dict[str, str]] | None,
+        as2_config: dict[str, Any] | None,
+        sftp_config: dict[str, Any] | None,
+        security_policy_name: str | None,
     ) -> str:
         connector = Connector(
             region_name=self.region_name,
@@ -293,12 +293,12 @@ class TransferBackend(BaseBackend):
     def update_connector(
         self,
         connector_id: str,
-        url: Optional[str],
-        access_role: Optional[str],
-        logging_role: Optional[str],
-        as2_config: Optional[dict[str, Any]],
-        sftp_config: Optional[dict[str, Any]],
-        security_policy_name: Optional[str],
+        url: str | None,
+        access_role: str | None,
+        logging_role: str | None,
+        as2_config: dict[str, Any] | None,
+        sftp_config: dict[str, Any] | None,
+        security_policy_name: str | None,
     ) -> str:
         if connector_id not in self.connectors:
             raise ConnectorNotFound(connector_id=connector_id)

--- a/moto/transfer/types.py
+++ b/moto/transfer/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
@@ -21,18 +21,14 @@ class User(BaseModel):
     region_name: str
     account_id: str
     server_id: str
-    home_directory: Optional[str]
-    home_directory_type: Optional[UserHomeDirectoryType]
-    policy: Optional[str]
+    home_directory: str | None
+    home_directory_type: UserHomeDirectoryType | None
+    policy: str | None
     role: str
     user_name: str
     arn: str = field(default="", init=False)
-    home_directory_mappings: list[dict[str, Optional[str]]] = field(
-        default_factory=list
-    )
-    posix_profile: dict[str, Optional[Union[str, list[str]]]] = field(
-        default_factory=dict
-    )
+    home_directory_mappings: list[dict[str, str | None]] = field(default_factory=list)
+    posix_profile: dict[str, str | list[str] | None] = field(default_factory=dict)
     ssh_public_keys: list[dict[str, str]] = field(default_factory=list)
     tags: list[dict[str, str]] = field(default_factory=list)
 
@@ -123,25 +119,25 @@ AS2_TRANSPORTS_TYPE = list[Literal["HTTP"]]
 class Server(BaseModel):
     region_name: str
     account_id: str
-    certificate: Optional[str]
-    domain: Optional[ServerDomain]
-    endpoint_type: Optional[ServerEndpointType]
-    host_key_fingerprint: Optional[str]
-    identity_provider_type: Optional[ServerIdentityProviderType]
-    logging_role: Optional[str]
-    post_authentication_login_banner: Optional[str]
-    pre_authentication_login_banner: Optional[str]
-    protocols: Optional[list[ServerProtocols]]
-    security_policy_name: Optional[str]
-    structured_log_destinations: Optional[list[str]]
+    certificate: str | None
+    domain: ServerDomain | None
+    endpoint_type: ServerEndpointType | None
+    host_key_fingerprint: str | None
+    identity_provider_type: ServerIdentityProviderType | None
+    logging_role: str | None
+    post_authentication_login_banner: str | None
+    pre_authentication_login_banner: str | None
+    protocols: list[ServerProtocols] | None
+    security_policy_name: str | None
+    structured_log_destinations: list[str] | None
     arn: str = field(default="", init=False)
     as2_service_managed_egress_ip_addresses: list[str] = field(default_factory=list)
     endpoint_details: dict[str, str] = field(default_factory=dict)
     identity_provider_details: dict[str, str] = field(default_factory=dict)
     protocol_details: dict[str, str] = field(default_factory=dict)
-    s3_storage_options: dict[str, Optional[str]] = field(default_factory=dict)
+    s3_storage_options: dict[str, str | None] = field(default_factory=dict)
     server_id: str = field(default="", init=False)
-    state: Optional[ServerState] = ServerState.ONLINE
+    state: ServerState | None = ServerState.ONLINE
     tags: list[dict[str, str]] = field(default_factory=list)
     user_count: int = field(default=0)
     workflow_details: dict[str, list[dict[str, str]]] = field(default_factory=dict)
@@ -254,10 +250,10 @@ class Connector(BaseModel):  # type: ignore[misc]
     account_id: str
     url: str
     access_role: str
-    logging_role: Optional[str]
-    as2_config: Optional[dict[str, Any]]
-    sftp_config: Optional[dict[str, Any]]
-    security_policy_name: Optional[str]
+    logging_role: str | None
+    as2_config: dict[str, Any] | None
+    sftp_config: dict[str, Any] | None
+    security_policy_name: str | None
     arn: str = field(default="", init=False)
     connector_id: str = field(default="", init=False)
     tags: list[dict[str, str]] = field(default_factory=list)

--- a/moto/utilities/aws_headers.py
+++ b/moto/utilities/aws_headers.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from typing_extensions import Protocol
@@ -16,7 +16,7 @@ class GenericFunction(Protocol):
     def __call__(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
-def gen_amz_crc32(response: Any, headerdict: Optional[dict[str, Any]] = None) -> int:
+def gen_amz_crc32(response: Any, headerdict: dict[str, Any] | None = None) -> int:
     if not isinstance(response, bytes):
         response = response.encode("utf-8")
 
@@ -28,7 +28,7 @@ def gen_amz_crc32(response: Any, headerdict: Optional[dict[str, Any]] = None) ->
     return crc
 
 
-def gen_amzn_requestid_long(headerdict: Optional[dict[str, Any]] = None) -> str:
+def gen_amzn_requestid_long(headerdict: dict[str, Any] | None = None) -> str:
     from moto.moto_api._internal import mock_random as random
 
     req_id = random.get_random_string(length=52)

--- a/moto/utilities/distutils_version.py
+++ b/moto/utilities/distutils_version.py
@@ -30,7 +30,7 @@ Every version number class implements the following interface:
 """
 
 import re
-from typing import Any, Optional
+from typing import Any
 
 
 class Version:
@@ -40,7 +40,7 @@ class Version:
     rich comparisons to _cmp.
     """
 
-    def __init__(self, vstring: Optional[str] = None):
+    def __init__(self, vstring: str | None = None):
         if vstring:
             self.parse(vstring)  # type: ignore[attr-defined]
 
@@ -194,7 +194,7 @@ class LooseVersion(Version):
 
     component_re = re.compile(r"(\d+ | [a-z]+ | \.)", re.VERBOSE)
 
-    def __init__(self, vstring: Optional[str] = None):
+    def __init__(self, vstring: str | None = None):
         if vstring:
             self.parse(vstring)
 

--- a/moto/utilities/id_generator.py
+++ b/moto/utilities/id_generator.py
@@ -2,14 +2,14 @@ import abc
 import logging
 import threading
 from collections.abc import Callable
-from typing import Any, TypedDict, Union
+from typing import Any, TypedDict
 
 from moto.moto_api._internal import mock_random
 
 log = logging.getLogger(__name__)
 
-ExistingIds = Union[list[str], None]
-Tags = Union[dict[str, str], list[dict[str, str]], None]
+ExistingIds = list[str] | None
+Tags = dict[str, str] | list[dict[str, str]] | None
 
 # Custom resource tag to override the generated resource ID.
 TAG_KEY_CUSTOM_ID = "_custom_id_"
@@ -57,7 +57,7 @@ class MotoIdManager:
     use the `id_manager` instance created below."""
 
     _custom_ids: dict[str, str]
-    _id_sources: list[Callable[[IdSourceContext], Union[str, None]]]
+    _id_sources: list[Callable[[IdSourceContext], str | None]]
 
     _lock: threading.RLock
 
@@ -69,9 +69,7 @@ class MotoIdManager:
         self.add_id_source(self.get_id_from_tags)
         self.add_id_source(self.get_custom_id_from_context)
 
-    def get_custom_id(
-        self, resource_identifier: ResourceIdentifier
-    ) -> Union[str, None]:
+    def get_custom_id(self, resource_identifier: ResourceIdentifier) -> str | None:
         # retrieves a custom_id for a resource. Returns None if no id were registered
         # that matches the `resource_identifier`
         return self._custom_ids.get(resource_identifier.unique_identifier)
@@ -90,13 +88,11 @@ class MotoIdManager:
         with self._lock:
             self._custom_ids.pop(resource_identifier.unique_identifier, None)
 
-    def add_id_source(
-        self, id_source: Callable[[IdSourceContext], Union[str, None]]
-    ) -> None:
+    def add_id_source(self, id_source: Callable[[IdSourceContext], str | None]) -> None:
         self._id_sources.append(id_source)
 
     @staticmethod
-    def get_id_from_tags(id_source_context: IdSourceContext) -> Union[str, None]:
+    def get_id_from_tags(id_source_context: IdSourceContext) -> str | None:
         if not (tags := id_source_context.get("tags")):
             return None
 
@@ -115,15 +111,13 @@ class MotoIdManager:
 
     def get_custom_id_from_context(
         self, id_source_context: IdSourceContext
-    ) -> Union[str, None]:
+    ) -> str | None:
         # retrieves a custom_id for a resource. Returns None
         if resource_identifier := id_source_context.get("resource_identifier"):
             return self.get_custom_id(resource_identifier)
         return None
 
-    def find_id_from_sources(
-        self, id_source_context: IdSourceContext
-    ) -> Union[str, None]:
+    def find_id_from_sources(self, id_source_context: IdSourceContext) -> str | None:
         existing_ids = id_source_context.get("existing_ids") or []
         for id_source in self._id_sources:
             if found_id := id_source(id_source_context):

--- a/moto/utilities/paginator.py
+++ b/moto/utilities/paginator.py
@@ -2,7 +2,7 @@ import inspect
 from collections.abc import Callable
 from copy import deepcopy
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Optional, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from botocore.paginate import TokenDecoder, TokenEncoder
 
@@ -22,13 +22,13 @@ T = TypeVar("T")
 class GenericFunction(Protocol):
     def __call__(
         self, func: "Callable[P1, list[T]]"
-    ) -> "Callable[P2, tuple[list[T], Optional[str]]]": ...
+    ) -> "Callable[P2, tuple[list[T], str | None]]": ...
 
 
 def paginate(pagination_model: dict[str, Any]) -> GenericFunction:
     def pagination_decorator(
         func: Callable[..., list[T]],
-    ) -> Callable[..., tuple[list[T], Optional[str]]]:
+    ) -> Callable[..., tuple[list[T], str | None]]:
         @wraps(func)
         def pagination_wrapper(*args: Any, **kwargs: Any) -> Any:  # type: ignore
             method = func.__name__
@@ -101,7 +101,7 @@ class Paginator:
         self._param_checksum = self._calculate_parameter_checksum()
         self._parsed_token = self._parse_starting_token()
 
-    def _parse_starting_token(self) -> Optional[dict[str, Any]]:
+    def _parse_starting_token(self) -> dict[str, Any] | None:
         if self._starting_token is None:
             return None
         # The starting token is a dict passed as a base64 encoded string.
@@ -115,7 +115,7 @@ class Paginator:
             raise InvalidToken(f"Input inconsistent with page token: {str(next_token)}")
         return next_token
 
-    def _raise_exception_if_required(self, token: Optional[str]) -> None:
+    def _raise_exception_if_required(self, token: str | None) -> None:
         if self._fail_on_invalid_token:
             if isinstance(self._fail_on_invalid_token, type):
                 # we need to raise a custom exception
@@ -170,7 +170,7 @@ class Paginator:
         token_dict["uniqueAttributes"] = "|".join(range_keys)
         return self._token_encoder.encode(token_dict)
 
-    def paginate(self, results: list[Any]) -> tuple[list[Any], Optional[str]]:
+    def paginate(self, results: list[Any]) -> tuple[list[Any], str | None]:
         index_start = 0
         if self._starting_token:
             try:

--- a/moto/utilities/tagging_service.py
+++ b/moto/utilities/tagging_service.py
@@ -1,7 +1,6 @@
 """Tag functionality contained in class TaggingService."""
 
 import re
-from typing import Optional
 
 
 class TaggingService:
@@ -13,7 +12,7 @@ class TaggingService:
         self.tag_name = tag_name
         self.key_name = key_name
         self.value_name = value_name
-        self.tags: dict[str, dict[str, Optional[str]]] = {}
+        self.tags: dict[str, dict[str, str | None]] = {}
 
     def get_tag_dict_for_resource(self, arn: str) -> dict[str, str]:
         """Return dict of key/value pairs vs. list of key/values dicts."""
@@ -44,7 +43,7 @@ class TaggingService:
         """Return True if the ARN has any associated tags, False otherwise."""
         return arn in self.tags
 
-    def tag_resource(self, arn: str, tags: Optional[list[dict[str, str]]]) -> None:
+    def tag_resource(self, arn: str, tags: list[dict[str, str]] | None) -> None:
         """Store associated list of dicts with ARN.
 
         Note: the storage is internal to this class instance.
@@ -97,9 +96,9 @@ class TaggingService:
                 results.append(tag[self.key_name])
         return results
 
-    def flatten_tag_list(self, tags: list[dict[str, str]]) -> dict[str, Optional[str]]:
+    def flatten_tag_list(self, tags: list[dict[str, str]]) -> dict[str, str | None]:
         """Return dict of key/value pairs with 'tag_name', 'value_name'."""
-        result: dict[str, Optional[str]] = {}
+        result: dict[str, str | None] = {}
         for tag in tags:
             if self.value_name in tag:
                 result[tag[self.key_name]] = tag[self.value_name]
@@ -173,7 +172,7 @@ class TaggingService:
 
     @staticmethod
     def convert_dict_to_tags_input(
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> list[dict[str, str]]:
         """Given a dictionary, return generic boto params for tags"""
         if not tags:

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -3,7 +3,7 @@ import hashlib
 import json
 import pkgutil
 from collections.abc import Iterator, MutableMapping
-from typing import Any, Optional, TypeVar
+from typing import Any, TypeVar
 from uuid import UUID
 
 from requests.structures import CaseInsensitiveDict as _CaseInsensitiveDict
@@ -32,7 +32,7 @@ def get_partition(region: str) -> str:
     return DEFAULT_PARTITION
 
 
-def str2bool(v: Any) -> Optional[bool]:
+def str2bool(v: Any) -> bool | None:
     if v in ("yes", True, "true", "True", "TRUE", "t", "1"):
         return True
     elif v in ("no", False, "false", "False", "FALSE", "f", "0"):

--- a/moto/vpclattice/models.py
+++ b/moto/vpclattice/models.py
@@ -1,7 +1,7 @@
 import random
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -19,11 +19,11 @@ class VPCLatticeService(BaseModel):
         region: str,
         account_id: str,
         auth_type: str,
-        certificate_arn: Optional[str],
+        certificate_arn: str | None,
         client_token: str,
-        custom_domain_name: Optional[str],
+        custom_domain_name: str | None,
         name: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> None:
         self.id: str = f"svc-{str(uuid.uuid4())[:17]}"
         self.auth_type: str = auth_type
@@ -59,8 +59,8 @@ class VPCLatticeServiceNetwork(BaseModel):
         auth_type: str,
         client_token: str,
         name: str,
-        sharing_config: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        sharing_config: dict[str, Any] | None,
+        tags: dict[str, str] | None,
     ) -> None:
         self.auth_type: str = auth_type
         self.client_token: str = client_token
@@ -90,10 +90,10 @@ class VPCLatticeListener(BaseModel):
         service_identifier: str,
         name: str,
         protocol: str,
-        port: Optional[int],
+        port: int | None,
         default_action: dict[str, Any],
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> None:
         self.id: str = f"listener-{str(uuid.uuid4())[:17]}"
         self.arn: str = f"arn:aws:vpc-lattice:{region}:{account_id}:service/{service_identifier}/listener/{self.id}"
@@ -134,7 +134,7 @@ class VPCLatticeServiceNetworkResourceAssociation(BaseModel):
         # resource_configuration: VPCLatticeResourceConfiguration,
         private_dns_enabled: bool,
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> None:
         now_iso = datetime.now(timezone.utc).isoformat()
         self.id: str = f"snra-{str(uuid.uuid4())[:17]}"
@@ -182,7 +182,7 @@ class VPCLatticeServiceNetworkServiceAssociation(BaseModel):
         service_network_identifier: str,
         service_identifier: str,
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> None:
         now_iso = datetime.now(timezone.utc).isoformat()
         self.id: str = f"snsa-{str(uuid.uuid4())[:17]}"
@@ -219,9 +219,9 @@ class VPCLatticeServiceNetworkVpcAssociation(BaseModel):
         region: str,
         account_id: str,
         client_token: str,
-        security_group_ids: Optional[list[str]],
+        security_group_ids: list[str] | None,
         service_network: VPCLatticeServiceNetwork,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
         vpc_identifier: str,
     ) -> None:
         now_iso = datetime.now(timezone.utc).isoformat()
@@ -303,9 +303,9 @@ class VPCLatticeTargetGroup(BaseModel):
         account_id: str,
         name: str,
         target_type: str,
-        config: Optional[dict[str, Any]],
+        config: dict[str, Any] | None,
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> None:
         self.id: str = f"tg-{str(uuid.uuid4())[:17]}"
         self.arn: str = (
@@ -317,7 +317,7 @@ class VPCLatticeTargetGroup(BaseModel):
         self.client_token: str = client_token
         self.tags: dict[str, str] = tags or {}
         self.status: str = "CREATE_IN_PROGRESS"
-        self.vpcIdentifer: Optional[str] = self.config.get("vpcIdentifier")
+        self.vpcIdentifer: str | None = self.config.get("vpcIdentifier")
         self.createdAt = datetime.now(timezone.utc).isoformat()
         self.last_updated_at = datetime.now(timezone.utc).isoformat()
 
@@ -340,7 +340,7 @@ class VPCLatticeDNSEntry:
         self,
         region_name: str,
         service_id: str,
-        custom_domain_name: Optional[str] = None,
+        custom_domain_name: str | None = None,
     ) -> None:
         self.domain_name: str = (
             custom_domain_name or f"{service_id}.{region_name}.vpclattice.amazonaws.com"
@@ -359,8 +359,8 @@ class VPCLatticeAccessLogSubscription(BaseModel):
         destinationArn: str,
         resourceArn: str,
         resourceId: str,  # resourceIdentifier
-        serviceNetworkLogType: Optional[str],
-        tags: Optional[dict[str, str]],
+        serviceNetworkLogType: str | None,
+        tags: dict[str, str] | None,
     ) -> None:
         self.id: str = f"als-{str(uuid.uuid4())[:17]}"
         self.arn: str = (
@@ -474,11 +474,11 @@ class VPCLatticeBackend(BaseBackend):
     def create_service(
         self,
         auth_type: str,
-        certificate_arn: Optional[str],
+        certificate_arn: str | None,
         client_token: str,
-        custom_domain_name: Optional[str],
+        custom_domain_name: str | None,
         name: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> VPCLatticeService:
         service = VPCLatticeService(
             self.region_name,
@@ -509,8 +509,8 @@ class VPCLatticeBackend(BaseBackend):
         auth_type: str,
         client_token: str,
         name: str,
-        sharing_config: Optional[dict[str, Any]],
-        tags: Optional[dict[str, str]],
+        sharing_config: dict[str, Any] | None,
+        tags: dict[str, str] | None,
     ) -> VPCLatticeServiceNetwork:
         """
         WARNING: This method currently does NOT fail if there is a disassociation in progress.
@@ -543,9 +543,9 @@ class VPCLatticeBackend(BaseBackend):
     def create_service_network_vpc_association(
         self,
         client_token: str,
-        security_group_ids: Optional[list[str]],
+        security_group_ids: list[str] | None,
         service_network_identifier: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
         vpc_identifier: str,
     ) -> VPCLatticeServiceNetworkVpcAssociation:
         sn = self.get_service_network(service_network_identifier)
@@ -605,9 +605,9 @@ class VPCLatticeBackend(BaseBackend):
         self,
         resourceIdentifier: str,
         destinationArn: str,
-        client_token: Optional[str],
-        serviceNetworkLogType: Optional[str],
-        tags: Optional[dict[str, str]],
+        client_token: str | None,
+        serviceNetworkLogType: str | None,
+        tags: dict[str, str] | None,
     ) -> VPCLatticeAccessLogSubscription:
         resource: Any = None
         if resourceIdentifier.startswith("sn-"):
@@ -649,8 +649,8 @@ class VPCLatticeBackend(BaseBackend):
     def list_access_log_subscriptions(
         self,
         resourceIdentifier: str,
-        maxResults: Optional[int] = None,
-        nextToken: Optional[str] = None,
+        maxResults: int | None = None,
+        nextToken: str | None = None,
     ) -> list[VPCLatticeAccessLogSubscription]:
         return [
             sub
@@ -777,8 +777,8 @@ class VPCLatticeBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_service_network_vpc_associations(
         self,
-        serviceNetworkIdentifier: Optional[str] = None,
-        vpcIdentifier: Optional[str] = None,
+        serviceNetworkIdentifier: str | None = None,
+        vpcIdentifier: str | None = None,
     ) -> list[VPCLatticeServiceNetworkVpcAssociation]:
         associations = list(self.service_network_vpc_associations.values())
         if serviceNetworkIdentifier:
@@ -799,10 +799,10 @@ class VPCLatticeBackend(BaseBackend):
         service_identifier: str,
         name: str,
         protocol: str,
-        port: Optional[int],
+        port: int | None,
         default_action: dict[str, Any],
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> VPCLatticeListener:
         service = self.get_service(service_identifier)
 
@@ -852,9 +852,9 @@ class VPCLatticeBackend(BaseBackend):
         self,
         name: str,
         target_type: str,
-        config: Optional[dict[str, Any]],
+        config: dict[str, Any] | None,
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> VPCLatticeTargetGroup:
         target_group = VPCLatticeTargetGroup(
             self.region_name,
@@ -881,8 +881,8 @@ class VPCLatticeBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_target_groups(
         self,
-        vpc_identifier: Optional[str] = None,
-        target_group_type: Optional[str] = None,
+        vpc_identifier: str | None = None,
+        target_group_type: str | None = None,
     ) -> list[VPCLatticeTargetGroup]:
         target_groups = list(self.target_groups.values())
 
@@ -904,7 +904,7 @@ class VPCLatticeBackend(BaseBackend):
         service_network_identifier: str,
         private_dns_enabled: bool,
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> VPCLatticeServiceNetworkResourceAssociation:
         service_network = self.get_service_network(service_network_identifier)
         # TODO: Once resource configs are implemented, do something with the resource_config_id
@@ -937,8 +937,8 @@ class VPCLatticeBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_service_network_resource_associations(
         self,
-        service_network_identifier: Optional[str] = None,
-        resource_configuration_identifier: Optional[str] = None,
+        service_network_identifier: str | None = None,
+        resource_configuration_identifier: str | None = None,
     ) -> list[VPCLatticeServiceNetworkResourceAssociation]:
         associations = list(self.service_network_resource_associations.values())
         if service_network_identifier:
@@ -963,7 +963,7 @@ class VPCLatticeBackend(BaseBackend):
         service_network_identifier: str,
         service_identifier: str,
         client_token: str,
-        tags: Optional[dict[str, str]],
+        tags: dict[str, str] | None,
     ) -> VPCLatticeServiceNetworkServiceAssociation:
         service_network = self.get_service_network(service_network_identifier)
         service = self.get_service(service_identifier)
@@ -995,8 +995,8 @@ class VPCLatticeBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_service_network_service_associations(
         self,
-        service_network_identifier: Optional[str] = None,
-        service_identifier: Optional[str] = None,
+        service_network_identifier: str | None = None,
+        service_identifier: str | None = None,
     ) -> list[VPCLatticeServiceNetworkServiceAssociation]:
         associations = list(self.service_network_service_associations.values())
         if service_network_identifier:

--- a/moto/wafv2/exceptions.py
+++ b/moto/wafv2/exceptions.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from moto.core.exceptions import JsonRESTError
 
 
@@ -18,10 +16,10 @@ class WAFV2DuplicateItemException(WAFv2ClientError):
 class WAFV2InsufficientInformationException(WAFv2ClientError):
     def __init__(
         self,
-        name: Optional[str],
-        scope: Optional[str],
-        id: Optional[str],
-        arn: Optional[str],
+        name: str | None,
+        scope: str | None,
+        id: str | None,
+        arn: str | None,
     ) -> None:
         super().__init__(
             "AcessDeniedException",

--- a/moto/wafv2/models.py
+++ b/moto/wafv2/models.py
@@ -1,6 +1,6 @@
 import re
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -83,12 +83,12 @@ class FakeRule(BaseModel):
         name: str,
         priority: int,
         statement: dict[str, Any],
-        visibility_config: dict[str, Union[str, bool]],
-        action: Optional[dict[str, Any]] = None,
-        captcha_config: Optional[dict[str, dict[str, int]]] = None,
-        challenge_config: Optional[dict[str, dict[str, int]]] = None,
-        override_action: Optional[dict[str, Any]] = None,
-        rule_labels: Optional[list[dict[str, str]]] = None,
+        visibility_config: dict[str, str | bool],
+        action: dict[str, Any] | None = None,
+        captcha_config: dict[str, dict[str, int]] | None = None,
+        challenge_config: dict[str, dict[str, int]] | None = None,
+        override_action: dict[str, Any] | None = None,
+        rule_labels: list[dict[str, str]] | None = None,
     ):
         self.name = name
         self.priority = priority
@@ -100,10 +100,10 @@ class FakeRule(BaseModel):
         self.override_action = override_action
         self.rule_labels = rule_labels
 
-    def get_consumed_label(self) -> Optional[str]:
+    def get_consumed_label(self) -> str | None:
         return self.statement.get("LabelMatchStatement", {}).get("Key")
 
-    def get_available_labels(self) -> Optional[list[str]]:
+    def get_available_labels(self) -> list[str] | None:
         return [r["Name"] for r in self.rule_labels] if self.rule_labels else None
 
     def to_dict(self) -> dict[str, Any]:
@@ -133,13 +133,13 @@ class FakeWebACL(BaseModel):
         wacl_id: str,
         visibility_config: dict[str, Any],
         default_action: dict[str, Any],
-        description: Optional[str],
-        rules: Optional[list[FakeRule]],
-        association_config: Optional[dict[str, Any]] = None,
-        captcha_config: Optional[dict[str, Any]] = None,
-        challenge_config: Optional[dict[str, Any]] = None,
-        custom_response_bodies: Optional[dict[str, Any]] = None,
-        token_domains: Optional[list[str]] = None,
+        description: str | None,
+        rules: list[FakeRule] | None,
+        association_config: dict[str, Any] | None = None,
+        captcha_config: dict[str, Any] | None = None,
+        challenge_config: dict[str, Any] | None = None,
+        custom_response_bodies: dict[str, Any] | None = None,
+        token_domains: list[str] | None = None,
     ):
         self.name = name
         self.account = account
@@ -168,15 +168,15 @@ class FakeWebACL(BaseModel):
 
     def update(
         self,
-        default_action: Optional[dict[str, Any]],
-        rules: Optional[list[FakeRule]],
-        description: Optional[str],
-        visibility_config: Optional[dict[str, Any]],
-        custom_response_bodies: Optional[dict[str, Any]],
-        captcha_config: Optional[dict[str, Any]],
-        challenge_config: Optional[dict[str, Any]],
-        token_domains: Optional[list[str]],
-        association_config: Optional[dict[str, Any]],
+        default_action: dict[str, Any] | None,
+        rules: list[FakeRule] | None,
+        description: str | None,
+        visibility_config: dict[str, Any] | None,
+        custom_response_bodies: dict[str, Any] | None,
+        captcha_config: dict[str, Any] | None,
+        challenge_config: dict[str, Any] | None,
+        token_domains: list[str] | None,
+        association_config: dict[str, Any] | None,
     ) -> None:
         if default_action is not None:
             self.default_action = default_action
@@ -253,7 +253,7 @@ class FakeIPSet(BaseModel):
 
         self.lock_token = str(mock_random.uuid4())[0:6]
 
-    def update(self, description: Optional[str], addresses: list[str]) -> None:
+    def update(self, description: str | None, addresses: list[str]) -> None:
         if description is not None:
             self.description = description
         self.addresses = addresses
@@ -277,9 +277,9 @@ class FakeLoggingConfiguration(BaseModel):
         self,
         arn: str,
         log_destination_configs: list[str],
-        redacted_fields: Optional[dict[str, Any]],
-        managed_gy_firewall_manager: Optional[bool],
-        logging_filter: Optional[dict[str, Any]],
+        redacted_fields: dict[str, Any] | None,
+        managed_gy_firewall_manager: bool | None,
+        logging_filter: dict[str, Any] | None,
     ):
         self.arn = arn
         self.log_destination_configs = log_destination_configs
@@ -307,9 +307,9 @@ class FakeRuleGroup(BaseModel):
         scope: str,
         capacity: int,
         visibility_config: dict[str, Any],
-        description: Optional[str],
-        rules: Optional[list[FakeRule]],
-        custom_response_bodies: Optional[dict[str, Any]] = None,
+        description: str | None,
+        rules: list[FakeRule] | None,
+        custom_response_bodies: dict[str, Any] | None = None,
     ):
         self.account = account
         self.name = name
@@ -329,7 +329,7 @@ class FakeRuleGroup(BaseModel):
     def _generate_lock_token(self) -> str:
         return str(mock_random.uuid4())
 
-    def _get_available_labels(self) -> Optional[list[dict[str, str]]]:
+    def _get_available_labels(self) -> list[dict[str, str]] | None:
         return (
             [
                 {"Name": f"{self.label_namespace}{label}"}
@@ -340,7 +340,7 @@ class FakeRuleGroup(BaseModel):
             else None
         )
 
-    def _get_consumed_labels(self) -> Optional[list[dict[str, str]]]:
+    def _get_consumed_labels(self) -> list[dict[str, str]] | None:
         return (
             [
                 {"Name": f"{self.label_namespace}{label}"}
@@ -356,10 +356,10 @@ class FakeRuleGroup(BaseModel):
 
     def update(
         self,
-        description: Optional[str],
-        rules: Optional[list[FakeRule]],
-        visibility_config: Optional[dict[str, Any]],
-        custom_response_bodies: Optional[dict[str, Any]],
+        description: str | None,
+        rules: list[FakeRule] | None,
+        visibility_config: dict[str, Any] | None,
+        custom_response_bodies: dict[str, Any] | None,
     ) -> str:
         if description is not None:
             self.description = description
@@ -425,8 +425,8 @@ class FakeRegexPatternSet(BaseModel):
 
     def update(
         self,
-        description: Optional[str],
-        regular_expressions: Optional[list[dict[str, str]]],
+        description: str | None,
+        regular_expressions: list[dict[str, str]] | None,
     ) -> None:
         if description is not None:
             self.description = description
@@ -488,7 +488,7 @@ class WAFV2Backend(BaseBackend):
         if stage:
             stage.web_acl_arn = None
 
-    def get_web_acl_for_resource(self, resource_arn: str) -> Optional[FakeWebACL]:
+    def get_web_acl_for_resource(self, resource_arn: str) -> FakeWebACL | None:
         for wacl in self.wacls.values():
             if resource_arn in wacl.associated_resources:
                 return wacl
@@ -520,11 +520,11 @@ class WAFV2Backend(BaseBackend):
         description: str,
         tags: list[dict[str, str]],
         rules: list[dict[str, Any]],
-        association_config: Optional[dict[str, Any]],
-        captcha_config: Optional[dict[str, Any]],
-        challenge_config: Optional[dict[str, Any]],
-        custom_response_bodies: Optional[dict[str, Any]],
-        token_domains: Optional[list[str]],
+        association_config: dict[str, Any] | None,
+        captcha_config: dict[str, Any] | None,
+        challenge_config: dict[str, Any] | None,
+        custom_response_bodies: dict[str, Any] | None,
+        token_domains: list[str] | None,
     ) -> FakeWebACL:
         wacl_id = self._generate_id()
         arn = make_arn_for_wacl(
@@ -575,7 +575,7 @@ class WAFV2Backend(BaseBackend):
         self.wacls.pop(arn)
 
     def get_web_acl(
-        self, arn: Optional[str], name: Optional[str], _id: Optional[str]
+        self, arn: str | None, name: str | None, _id: str | None
     ) -> FakeWebACL:
         if arn:
             wacl = self.wacls.get(arn)
@@ -617,16 +617,16 @@ class WAFV2Backend(BaseBackend):
         self,
         name: str,
         _id: str,
-        default_action: Optional[dict[str, Any]],
-        rules: Optional[list[dict[str, Any]]],
-        description: Optional[str],
-        visibility_config: Optional[dict[str, Any]],
+        default_action: dict[str, Any] | None,
+        rules: list[dict[str, Any]] | None,
+        description: str | None,
+        visibility_config: dict[str, Any] | None,
         lock_token: str,
-        custom_response_bodies: Optional[dict[str, Any]],
-        captcha_config: Optional[dict[str, Any]],
-        challenge_config: Optional[dict[str, Any]],
-        token_domains: Optional[list[str]],
-        association_config: Optional[dict[str, Any]],
+        custom_response_bodies: dict[str, Any] | None,
+        captcha_config: dict[str, Any] | None,
+        challenge_config: dict[str, Any] | None,
+        token_domains: list[str] | None,
+        association_config: dict[str, Any] | None,
     ) -> str:
         acl = self.get_web_acl(None, name, _id)
         if acl.lock_token != lock_token:
@@ -725,7 +725,7 @@ class WAFV2Backend(BaseBackend):
         name: str,
         scope: str,
         _id: str,
-        description: Optional[str],
+        description: str | None,
         addresses: list[str],
         lock_token: str,
     ) -> FakeIPSet:
@@ -751,7 +751,7 @@ class WAFV2Backend(BaseBackend):
         self,
         arn: str,
         log_destination_configs: list[str],
-        redacted_fields: Optional[dict[str, Any]],
+        redacted_fields: dict[str, Any] | None,
         managed_gy_firewall_manager: bool,
         logging_filter: dict[str, Any],
     ) -> FakeLoggingConfiguration:
@@ -793,11 +793,11 @@ class WAFV2Backend(BaseBackend):
         name: str,
         scope: str,
         capacity: int,
-        description: Optional[str],
-        rules: Optional[list[dict[str, Any]]],
-        visibility_config: dict[str, Union[bool, str]],
-        tags: Optional[list[dict[str, str]]],
-        custom_response_bodies: Optional[dict[str, str]],
+        description: str | None,
+        rules: list[dict[str, Any]] | None,
+        visibility_config: dict[str, bool | str],
+        tags: list[dict[str, str]] | None,
+        custom_response_bodies: dict[str, str] | None,
     ) -> FakeRuleGroup:
         id = self._generate_id()
         arn = make_arn_for_rule_group(
@@ -834,11 +834,11 @@ class WAFV2Backend(BaseBackend):
         name: str,
         scope: str,
         id: str,
-        description: Optional[str],
-        rules: Optional[list[dict[str, Any]]],
+        description: str | None,
+        rules: list[dict[str, Any]] | None,
         visibility_config: dict[str, Any],
         lock_token: str,
-        custom_response_bodies: Optional[dict[str, Any]],
+        custom_response_bodies: dict[str, Any] | None,
     ) -> FakeRuleGroup:
         arn = make_arn_for_rule_group(
             name, self.account_id, self.region_name, id, scope
@@ -874,10 +874,10 @@ class WAFV2Backend(BaseBackend):
 
     def get_rule_group(
         self,
-        name: Optional[str],
-        scope: Optional[str],
-        id: Optional[str],
-        arn: Optional[str],
+        name: str | None,
+        scope: str | None,
+        id: str | None,
+        arn: str | None,
     ) -> FakeRuleGroup:
         if not arn and not (name and scope and id):
             raise WAFV2InsufficientInformationException(name, scope, id, arn)
@@ -955,8 +955,8 @@ class WAFV2Backend(BaseBackend):
         name: str,
         scope: str,
         id: str,
-        description: Optional[str],
-        regular_expressions: Optional[list[dict[str, str]]],
+        description: str | None,
+        regular_expressions: list[dict[str, str]] | None,
         lock_token: str,
     ) -> FakeRegexPatternSet:
         arn = make_arn_for_regex_pattern_set(

--- a/moto/workspaces/models.py
+++ b/moto/workspaces/models.py
@@ -2,7 +2,7 @@
 
 import re
 from collections.abc import Mapping
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -493,7 +493,7 @@ class WorkSpacesBackend(BaseBackend):
         )
 
     def describe_workspace_directories(
-        self, directory_ids: Optional[list[str]] = None
+        self, directory_ids: list[str] | None = None
     ) -> list[WorkSpaceDirectory]:
         """Return info on all directories or directories with matching IDs."""
         # Pagination not yet implemented
@@ -583,7 +583,7 @@ class WorkSpacesBackend(BaseBackend):
         return workspace_image.to_dict()
 
     def describe_workspace_images(
-        self, image_ids: Optional[list[str]], image_type: Optional[str]
+        self, image_ids: list[str] | None, image_type: str | None
     ) -> list[dict[str, Any]]:
         # Pagination not yet implemented
         workspace_images = list(self.workspace_images.values())

--- a/moto/workspacesweb/models.py
+++ b/moto/workspacesweb/models.py
@@ -2,7 +2,7 @@
 
 import datetime
 import uuid
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -182,12 +182,12 @@ class FakePortal(BaseModel):
         self.status = "CREATED"
         self.renderer_type = "AppStream"
         self.status_reason = "TestStatusReason"
-        self.browser_settings_arn: Optional[str] = None
-        self.network_settings_arn: Optional[str] = None
-        self.trust_store_arn: Optional[str] = None
-        self.ip_access_settings_arn: Optional[str] = None
-        self.user_access_logging_settings_arn: Optional[str] = None
-        self.user_settings_arn: Optional[str] = None
+        self.browser_settings_arn: str | None = None
+        self.network_settings_arn: str | None = None
+        self.trust_store_arn: str | None = None
+        self.ip_access_settings_arn: str | None = None
+        self.user_access_logging_settings_arn: str | None = None
+        self.user_settings_arn: str | None = None
 
     def arn_formatter(self, _id: str, account_id: str, region_name: str) -> str:
         return f"arn:{get_partition(region_name)}:workspaces-web:{region_name}:{account_id}:portal/{_id}"
@@ -265,7 +265,7 @@ class WorkSpacesWebBackend(BaseBackend):
         browser_policy: str,
         client_token: str,
         customer_managed_key: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> str:
         browser_settings_object = FakeBrowserSettings(
             additional_encryption_context,
@@ -301,7 +301,7 @@ class WorkSpacesWebBackend(BaseBackend):
         display_name: str,
         instance_type: str,
         max_concurrent_sessions: str,
-        tags: Optional[list[dict[str, str]]] = None,
+        tags: list[dict[str, str]] | None = None,
     ) -> tuple[str, str]:
         portal_object = FakePortal(
             additional_encryption_context,

--- a/moto/xray/exceptions.py
+++ b/moto/xray/exceptions.py
@@ -1,12 +1,12 @@
-from typing import Any, Optional
+from typing import Any
 
 
 class BadSegmentException(Exception):
     def __init__(
         self,
-        seg_id: Optional[str] = None,
-        code: Optional[str] = None,
-        message: Optional[str] = None,
+        seg_id: str | None = None,
+        code: str | None = None,
+        message: str | None = None,
     ):
         self.id = seg_id
         self.code = code

--- a/moto/xray/models.py
+++ b/moto/xray/models.py
@@ -2,7 +2,7 @@ import bisect
 import datetime
 import json
 from collections import defaultdict
-from typing import Any, Optional
+from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
@@ -43,7 +43,7 @@ class TraceSegment(BaseModel):
         trace_id: str,
         start_time: float,
         raw: Any,
-        end_time: Optional[float] = None,
+        end_time: float | None = None,
         in_progress: bool = False,
         service: Any = None,
         user: Any = None,
@@ -59,13 +59,13 @@ class TraceSegment(BaseModel):
         self.name = name
         self.id = segment_id
         self.trace_id = trace_id
-        self._trace_version: Optional[int] = None
-        self._original_request_start_time: Optional[datetime.datetime] = None
+        self._trace_version: int | None = None
+        self._original_request_start_time: datetime.datetime | None = None
         self._trace_identifier = None
         self.start_time = start_time
-        self._start_date: Optional[datetime.datetime] = None
+        self._start_date: datetime.datetime | None = None
         self.end_time = end_time
-        self._end_date: Optional[datetime.datetime] = None
+        self._end_date: datetime.datetime | None = None
         self.in_progress = in_progress
         self.service = service
         self.user = user

--- a/moto/xray/responses.py
+++ b/moto/xray/responses.py
@@ -1,6 +1,6 @@
 import datetime
 import json
-from typing import Any, Union
+from typing import Any
 from urllib.parse import urlsplit
 
 from moto.core.exceptions import AWSError
@@ -44,7 +44,7 @@ class XRayResponse(BaseResponse):
         return ""
 
     # PutTraceSegments
-    def trace_segments(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def trace_segments(self) -> str | tuple[str, dict[str, int]]:
         docs = self._get_param("TraceSegmentDocuments")
 
         if docs is None:
@@ -72,7 +72,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # GetTraceSummaries
-    def trace_summaries(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def trace_summaries(self) -> str | tuple[str, dict[str, int]]:
         start_time = self._get_param("StartTime")
         end_time = self._get_param("EndTime")
         if start_time is None:
@@ -122,7 +122,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # BatchGetTraces
-    def traces(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def traces(self) -> str | tuple[str, dict[str, int]]:
         trace_ids = self._get_param("TraceIds")
 
         if trace_ids is None:
@@ -145,7 +145,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # GetServiceGraph - just a dummy response for now
-    def service_graph(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def service_graph(self) -> str | tuple[str, dict[str, int]]:
         start_time = self._get_param("StartTime")
         end_time = self._get_param("EndTime")
         # next_token = self._get_param('NextToken')  # not implemented yet
@@ -167,7 +167,7 @@ class XRayResponse(BaseResponse):
         return json.dumps(result)
 
     # GetTraceGraph - just a dummy response for now
-    def trace_graph(self) -> Union[str, tuple[str, dict[str, int]]]:
+    def trace_graph(self) -> str | tuple[str, dict[str, int]]:
         trace_ids = self._get_param("TraceIds")
         # next_token = self._get_param('NextToken')  # not implemented yet
 

--- a/tests/test_core/test_account_id_resolution.py
+++ b/tests/test_core/test_account_id_resolution.py
@@ -1,5 +1,4 @@
 import os
-from typing import Optional
 from unittest import SkipTest
 
 import requests
@@ -53,7 +52,7 @@ class TestAccountIdResolution:
         assert self._get_account_id(resp) == ACCOUNT_ID
 
     def _get_caller_identity(
-        self, extra_headers: Optional[dict[str, str]] = None
+        self, extra_headers: dict[str, str] | None = None
     ) -> requests.Response:
         data = "Action=GetCallerIdentity&Version=2011-06-15"
         headers = {

--- a/tests/test_core/test_auth.py
+++ b/tests/test_core/test_auth.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from typing import Any, Optional
+from typing import Any
 from unittest import SkipTest
 from uuid import uuid4
 
@@ -80,7 +80,7 @@ def create_group_with_attached_policy_and_add_user(
     user_name: str,
     policy_document: dict[str, Any],
     group_name: str = "test-group",
-    policy_name: Optional[str] = None,
+    policy_name: str | None = None,
 ) -> None:
     if not policy_name:
         policy_name = str(uuid4())
@@ -115,7 +115,7 @@ def create_group_with_multiple_policies_and_add_user(
     attached_policy_document: dict[str, Any],
     group_name: str = "test-group",
     inline_policy_name: str = "policy1",
-    attached_policy_name: Optional[str] = None,
+    attached_policy_name: str | None = None,
 ) -> None:
     if not attached_policy_name:
         attached_policy_name = str(uuid4())

--- a/tests/test_core/test_backenddict.py
+++ b/tests/test_core/test_backenddict.py
@@ -1,7 +1,7 @@
 import random
 import time
 from threading import Thread
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 
@@ -143,7 +143,7 @@ def _create_asb(
     account_id: str,
     backend: Any = None,
     use_boto3_regions: bool = False,
-    regions: Optional[list[str]] = None,
+    regions: list[str] | None = None,
 ) -> Any:
     return AccountSpecificBackend(
         service_name="ec2",

--- a/tests/test_core/utilities.py
+++ b/tests/test_core/utilities.py
@@ -1,6 +1,5 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from threading import Event, Thread
-from typing import Optional
 
 
 class SimpleServer:
@@ -8,9 +7,9 @@ class SimpleServer:
         self._port = 0
         self._handler = handler
 
-        self._thread: Optional[Thread] = None
+        self._thread: Thread | None = None
         self._ip_address = "0.0.0.0"
-        self._server: Optional[HTTPServer] = None
+        self._server: HTTPServer | None = None
         self._server_ready_event = Event()
 
     def _server_entry(self) -> None:

--- a/tests/test_ec2/__init__.py
+++ b/tests/test_ec2/__init__.py
@@ -1,7 +1,6 @@
 from contextlib import nullcontext
 from functools import wraps
 from time import sleep
-from typing import Optional
 from uuid import uuid4
 
 import boto3
@@ -31,7 +30,7 @@ def ec2_aws_verified(
     create_transit_gateway: bool = False,
     create_customer_gateway: bool = False,
     create_launch_template: bool = False,
-    launch_template_data: Optional[dict] = None,
+    launch_template_data: dict | None = None,
     return_launch_template_details: bool = False,
 ):
     """
@@ -75,7 +74,7 @@ def _invoke_func(
     create_customer_gateway: bool,
     create_launch_template: bool,
     return_launch_template_details: bool,
-    launch_template_data: Optional[dict],
+    launch_template_data: dict | None,
     func,
     kwargs,
 ):

--- a/tests/test_iotdata/test_iotdata.py
+++ b/tests/test_iotdata/test_iotdata.py
@@ -1,6 +1,5 @@
 import json
 import sys
-from typing import Optional
 from unittest import SkipTest
 
 import boto3
@@ -19,7 +18,7 @@ boto3_version = sys.modules["botocore"].__version__
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_basic(name: Optional[str] = None) -> None:
+def test_basic(name: str | None = None) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
 
     raw_payload = b'{"state": {"desired": {"led": "on"}}}'
@@ -51,7 +50,7 @@ def test_basic(name: Optional[str] = None) -> None:
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_update(name: Optional[str] = None) -> None:
+def test_update(name: str | None = None) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
     raw_payload = b'{"state": {"desired": {"led": "on"}}}'
 
@@ -99,7 +98,7 @@ def test_update(name: Optional[str] = None) -> None:
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_create_named_shadows(name: Optional[str] = None) -> None:
+def test_create_named_shadows(name: str | None = None) -> None:
     if LooseVersion(boto3_version) < LooseVersion("1.29.0"):
         raise SkipTest("Parameter only available in newer versions")
     client = boto3.client("iot-data", region_name="ap-northeast-1")
@@ -165,7 +164,7 @@ def test_publish() -> None:
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_delete_field_from_device_shadow(name: Optional[str] = None) -> None:
+def test_delete_field_from_device_shadow(name: str | None = None) -> None:
     iot = boto3.client("iot-data", region_name="ap-northeast-1")
 
     iot.update_thing_shadow(
@@ -322,11 +321,11 @@ def test_delete_field_from_device_shadow(name: Optional[str] = None) -> None:
     ],
 )
 def test_delta_calculation(
-    desired: dict[str, dict[str, Optional[bool]]],
-    initial_delta: dict[str, dict[str, Optional[bool]]],
-    reported: dict[str, dict[str, Optional[bool]]],
-    delta_after_report: dict[str, dict[str, Optional[bool]]],
-    name: Optional[str] = None,
+    desired: dict[str, dict[str, bool | None]],
+    initial_delta: dict[str, dict[str, bool | None]],
+    reported: dict[str, dict[str, bool | None]],
+    delta_after_report: dict[str, dict[str, bool | None]],
+    name: str | None = None,
 ) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
     desired_payload = json.dumps({"state": desired}).encode("utf-8")
@@ -369,7 +368,7 @@ def test_delta_calculation(
 def test_update_desired(
     initial_state: dict[str, str],
     updated_state: dict[str, str],
-    name: Optional[str] = None,
+    name: str | None = None,
 ) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
 
@@ -391,7 +390,7 @@ def test_update_desired(
 
 @iot_aws_verified()
 @pytest.mark.aws_verified
-def test_update_empty_state(name: Optional[str] = None) -> None:
+def test_update_empty_state(name: str | None = None) -> None:
     client = boto3.client("iot-data", region_name="ap-northeast-1")
 
     # CREATE

--- a/tests/test_lakeformation/test_lakeformation.py
+++ b/tests/test_lakeformation/test_lakeformation.py
@@ -1,7 +1,5 @@
 """Unit tests for lakeformation-supported APIs."""
 
-from typing import Optional
-
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -298,7 +296,7 @@ def catalog_response(principal: str) -> dict:
 
 
 def data_location_response(
-    principal: str, resource_arn: str, catalog_id: Optional[str] = None
+    principal: str, resource_arn: str, catalog_id: str | None = None
 ) -> dict:
     response = {
         "Principal": {"DataLakePrincipalIdentifier": principal},


### PR DESCRIPTION
Now that we no longer support Python 3.9 (#9989 ), we can start using `X | Y` instead of `Union[X, Y]`.