### PR TITLE
Chore: Update EC2 types

### DIFF
--- a/moto/ec2/resources/instance_types.json
+++ b/moto/ec2/resources/instance_types.json
@@ -8090,7 +8090,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -8244,7 +8244,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -8788,7 +8788,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -9092,7 +9092,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -10422,7 +10422,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -10576,7 +10576,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -10863,7 +10863,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -11231,7 +11231,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -11338,7 +11338,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -11571,7 +11571,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -11586,7 +11586,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 1,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 25.0,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -11698,7 +11698,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -11713,7 +11713,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 9,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 37.5,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -11833,7 +11833,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -11946,7 +11946,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -11964,7 +11964,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 9,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 50.0,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -12092,7 +12092,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -12207,7 +12207,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -12222,7 +12222,7 @@
    "MaximumNetworkInterfaces": 8,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 2,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 12.5,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 64,
@@ -12326,7 +12326,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -12797,7 +12797,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -12936,7 +12936,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -13208,7 +13208,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -13493,7 +13493,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -13624,7 +13624,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -13747,7 +13747,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -13972,7 +13972,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -13988,7 +13988,7 @@
    "MaximumNetworkInterfaces": 8,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 0,
+     "AdditionalFlexibleNetworkInterfaces": 4,
      "BaselineBandwidthInGbps": 75.0,
      "DefaultEnaQueueCountPerInterface": 16,
      "MaximumEnaQueueCount": 128,
@@ -14108,7 +14108,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -14124,7 +14124,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 0,
+     "AdditionalFlexibleNetworkInterfaces": 1,
      "BaselineBandwidthInGbps": 100.0,
      "DefaultEnaQueueCountPerInterface": 16,
      "MaximumEnaQueueCount": 240,
@@ -14252,7 +14252,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -14268,7 +14268,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 0,
+     "AdditionalFlexibleNetworkInterfaces": 9,
      "BaselineBandwidthInGbps": 150.0,
      "DefaultEnaQueueCountPerInterface": 32,
      "MaximumEnaQueueCount": 480,
@@ -14387,7 +14387,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -14503,7 +14503,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -14522,7 +14522,7 @@
    "MaximumNetworkInterfaces": 16,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 0,
+     "AdditionalFlexibleNetworkInterfaces": 4,
      "BaselineBandwidthInGbps": 200.0,
      "DefaultEnaQueueCountPerInterface": 32,
      "MaximumEnaQueueCount": 256,
@@ -14533,7 +14533,7 @@
      "PeakBandwidthInGbps": 200.0
     },
     {
-     "AdditionalFlexibleNetworkInterfaces": 0,
+     "AdditionalFlexibleNetworkInterfaces": 4,
      "BaselineBandwidthInGbps": 200.0,
      "DefaultEnaQueueCountPerInterface": 32,
      "MaximumEnaQueueCount": 256,
@@ -14780,7 +14780,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -14796,7 +14796,7 @@
    "MaximumNetworkInterfaces": 8,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 0,
+     "AdditionalFlexibleNetworkInterfaces": 2,
      "BaselineBandwidthInGbps": 50.0,
      "DefaultEnaQueueCountPerInterface": 16,
      "MaximumEnaQueueCount": 128,
@@ -14908,7 +14908,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -15128,7 +15128,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -16795,7 +16795,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -16969,7 +16969,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -17084,7 +17084,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -17207,7 +17207,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -17455,7 +17455,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -17556,7 +17556,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -17656,7 +17656,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -17946,7 +17946,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -18132,7 +18132,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -18394,7 +18394,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -18545,7 +18545,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -18666,7 +18666,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -18891,7 +18891,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -20129,7 +20129,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -20261,7 +20261,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -20401,7 +20401,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -20513,7 +20513,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -20629,7 +20629,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -20753,7 +20753,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -20862,7 +20862,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -21105,7 +21105,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -21246,7 +21246,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -21403,7 +21403,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -21792,7 +21792,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -21917,7 +21917,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -22026,7 +22026,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -22122,7 +22122,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -22222,7 +22222,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -23812,7 +23812,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -24148,7 +24148,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -24359,7 +24359,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -24479,7 +24479,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -24817,7 +24817,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -24961,7 +24961,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -25181,7 +25181,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -25285,7 +25285,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -27255,7 +27255,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -27615,7 +27615,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -27838,7 +27838,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -27970,7 +27970,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -28192,7 +28192,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -28332,7 +28332,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -28614,7 +28614,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -28732,7 +28732,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -28848,7 +28848,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -28965,7 +28965,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -29713,17 +29713,38 @@
   "DedicatedHostsSupported": true,
   "EbsInfo": {
    "AttachmentLimitType": "dedicated",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    },
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    }
+   ],
    "EbsOptimizedInfo": {
-    "BaselineBandwidthInMbps": 60000,
-    "BaselineIops": 240000,
-    "BaselineThroughputInMBps": 7500.0,
-    "MaximumBandwidthInMbps": 60000,
-    "MaximumIops": 240000,
-    "MaximumThroughputInMBps": 7500.0
+    "BaselineBandwidthInMbps": 120000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 15000.0,
+    "MaximumBandwidthInMbps": 120000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 15000.0
    },
    "EbsOptimizedSupport": "default",
    "EncryptionSupport": "supported",
    "MaximumEbsAttachments": 128,
+   "MaximumEbsCards": 2,
    "NvmeSupport": "required"
   },
   "FreeTierEligible": false,
@@ -33422,6 +33443,1715 @@
    ]
   }
  },
+ "c8ib.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 37500,
+    "BaselineIops": 180000,
+    "BaselineThroughputInMBps": 4687.5,
+    "MaximumBandwidthInMbps": 37500,
+    "MaximumIops": 180000,
+    "MaximumThroughputInMBps": 4687.5
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 98304
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 192,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 50000,
+    "BaselineIops": 240000,
+    "BaselineThroughputInMBps": 6250.0,
+    "MaximumBandwidthInMbps": 50000,
+    "MaximumIops": 240000,
+    "MaximumThroughputInMBps": 6250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 48,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 66.666,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "66.67 Gigabit",
+     "PeakBandwidthInGbps": 66.666
+    }
+   ],
+   "NetworkPerformance": "66.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 75000,
+    "BaselineIops": 360000,
+    "BaselineThroughputInMBps": 9375.0,
+    "MaximumBandwidthInMbps": 75000,
+    "MaximumIops": 360000,
+    "MaximumThroughputInMBps": 9375.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 100.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit",
+     "PeakBandwidthInGbps": 100.0
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 6250,
+    "BaselineIops": 30000,
+    "BaselineThroughputInMBps": 781.25,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 8.333,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 26.67 Gigabit",
+     "PeakBandwidthInGbps": 26.667
+    }
+   ],
+   "NetworkPerformance": "Up to 26.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 100000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 12500.0,
+    "MaximumBandwidthInMbps": 100000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 12500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 88,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 133.333,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 512,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "133.33 Gigabit",
+     "PeakBandwidthInGbps": 133.333
+    }
+   ],
+   "NetworkPerformance": "133.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 150000,
+    "BaselineIops": 720000,
+    "BaselineThroughputInMBps": 18750.0,
+    "MaximumBandwidthInMbps": 150000,
+    "MaximumIops": 720000,
+    "MaximumThroughputInMBps": 18750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "200 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    6,
+    9,
+    12,
+    15,
+    18,
+    21,
+    24,
+    27,
+    30,
+    33,
+    36,
+    39,
+    42,
+    45,
+    48,
+    51,
+    54,
+    57,
+    60,
+    63,
+    66,
+    69,
+    72,
+    75,
+    78,
+    81,
+    84,
+    87,
+    90,
+    93,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 12500,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1562.5,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 16.666,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 64,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 33.33 Gigabit",
+     "PeakBandwidthInGbps": 33.333
+    }
+   ],
+   "NetworkPerformance": "Up to 33.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 25000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3125.0,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 33.333,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "33.33 Gigabit",
+     "PeakBandwidthInGbps": 33.333
+    }
+   ],
+   "NetworkPerformance": "33.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.96xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    },
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 300000,
+    "BaselineIops": 1440000,
+    "BaselineThroughputInMBps": 37500.0,
+    "MaximumBandwidthInMbps": 300000,
+    "MaximumIops": 1440000,
+    "MaximumThroughputInMBps": 37500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.96xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "400 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384,
+   "ValidCores": [
+    12,
+    18,
+    24,
+    30,
+    36,
+    42,
+    48,
+    54,
+    60,
+    66,
+    72,
+    78,
+    84,
+    90,
+    96,
+    102,
+    108,
+    114,
+    120,
+    126,
+    132,
+    138,
+    144,
+    150,
+    156,
+    162,
+    168,
+    174,
+    180,
+    186,
+    192
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1563,
+    "BaselineIops": 7500,
+    "BaselineThroughputInMBps": 195.375,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.large",
+  "MemoryInfo": {
+   "SizeInMiB": 4096
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 2.083,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 16.67 Gigabit",
+     "PeakBandwidthInGbps": 16.667
+    }
+   ],
+   "NetworkPerformance": "Up to 16.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ib.metal-48xl": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "shared",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 150000,
+    "BaselineIops": 720000,
+    "BaselineThroughputInMBps": 18750.0,
+    "MaximumBandwidthInMbps": 150000,
+    "MaximumIops": 720000,
+    "MaximumThroughputInMBps": 18750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.metal-48xl",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "200 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmSupport": "unsupported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "unsupported",
+  "SupportedBootModes": [
+   "legacy-bios"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192
+  }
+ },
+ "c8ib.metal-96xl": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "shared",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    },
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 300000,
+    "BaselineIops": 1440000,
+    "BaselineThroughputInMBps": 37500.0,
+    "MaximumBandwidthInMbps": 300000,
+    "MaximumIops": 1440000,
+    "MaximumThroughputInMBps": 37500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 78,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.metal-96xl",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "400 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmSupport": "unsupported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "unsupported",
+  "SupportedBootModes": [
+   "legacy-bios"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384
+  }
+ },
+ "c8ib.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 3125,
+    "BaselineIops": 15000,
+    "BaselineThroughputInMBps": 390.625,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ib.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 4.166,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 20 Gigabit",
+     "PeakBandwidthInGbps": 20.0
+    }
+   ],
+   "NetworkPerformance": "Up to 20 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
  "c8id.12xlarge": {
   "AutoRecoverySupported": false,
   "BareMetal": false,
@@ -35270,6 +37000,2436 @@
   "SupportedUsageClasses": [
    "on-demand",
    "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 98304
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 75.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 192,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit",
+     "PeakBandwidthInGbps": 75.0
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 48,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 100.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit",
+     "PeakBandwidthInGbps": 100.0
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 30000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3750.0,
+    "MaximumBandwidthInMbps": 30000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 150.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "150 Gigabit",
+     "PeakBandwidthInGbps": 150.0
+    }
+   ],
+   "NetworkPerformance": "150 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 12.5,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 40 Gigabit",
+     "PeakBandwidthInGbps": 40.0
+    }
+   ],
+   "NetworkPerformance": "Up to 40 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 88,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 512,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "200 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 60000,
+    "BaselineIops": 240000,
+    "BaselineThroughputInMBps": 7500.0,
+    "MaximumBandwidthInMbps": 60000,
+    "MaximumIops": 240000,
+    "MaximumThroughputInMBps": 7500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "300 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    6,
+    9,
+    12,
+    15,
+    18,
+    21,
+    24,
+    27,
+    30,
+    33,
+    36,
+    39,
+    42,
+    45,
+    48,
+    51,
+    54,
+    57,
+    60,
+    63,
+    66,
+    69,
+    72,
+    75,
+    78,
+    81,
+    84,
+    87,
+    90,
+    93,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 25.0,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 64,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "Up to 50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.96xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    },
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 120000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 15000.0,
+    "MaximumBandwidthInMbps": 120000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 15000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.96xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "600 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384,
+   "ValidCores": [
+    12,
+    18,
+    24,
+    30,
+    36,
+    42,
+    48,
+    54,
+    60,
+    66,
+    72,
+    78,
+    84,
+    90,
+    96,
+    102,
+    108,
+    114,
+    120,
+    126,
+    132,
+    138,
+    144,
+    150,
+    156,
+    162,
+    168,
+    174,
+    180,
+    186,
+    192
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.large",
+  "MemoryInfo": {
+   "SizeInMiB": 4096
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 3.125,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit",
+     "PeakBandwidthInGbps": 25.0
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8in.metal-48xl": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "shared",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 60000,
+    "BaselineIops": 240000,
+    "BaselineThroughputInMBps": 7500.0,
+    "MaximumBandwidthInMbps": 60000,
+    "MaximumIops": 240000,
+    "MaximumThroughputInMBps": 7500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.metal-48xl",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "300 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmSupport": "unsupported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "unsupported",
+  "SupportedBootModes": [
+   "legacy-bios"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192
+  }
+ },
+ "c8in.metal-96xl": {
+  "AutoRecoverySupported": true,
+  "BareMetal": true,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "shared",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    },
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 120000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 15000.0,
+    "MaximumBandwidthInMbps": 120000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 15000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 78,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.metal-96xl",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "600 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmSupport": "unsupported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "unsupported",
+  "SupportedBootModes": [
+   "legacy-bios"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384
+  }
+ },
+ "c8in.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8in.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 6.25,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 30 Gigabit",
+     "PeakBandwidthInGbps": 30.0
+    }
+   ],
+   "NetworkPerformance": "Up to 30 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ine.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ine.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 98304
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 75.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 384,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit",
+     "PeakBandwidthInGbps": 75.0
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ine.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ine.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 12.5,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "12.5 Gigabit",
+     "PeakBandwidthInGbps": 12.5
+    }
+   ],
+   "NetworkPerformance": "12.5 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ine.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ine.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 25.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit",
+     "PeakBandwidthInGbps": 25.0
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ine.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ine.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ine.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ine.large",
+  "MemoryInfo": {
+   "SizeInMiB": 4096
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 3.125,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "3.12 Gigabit",
+     "PeakBandwidthInGbps": 3.125
+    }
+   ],
+   "NetworkPerformance": "3.125 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "c8ine.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "c8ine.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 6.25,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "6.25 Gigabit",
+     "PeakBandwidthInGbps": 6.25
+    }
+   ],
+   "NetworkPerformance": "6.25 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
   ],
   "SupportedVirtualizationTypes": [
    "hvm"
@@ -37348,412 +41508,6 @@
    ]
   }
  },
- "f1.16xlarge": {
-  "AutoRecoverySupported": false,
-  "BareMetal": false,
-  "BurstablePerformanceSupported": false,
-  "CurrentGeneration": true,
-  "DedicatedHostsSupported": true,
-  "EbsInfo": {
-   "AttachmentLimitType": "shared",
-   "EbsOptimizedInfo": {
-    "BaselineBandwidthInMbps": 14000,
-    "BaselineIops": 75000,
-    "BaselineThroughputInMBps": 1750.0,
-    "MaximumBandwidthInMbps": 14000,
-    "MaximumIops": 75000,
-    "MaximumThroughputInMBps": 1750.0
-   },
-   "EbsOptimizedSupport": "default",
-   "EncryptionSupport": "supported",
-   "MaximumEbsAttachments": 19,
-   "NvmeSupport": "unsupported"
-  },
-  "FpgaInfo": {
-   "Fpgas": [
-    {
-     "Count": 8,
-     "Manufacturer": "Xilinx",
-     "MemoryInfo": {
-      "SizeInMiB": 65536
-     },
-     "Name": "Virtex UltraScale (VU9P)"
-    }
-   ],
-   "TotalFpgaMemoryInMiB": 524288
-  },
-  "FreeTierEligible": false,
-  "HibernationSupported": false,
-  "Hypervisor": "xen",
-  "InstanceStorageInfo": {
-   "Disks": [
-    {
-     "Count": 4,
-     "SizeInGB": 940,
-     "Type": "ssd"
-    }
-   ],
-   "EncryptionSupport": "required",
-   "NvmeSupport": "required",
-   "TotalSizeInGB": 3760
-  },
-  "InstanceStorageSupported": true,
-  "InstanceType": "f1.16xlarge",
-  "MemoryInfo": {
-   "SizeInMiB": 999424
-  },
-  "NetworkInfo": {
-   "ConnectionTrackingConfiguration": {
-    "DefaultTcpEstablishedTimeout": 432000,
-    "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 30
-   },
-   "DefaultNetworkCardIndex": 0,
-   "EfaSupported": false,
-   "EnaSrdSupported": false,
-   "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
-   "FlexibleEnaQueuesSupport": "unsupported",
-   "Ipv4AddressesPerInterface": 50,
-   "Ipv6AddressesPerInterface": 50,
-   "Ipv6Supported": true,
-   "MaximumNetworkCards": 1,
-   "MaximumNetworkInterfaces": 8,
-   "NetworkCards": [
-    {
-     "BaselineBandwidthInGbps": 5.0,
-     "MaximumNetworkInterfaces": 8,
-     "NetworkCardIndex": 0,
-     "NetworkPerformance": "25 Gigabit",
-     "PeakBandwidthInGbps": 20.0
-    }
-   ],
-   "NetworkPerformance": "25 Gigabit",
-   "SecondaryNetworkSupported": false
-  },
-  "NitroEnclavesSupport": "unsupported",
-  "NitroTpmSupport": "unsupported",
-  "PhcSupport": "unsupported",
-  "PlacementGroupInfo": {
-   "SupportedStrategies": [
-    "cluster",
-    "partition",
-    "spread"
-   ]
-  },
-  "ProcessorInfo": {
-   "Manufacturer": "Intel",
-   "SupportedArchitectures": [
-    "x86_64"
-   ],
-   "SustainedClockSpeedInGhz": 2.3
-  },
-  "RebootMigrationSupport": "unsupported",
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
-  "SupportedRootDeviceTypes": [
-   "ebs"
-  ],
-  "SupportedUsageClasses": [
-   "on-demand",
-   "spot"
-  ],
-  "SupportedVirtualizationTypes": [
-   "hvm"
-  ],
-  "VCpuInfo": {
-   "DefaultCores": 32,
-   "DefaultThreadsPerCore": 2,
-   "DefaultVCpus": 64,
-   "ValidCores": [
-    2,
-    4,
-    6,
-    8,
-    10,
-    12,
-    14,
-    16,
-    18,
-    20,
-    22,
-    24,
-    26,
-    28,
-    30,
-    32
-   ],
-   "ValidThreadsPerCore": [
-    1,
-    2
-   ]
-  }
- },
- "f1.2xlarge": {
-  "AutoRecoverySupported": false,
-  "BareMetal": false,
-  "BurstablePerformanceSupported": false,
-  "CurrentGeneration": true,
-  "DedicatedHostsSupported": true,
-  "EbsInfo": {
-   "AttachmentLimitType": "shared",
-   "EbsOptimizedInfo": {
-    "BaselineBandwidthInMbps": 1700,
-    "BaselineIops": 12000,
-    "BaselineThroughputInMBps": 212.5,
-    "MaximumBandwidthInMbps": 1700,
-    "MaximumIops": 12000,
-    "MaximumThroughputInMBps": 212.5
-   },
-   "EbsOptimizedSupport": "default",
-   "EncryptionSupport": "supported",
-   "MaximumEbsAttachments": 26,
-   "NvmeSupport": "supported"
-  },
-  "FpgaInfo": {
-   "Fpgas": [
-    {
-     "Count": 1,
-     "Manufacturer": "Xilinx",
-     "MemoryInfo": {
-      "SizeInMiB": 65536
-     },
-     "Name": "Virtex UltraScale (VU9P)"
-    }
-   ],
-   "TotalFpgaMemoryInMiB": 65536
-  },
-  "FreeTierEligible": false,
-  "HibernationSupported": false,
-  "Hypervisor": "xen",
-  "InstanceStorageInfo": {
-   "Disks": [
-    {
-     "Count": 1,
-     "SizeInGB": 470,
-     "Type": "ssd"
-    }
-   ],
-   "EncryptionSupport": "required",
-   "NvmeSupport": "required",
-   "TotalSizeInGB": 470
-  },
-  "InstanceStorageSupported": true,
-  "InstanceType": "f1.2xlarge",
-  "MemoryInfo": {
-   "SizeInMiB": 124928
-  },
-  "NetworkInfo": {
-   "ConnectionTrackingConfiguration": {
-    "DefaultTcpEstablishedTimeout": 432000,
-    "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 30
-   },
-   "DefaultNetworkCardIndex": 0,
-   "EfaSupported": false,
-   "EnaSrdSupported": false,
-   "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
-   "FlexibleEnaQueuesSupport": "unsupported",
-   "Ipv4AddressesPerInterface": 15,
-   "Ipv6AddressesPerInterface": 15,
-   "Ipv6Supported": true,
-   "MaximumNetworkCards": 1,
-   "MaximumNetworkInterfaces": 4,
-   "NetworkCards": [
-    {
-     "BaselineBandwidthInGbps": 2.5,
-     "MaximumNetworkInterfaces": 4,
-     "NetworkCardIndex": 0,
-     "NetworkPerformance": "Up to 10 Gigabit",
-     "PeakBandwidthInGbps": 10.0
-    }
-   ],
-   "NetworkPerformance": "Up to 10 Gigabit",
-   "SecondaryNetworkSupported": false
-  },
-  "NitroEnclavesSupport": "unsupported",
-  "NitroTpmSupport": "unsupported",
-  "PhcSupport": "unsupported",
-  "PlacementGroupInfo": {
-   "SupportedStrategies": [
-    "cluster",
-    "partition",
-    "spread"
-   ]
-  },
-  "ProcessorInfo": {
-   "Manufacturer": "Intel",
-   "SupportedArchitectures": [
-    "x86_64"
-   ],
-   "SustainedClockSpeedInGhz": 2.3
-  },
-  "RebootMigrationSupport": "unsupported",
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
-  "SupportedRootDeviceTypes": [
-   "ebs"
-  ],
-  "SupportedUsageClasses": [
-   "on-demand",
-   "spot"
-  ],
-  "SupportedVirtualizationTypes": [
-   "hvm"
-  ],
-  "VCpuInfo": {
-   "DefaultCores": 4,
-   "DefaultThreadsPerCore": 2,
-   "DefaultVCpus": 8,
-   "ValidCores": [
-    1,
-    2,
-    3,
-    4
-   ],
-   "ValidThreadsPerCore": [
-    1,
-    2
-   ]
-  }
- },
- "f1.4xlarge": {
-  "AutoRecoverySupported": false,
-  "BareMetal": false,
-  "BurstablePerformanceSupported": false,
-  "CurrentGeneration": true,
-  "DedicatedHostsSupported": true,
-  "EbsInfo": {
-   "AttachmentLimitType": "shared",
-   "EbsOptimizedInfo": {
-    "BaselineBandwidthInMbps": 3500,
-    "BaselineIops": 44000,
-    "BaselineThroughputInMBps": 437.5,
-    "MaximumBandwidthInMbps": 3500,
-    "MaximumIops": 44000,
-    "MaximumThroughputInMBps": 437.5
-   },
-   "EbsOptimizedSupport": "default",
-   "EncryptionSupport": "supported",
-   "MaximumEbsAttachments": 25,
-   "NvmeSupport": "supported"
-  },
-  "FpgaInfo": {
-   "Fpgas": [
-    {
-     "Count": 2,
-     "Manufacturer": "Xilinx",
-     "MemoryInfo": {
-      "SizeInMiB": 65536
-     },
-     "Name": "Virtex UltraScale (VU9P)"
-    }
-   ],
-   "TotalFpgaMemoryInMiB": 131072
-  },
-  "FreeTierEligible": false,
-  "HibernationSupported": false,
-  "Hypervisor": "xen",
-  "InstanceStorageInfo": {
-   "Disks": [
-    {
-     "Count": 1,
-     "SizeInGB": 940,
-     "Type": "ssd"
-    }
-   ],
-   "EncryptionSupport": "required",
-   "NvmeSupport": "required",
-   "TotalSizeInGB": 940
-  },
-  "InstanceStorageSupported": true,
-  "InstanceType": "f1.4xlarge",
-  "MemoryInfo": {
-   "SizeInMiB": 249856
-  },
-  "NetworkInfo": {
-   "ConnectionTrackingConfiguration": {
-    "DefaultTcpEstablishedTimeout": 432000,
-    "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 30
-   },
-   "DefaultNetworkCardIndex": 0,
-   "EfaSupported": false,
-   "EnaSrdSupported": false,
-   "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
-   "FlexibleEnaQueuesSupport": "unsupported",
-   "Ipv4AddressesPerInterface": 30,
-   "Ipv6AddressesPerInterface": 30,
-   "Ipv6Supported": true,
-   "MaximumNetworkCards": 1,
-   "MaximumNetworkInterfaces": 8,
-   "NetworkCards": [
-    {
-     "BaselineBandwidthInGbps": 5.0,
-     "MaximumNetworkInterfaces": 8,
-     "NetworkCardIndex": 0,
-     "NetworkPerformance": "Up to 10 Gigabit",
-     "PeakBandwidthInGbps": 10.0
-    }
-   ],
-   "NetworkPerformance": "Up to 10 Gigabit",
-   "SecondaryNetworkSupported": false
-  },
-  "NitroEnclavesSupport": "unsupported",
-  "NitroTpmSupport": "unsupported",
-  "PhcSupport": "unsupported",
-  "PlacementGroupInfo": {
-   "SupportedStrategies": [
-    "cluster",
-    "partition",
-    "spread"
-   ]
-  },
-  "ProcessorInfo": {
-   "Manufacturer": "Intel",
-   "SupportedArchitectures": [
-    "x86_64"
-   ],
-   "SustainedClockSpeedInGhz": 2.3
-  },
-  "RebootMigrationSupport": "unsupported",
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
-  "SupportedRootDeviceTypes": [
-   "ebs"
-  ],
-  "SupportedUsageClasses": [
-   "on-demand",
-   "spot"
-  ],
-  "SupportedVirtualizationTypes": [
-   "hvm"
-  ],
-  "VCpuInfo": {
-   "DefaultCores": 8,
-   "DefaultThreadsPerCore": 2,
-   "DefaultVCpus": 16,
-   "ValidCores": [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8
-   ],
-   "ValidThreadsPerCore": [
-    1,
-    2
-   ]
-  }
- },
  "f2.12xlarge": {
   "AutoRecoverySupported": false,
   "BareMetal": false,
@@ -38767,8 +42521,8 @@
      },
      "Name": "Radeon Pro V520",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -38901,8 +42655,8 @@
      },
      "Name": "T4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -39497,8 +43251,8 @@
      },
      "Name": "T4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -39647,8 +43401,8 @@
      },
      "Name": "T4",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -40324,8 +44078,8 @@
      },
      "Name": "A10G",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -40593,8 +44347,8 @@
      },
      "Name": "A10G",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -40726,8 +44480,8 @@
      },
      "Name": "A10G",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -40862,8 +44616,8 @@
      },
      "Name": "A10G",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -40995,8 +44749,8 @@
      },
      "Name": "T4g",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -41179,8 +44933,8 @@
      },
      "Name": "T4g",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -41307,8 +45061,8 @@
      },
      "Name": "T4g",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -41833,8 +45587,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -41986,8 +45740,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -42140,8 +45894,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -42170,7 +45924,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -42296,8 +46050,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -42326,7 +46080,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -42470,7 +46224,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -42595,8 +46349,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -42773,7 +46527,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -42895,8 +46649,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -42925,7 +46679,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -43037,8 +46791,8 @@
      },
      "Name": "L40S",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -43339,8 +47093,8 @@
      },
      "Name": "L40S",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -43498,8 +47252,8 @@
      },
      "Name": "L40S",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -43642,8 +47396,8 @@
      },
      "Name": "L40S",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -44116,8 +47870,8 @@
      },
      "Name": "L40S",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -44258,8 +48012,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -44691,8 +48445,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -44833,8 +48587,8 @@
      },
      "Name": "RTX PRO Server 6000",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -45000,8 +48754,8 @@
      },
      "Name": "RTX PRO Server 6000",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -45199,8 +48953,8 @@
      },
      "Name": "RTX PRO Server 6000",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -45705,8 +49459,8 @@
      },
      "Name": "RTX PRO Server 6000",
      "Workloads": [
-      "ml-ai",
-      "graphics"
+      "graphics",
+      "ml-ai"
      ]
     }
    ],
@@ -45864,8 +49618,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -46012,8 +49766,8 @@
      },
      "Name": "L4",
      "Workloads": [
-      "graphics",
-      "ml-ai"
+      "ml-ai",
+      "graphics"
      ]
     }
    ],
@@ -49154,7 +52908,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -49289,7 +53043,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -49558,7 +53312,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -51117,7 +54871,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -51253,7 +55007,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -51397,7 +55151,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -51676,7 +55430,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -51940,7 +55694,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -52060,7 +55814,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -52293,7 +56047,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -52438,7 +56192,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -52763,7 +56517,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -53059,7 +56813,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -53325,7 +57079,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -53446,7 +57200,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -53554,7 +57308,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -53666,7 +57420,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -53789,7 +57543,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -53934,7 +57688,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -54091,7 +57845,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -54385,7 +58139,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -54512,7 +58266,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -54937,7 +58691,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -55045,7 +58799,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -55157,7 +58911,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -71481,7 +75235,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -71635,7 +75389,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -71919,7 +75673,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -72041,7 +75795,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -72179,7 +75933,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -72387,7 +76141,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -72483,7 +76237,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -72605,7 +76359,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -72771,7 +76525,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -73079,7 +76833,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -73483,7 +77237,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -73595,7 +77349,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -73703,7 +77457,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -73936,7 +77690,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -73951,7 +77705,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 1,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 25.0,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -74063,7 +77817,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -74078,7 +77832,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 9,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 37.5,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -74311,7 +78065,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -74329,7 +78083,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 9,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 50.0,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -74457,7 +78211,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -74572,7 +78326,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -74587,7 +78341,7 @@
    "MaximumNetworkInterfaces": 8,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 2,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 12.5,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 64,
@@ -74691,7 +78445,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -74802,7 +78556,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -75027,7 +78781,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -75162,7 +78916,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -75448,7 +79202,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -75573,7 +79327,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -76112,7 +79866,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -76224,7 +79978,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -80395,7 +84149,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -80550,7 +84304,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -80839,7 +84593,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -80962,7 +84716,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -81101,7 +84855,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -81411,7 +85165,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -81534,7 +85288,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -81701,7 +85455,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -82014,7 +85768,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -82149,7 +85903,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -82300,7 +86054,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -82421,7 +86175,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -82534,7 +86288,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -82646,7 +86400,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -82757,7 +86511,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -82889,7 +86643,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -83029,7 +86783,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -83141,7 +86895,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -83733,7 +87487,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -83874,7 +87628,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -84031,7 +87785,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -84144,7 +87898,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -84420,7 +88174,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -84654,7 +88408,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -87469,7 +91223,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -87629,7 +91383,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -87805,7 +91559,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -88346,7 +92100,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -88474,7 +92228,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -88618,7 +92372,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -88942,7 +92696,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -89047,7 +92801,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -90912,7 +94666,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -91272,7 +95026,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -91495,7 +95249,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -91627,7 +95381,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -91989,7 +95743,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -92145,7 +95899,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -92271,7 +96025,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -92505,7 +96259,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -97100,6 +100854,1479 @@
    ]
   }
  },
+ "m8ib.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 37500,
+    "BaselineIops": 180000,
+    "BaselineThroughputInMBps": 4687.5,
+    "MaximumBandwidthInMbps": 37500,
+    "MaximumIops": 180000,
+    "MaximumThroughputInMBps": 4687.5
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 192,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 50000,
+    "BaselineIops": 240000,
+    "BaselineThroughputInMBps": 6250.0,
+    "MaximumBandwidthInMbps": 50000,
+    "MaximumIops": 240000,
+    "MaximumThroughputInMBps": 6250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 48,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 66.666,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "66.67 Gigabit",
+     "PeakBandwidthInGbps": 66.666
+    }
+   ],
+   "NetworkPerformance": "66.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 75000,
+    "BaselineIops": 360000,
+    "BaselineThroughputInMBps": 9375.0,
+    "MaximumBandwidthInMbps": 75000,
+    "MaximumIops": 360000,
+    "MaximumThroughputInMBps": 9375.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 100.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit",
+     "PeakBandwidthInGbps": 100.0
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 6250,
+    "BaselineIops": 30000,
+    "BaselineThroughputInMBps": 781.25,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 8.333,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 26.67 Gigabit",
+     "PeakBandwidthInGbps": 26.667
+    }
+   ],
+   "NetworkPerformance": "Up to 26.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 100000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 12500.0,
+    "MaximumBandwidthInMbps": 100000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 12500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 88,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 133.333,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 512,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "133.33 Gigabit",
+     "PeakBandwidthInGbps": 133.333
+    }
+   ],
+   "NetworkPerformance": "133.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 150000,
+    "BaselineIops": 720000,
+    "BaselineThroughputInMBps": 18750.0,
+    "MaximumBandwidthInMbps": 150000,
+    "MaximumIops": 720000,
+    "MaximumThroughputInMBps": 18750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "200 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    6,
+    9,
+    12,
+    15,
+    18,
+    21,
+    24,
+    27,
+    30,
+    33,
+    36,
+    39,
+    42,
+    45,
+    48,
+    51,
+    54,
+    57,
+    60,
+    63,
+    66,
+    69,
+    72,
+    75,
+    78,
+    81,
+    84,
+    87,
+    90,
+    93,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 12500,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1562.5,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 16.666,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 64,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 33.33 Gigabit",
+     "PeakBandwidthInGbps": 33.333
+    }
+   ],
+   "NetworkPerformance": "Up to 33.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 25000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3125.0,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 33.333,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "33.33 Gigabit",
+     "PeakBandwidthInGbps": 33.333
+    }
+   ],
+   "NetworkPerformance": "33.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.96xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    },
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 300000,
+    "BaselineIops": 1440000,
+    "BaselineThroughputInMBps": 37500.0,
+    "MaximumBandwidthInMbps": 300000,
+    "MaximumIops": 1440000,
+    "MaximumThroughputInMBps": 37500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.96xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "400 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384,
+   "ValidCores": [
+    12,
+    18,
+    24,
+    30,
+    36,
+    42,
+    48,
+    54,
+    60,
+    66,
+    72,
+    78,
+    84,
+    90,
+    96,
+    102,
+    108,
+    114,
+    120,
+    126,
+    132,
+    138,
+    144,
+    150,
+    156,
+    162,
+    168,
+    174,
+    180,
+    186,
+    192
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1563,
+    "BaselineIops": 7500,
+    "BaselineThroughputInMBps": 195.375,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.large",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 2.083,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 16.67 Gigabit",
+     "PeakBandwidthInGbps": 16.667
+    }
+   ],
+   "NetworkPerformance": "Up to 16.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ib.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 3125,
+    "BaselineIops": 15000,
+    "BaselineThroughputInMBps": 390.625,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ib.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 4.166,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 20 Gigabit",
+     "PeakBandwidthInGbps": 20.0
+    }
+   ],
+   "NetworkPerformance": "Up to 20 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
  "m8id.12xlarge": {
   "AutoRecoverySupported": false,
   "BareMetal": false,
@@ -98966,6 +104193,2200 @@
    ]
   }
  },
+ "m8in.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 75.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 192,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit",
+     "PeakBandwidthInGbps": 75.0
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 48,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 100.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit",
+     "PeakBandwidthInGbps": 100.0
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 30000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3750.0,
+    "MaximumBandwidthInMbps": 30000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 150.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "150 Gigabit",
+     "PeakBandwidthInGbps": 150.0
+    }
+   ],
+   "NetworkPerformance": "150 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 12.5,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 40 Gigabit",
+     "PeakBandwidthInGbps": 40.0
+    }
+   ],
+   "NetworkPerformance": "Up to 40 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 88,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 512,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "200 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 60000,
+    "BaselineIops": 240000,
+    "BaselineThroughputInMBps": 7500.0,
+    "MaximumBandwidthInMbps": 60000,
+    "MaximumIops": 240000,
+    "MaximumThroughputInMBps": 7500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "300 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    6,
+    9,
+    12,
+    15,
+    18,
+    21,
+    24,
+    27,
+    30,
+    33,
+    36,
+    39,
+    42,
+    45,
+    48,
+    51,
+    54,
+    57,
+    60,
+    63,
+    66,
+    69,
+    72,
+    75,
+    78,
+    81,
+    84,
+    87,
+    90,
+    93,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 25.0,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 64,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "Up to 50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.96xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    },
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 120000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 15000.0,
+    "MaximumBandwidthInMbps": 120000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 15000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.96xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "600 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384,
+   "ValidCores": [
+    12,
+    18,
+    24,
+    30,
+    36,
+    42,
+    48,
+    54,
+    60,
+    66,
+    72,
+    78,
+    84,
+    90,
+    96,
+    102,
+    108,
+    114,
+    120,
+    126,
+    132,
+    138,
+    144,
+    150,
+    156,
+    162,
+    168,
+    174,
+    180,
+    186,
+    192
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.large",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 3.125,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit",
+     "PeakBandwidthInGbps": 25.0
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8in.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8in.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 6.25,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 30 Gigabit",
+     "PeakBandwidthInGbps": 30.0
+    }
+   ],
+   "NetworkPerformance": "Up to 30 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ine.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ine.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 196608
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 75.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 384,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit",
+     "PeakBandwidthInGbps": 75.0
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ine.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ine.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 12.5,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "12.5 Gigabit",
+     "PeakBandwidthInGbps": 12.5
+    }
+   ],
+   "NetworkPerformance": "12.5 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ine.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ine.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 25.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "25 Gigabit",
+     "PeakBandwidthInGbps": 25.0
+    }
+   ],
+   "NetworkPerformance": "25 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ine.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ine.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ine.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ine.large",
+  "MemoryInfo": {
+   "SizeInMiB": 8192
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 3.125,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "3.12 Gigabit",
+     "PeakBandwidthInGbps": 3.125
+    }
+   ],
+   "NetworkPerformance": "3.125 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "m8ine.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": false,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "m8ine.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 6.25,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "6.25 Gigabit",
+     "PeakBandwidthInGbps": 6.25
+    }
+   ],
+   "NetworkPerformance": "6.25 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
  "mac-m4.metal": {
   "AutoRecoverySupported": false,
   "BareMetal": true,
@@ -99738,399 +107159,6 @@
    "DefaultCores": 4,
    "DefaultThreadsPerCore": 2,
    "DefaultVCpus": 8
-  }
- },
- "p3.16xlarge": {
-  "AutoRecoverySupported": true,
-  "BareMetal": false,
-  "BurstablePerformanceSupported": false,
-  "CurrentGeneration": true,
-  "DedicatedHostsSupported": true,
-  "EbsInfo": {
-   "AttachmentLimitType": "shared",
-   "EbsOptimizedInfo": {
-    "BaselineBandwidthInMbps": 14000,
-    "BaselineIops": 80000,
-    "BaselineThroughputInMBps": 1750.0,
-    "MaximumBandwidthInMbps": 14000,
-    "MaximumIops": 80000,
-    "MaximumThroughputInMBps": 1750.0
-   },
-   "EbsOptimizedSupport": "default",
-   "EncryptionSupport": "supported",
-   "MaximumEbsAttachments": 19,
-   "NvmeSupport": "unsupported"
-  },
-  "FreeTierEligible": false,
-  "GpuInfo": {
-   "Gpus": [
-    {
-     "Count": 8,
-     "GpuPartitionSize": 1.0,
-     "LogicalGpuCount": 8,
-     "Manufacturer": "NVIDIA",
-     "MemoryInfo": {
-      "SizeInMiB": 16384
-     },
-     "Name": "V100",
-     "Workloads": [
-      "ml-ai"
-     ]
-    }
-   ],
-   "TotalGpuMemoryInMiB": 131072
-  },
-  "HibernationSupported": false,
-  "Hypervisor": "xen",
-  "InstanceStorageSupported": false,
-  "InstanceType": "p3.16xlarge",
-  "MemoryInfo": {
-   "SizeInMiB": 499712
-  },
-  "NetworkInfo": {
-   "ConnectionTrackingConfiguration": {
-    "DefaultTcpEstablishedTimeout": 432000,
-    "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 30
-   },
-   "DefaultNetworkCardIndex": 0,
-   "EfaSupported": false,
-   "EnaSrdSupported": false,
-   "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
-   "FlexibleEnaQueuesSupport": "unsupported",
-   "Ipv4AddressesPerInterface": 30,
-   "Ipv6AddressesPerInterface": 30,
-   "Ipv6Supported": true,
-   "MaximumNetworkCards": 1,
-   "MaximumNetworkInterfaces": 8,
-   "NetworkCards": [
-    {
-     "BaselineBandwidthInGbps": 5.0,
-     "MaximumNetworkInterfaces": 8,
-     "NetworkCardIndex": 0,
-     "NetworkPerformance": "25 Gigabit",
-     "PeakBandwidthInGbps": 10.0
-    }
-   ],
-   "NetworkPerformance": "25 Gigabit",
-   "SecondaryNetworkSupported": false
-  },
-  "NitroEnclavesSupport": "unsupported",
-  "NitroTpmSupport": "unsupported",
-  "PhcSupport": "unsupported",
-  "PlacementGroupInfo": {
-   "SupportedStrategies": [
-    "cluster",
-    "partition",
-    "spread"
-   ]
-  },
-  "ProcessorInfo": {
-   "Manufacturer": "Intel",
-   "SupportedArchitectures": [
-    "x86_64"
-   ],
-   "SustainedClockSpeedInGhz": 2.7
-  },
-  "RebootMigrationSupport": "supported",
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
-  "SupportedRootDeviceTypes": [
-   "ebs"
-  ],
-  "SupportedUsageClasses": [
-   "on-demand",
-   "spot"
-  ],
-  "SupportedVirtualizationTypes": [
-   "hvm"
-  ],
-  "VCpuInfo": {
-   "DefaultCores": 32,
-   "DefaultThreadsPerCore": 2,
-   "DefaultVCpus": 64,
-   "ValidCores": [
-    2,
-    4,
-    6,
-    8,
-    10,
-    12,
-    14,
-    16,
-    18,
-    20,
-    22,
-    24,
-    26,
-    28,
-    30,
-    32
-   ],
-   "ValidThreadsPerCore": [
-    1,
-    2
-   ]
-  }
- },
- "p3.2xlarge": {
-  "AutoRecoverySupported": true,
-  "BareMetal": false,
-  "BurstablePerformanceSupported": false,
-  "CurrentGeneration": true,
-  "DedicatedHostsSupported": true,
-  "EbsInfo": {
-   "AttachmentLimitType": "shared",
-   "EbsOptimizedInfo": {
-    "BaselineBandwidthInMbps": 1750,
-    "BaselineIops": 10000,
-    "BaselineThroughputInMBps": 218.75,
-    "MaximumBandwidthInMbps": 1750,
-    "MaximumIops": 10000,
-    "MaximumThroughputInMBps": 218.75
-   },
-   "EbsOptimizedSupport": "default",
-   "EncryptionSupport": "supported",
-   "MaximumEbsAttachments": 26,
-   "NvmeSupport": "unsupported"
-  },
-  "FreeTierEligible": false,
-  "GpuInfo": {
-   "Gpus": [
-    {
-     "Count": 1,
-     "GpuPartitionSize": 1.0,
-     "LogicalGpuCount": 1,
-     "Manufacturer": "NVIDIA",
-     "MemoryInfo": {
-      "SizeInMiB": 16384
-     },
-     "Name": "V100",
-     "Workloads": [
-      "ml-ai"
-     ]
-    }
-   ],
-   "TotalGpuMemoryInMiB": 16384
-  },
-  "HibernationSupported": false,
-  "Hypervisor": "xen",
-  "InstanceStorageSupported": false,
-  "InstanceType": "p3.2xlarge",
-  "MemoryInfo": {
-   "SizeInMiB": 62464
-  },
-  "NetworkInfo": {
-   "ConnectionTrackingConfiguration": {
-    "DefaultTcpEstablishedTimeout": 432000,
-    "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 30
-   },
-   "DefaultNetworkCardIndex": 0,
-   "EfaSupported": false,
-   "EnaSrdSupported": false,
-   "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
-   "FlexibleEnaQueuesSupport": "unsupported",
-   "Ipv4AddressesPerInterface": 15,
-   "Ipv6AddressesPerInterface": 15,
-   "Ipv6Supported": true,
-   "MaximumNetworkCards": 1,
-   "MaximumNetworkInterfaces": 4,
-   "NetworkCards": [
-    {
-     "BaselineBandwidthInGbps": 2.5,
-     "MaximumNetworkInterfaces": 4,
-     "NetworkCardIndex": 0,
-     "NetworkPerformance": "Up to 10 Gigabit",
-     "PeakBandwidthInGbps": 10.0
-    }
-   ],
-   "NetworkPerformance": "Up to 10 Gigabit",
-   "SecondaryNetworkSupported": false
-  },
-  "NitroEnclavesSupport": "unsupported",
-  "NitroTpmSupport": "unsupported",
-  "PhcSupport": "unsupported",
-  "PlacementGroupInfo": {
-   "SupportedStrategies": [
-    "cluster",
-    "partition",
-    "spread"
-   ]
-  },
-  "ProcessorInfo": {
-   "Manufacturer": "Intel",
-   "SupportedArchitectures": [
-    "x86_64"
-   ],
-   "SustainedClockSpeedInGhz": 2.7
-  },
-  "RebootMigrationSupport": "supported",
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
-  "SupportedRootDeviceTypes": [
-   "ebs"
-  ],
-  "SupportedUsageClasses": [
-   "on-demand",
-   "spot"
-  ],
-  "SupportedVirtualizationTypes": [
-   "hvm"
-  ],
-  "VCpuInfo": {
-   "DefaultCores": 4,
-   "DefaultThreadsPerCore": 2,
-   "DefaultVCpus": 8,
-   "ValidCores": [
-    1,
-    2,
-    3,
-    4
-   ],
-   "ValidThreadsPerCore": [
-    1,
-    2
-   ]
-  }
- },
- "p3.8xlarge": {
-  "AutoRecoverySupported": true,
-  "BareMetal": false,
-  "BurstablePerformanceSupported": false,
-  "CurrentGeneration": true,
-  "DedicatedHostsSupported": true,
-  "EbsInfo": {
-   "AttachmentLimitType": "shared",
-   "EbsOptimizedInfo": {
-    "BaselineBandwidthInMbps": 7000,
-    "BaselineIops": 40000,
-    "BaselineThroughputInMBps": 875.0,
-    "MaximumBandwidthInMbps": 7000,
-    "MaximumIops": 40000,
-    "MaximumThroughputInMBps": 875.0
-   },
-   "EbsOptimizedSupport": "default",
-   "EncryptionSupport": "supported",
-   "MaximumEbsAttachments": 23,
-   "NvmeSupport": "unsupported"
-  },
-  "FreeTierEligible": false,
-  "GpuInfo": {
-   "Gpus": [
-    {
-     "Count": 4,
-     "GpuPartitionSize": 1.0,
-     "LogicalGpuCount": 4,
-     "Manufacturer": "NVIDIA",
-     "MemoryInfo": {
-      "SizeInMiB": 16384
-     },
-     "Name": "V100",
-     "Workloads": [
-      "ml-ai"
-     ]
-    }
-   ],
-   "TotalGpuMemoryInMiB": 65536
-  },
-  "HibernationSupported": false,
-  "Hypervisor": "xen",
-  "InstanceStorageSupported": false,
-  "InstanceType": "p3.8xlarge",
-  "MemoryInfo": {
-   "SizeInMiB": 249856
-  },
-  "NetworkInfo": {
-   "ConnectionTrackingConfiguration": {
-    "DefaultTcpEstablishedTimeout": 432000,
-    "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 30
-   },
-   "DefaultNetworkCardIndex": 0,
-   "EfaSupported": false,
-   "EnaSrdSupported": false,
-   "EnaSupport": "supported",
-   "EncryptionInTransitSupported": false,
-   "FlexibleEnaQueuesSupport": "unsupported",
-   "Ipv4AddressesPerInterface": 30,
-   "Ipv6AddressesPerInterface": 30,
-   "Ipv6Supported": true,
-   "MaximumNetworkCards": 1,
-   "MaximumNetworkInterfaces": 8,
-   "NetworkCards": [
-    {
-     "BaselineBandwidthInGbps": 5.0,
-     "MaximumNetworkInterfaces": 8,
-     "NetworkCardIndex": 0,
-     "NetworkPerformance": "10 Gigabit",
-     "PeakBandwidthInGbps": 10.0
-    }
-   ],
-   "NetworkPerformance": "10 Gigabit",
-   "SecondaryNetworkSupported": false
-  },
-  "NitroEnclavesSupport": "unsupported",
-  "NitroTpmSupport": "unsupported",
-  "PhcSupport": "unsupported",
-  "PlacementGroupInfo": {
-   "SupportedStrategies": [
-    "cluster",
-    "partition",
-    "spread"
-   ]
-  },
-  "ProcessorInfo": {
-   "Manufacturer": "Intel",
-   "SupportedArchitectures": [
-    "x86_64"
-   ],
-   "SustainedClockSpeedInGhz": 2.7
-  },
-  "RebootMigrationSupport": "supported",
-  "SupportedBootModes": [
-   "legacy-bios"
-  ],
-  "SupportedRootDeviceTypes": [
-   "ebs"
-  ],
-  "SupportedUsageClasses": [
-   "on-demand",
-   "spot"
-  ],
-  "SupportedVirtualizationTypes": [
-   "hvm"
-  ],
-  "VCpuInfo": {
-   "DefaultCores": 16,
-   "DefaultThreadsPerCore": 2,
-   "DefaultVCpus": 32,
-   "ValidCores": [
-    1,
-    2,
-    3,
-    4,
-    5,
-    6,
-    7,
-    8,
-    9,
-    10,
-    11,
-    12,
-    13,
-    14,
-    15,
-    16
-   ],
-   "ValidThreadsPerCore": [
-    1,
-    2
-   ]
   }
  },
  "p3dn.24xlarge": {
@@ -112278,7 +119306,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -112432,7 +119460,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -112716,7 +119744,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -112838,7 +119866,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -112976,7 +120004,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -113084,7 +120112,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -114610,7 +121638,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -114625,7 +121653,7 @@
    "MaximumNetworkInterfaces": 8,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 4,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 18.75,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 64,
@@ -114733,7 +121761,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -114748,7 +121776,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 1,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 25.0,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -114860,7 +121888,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -114875,7 +121903,7 @@
    "MaximumNetworkInterfaces": 15,
    "NetworkCards": [
     {
-     "AdditionalFlexibleNetworkInterfaces": 9,
+     "AdditionalFlexibleNetworkInterfaces": 0,
      "BaselineBandwidthInGbps": 37.5,
      "DefaultEnaQueueCountPerInterface": 8,
      "MaximumEnaQueueCount": 120,
@@ -115254,7 +122282,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -115699,7 +122727,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -115824,7 +122852,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -115959,7 +122987,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -116098,7 +123126,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -116245,7 +123273,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -116370,7 +123398,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -116528,7 +123556,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -116786,7 +123814,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -117021,7 +124049,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -121521,7 +128549,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -121636,7 +128664,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -121759,7 +128787,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -122007,7 +129035,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -122108,7 +129136,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -122208,7 +129236,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -122498,7 +129526,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -122684,7 +129712,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -122811,7 +129839,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -122946,7 +129974,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -123097,7 +130125,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -123218,7 +130246,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -123331,7 +130359,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -123443,7 +130471,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -123554,7 +130582,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -123687,7 +130715,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -123985,7 +131013,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -124374,7 +131402,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -124499,7 +131527,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -124608,7 +131636,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -124704,7 +131732,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -124804,7 +131832,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -127582,7 +134610,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -127742,7 +134770,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -127918,7 +134946,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -128249,7 +135277,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -128459,7 +135487,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -128731,7 +135759,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -128845,7 +135873,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -128951,7 +135979,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -131197,7 +138225,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -131385,7 +138413,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -131962,7 +138990,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -132102,7 +139130,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -132258,7 +139286,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -132384,7 +139412,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -132502,7 +139530,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -132735,7 +139763,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -137213,6 +144241,1479 @@
    ]
   }
  },
+ "r8ib.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 37500,
+    "BaselineIops": 180000,
+    "BaselineThroughputInMBps": 4687.5,
+    "MaximumBandwidthInMbps": 37500,
+    "MaximumIops": 180000,
+    "MaximumThroughputInMBps": 4687.5
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 192,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 50000,
+    "BaselineIops": 240000,
+    "BaselineThroughputInMBps": 6250.0,
+    "MaximumBandwidthInMbps": 50000,
+    "MaximumIops": 240000,
+    "MaximumThroughputInMBps": 6250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 48,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 66.666,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "66.67 Gigabit",
+     "PeakBandwidthInGbps": 66.666
+    }
+   ],
+   "NetworkPerformance": "66.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 75000,
+    "BaselineIops": 360000,
+    "BaselineThroughputInMBps": 9375.0,
+    "MaximumBandwidthInMbps": 75000,
+    "MaximumIops": 360000,
+    "MaximumThroughputInMBps": 9375.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 100.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit",
+     "PeakBandwidthInGbps": 100.0
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 6250,
+    "BaselineIops": 30000,
+    "BaselineThroughputInMBps": 781.25,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 8.333,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 26.67 Gigabit",
+     "PeakBandwidthInGbps": 26.667
+    }
+   ],
+   "NetworkPerformance": "Up to 26.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 100000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 12500.0,
+    "MaximumBandwidthInMbps": 100000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 12500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 88,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 133.333,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 512,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "133.33 Gigabit",
+     "PeakBandwidthInGbps": 133.333
+    }
+   ],
+   "NetworkPerformance": "133.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 150000,
+    "BaselineIops": 720000,
+    "BaselineThroughputInMBps": 18750.0,
+    "MaximumBandwidthInMbps": 150000,
+    "MaximumIops": 720000,
+    "MaximumThroughputInMBps": 18750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "200 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    6,
+    9,
+    12,
+    15,
+    18,
+    21,
+    24,
+    27,
+    30,
+    33,
+    36,
+    39,
+    42,
+    45,
+    48,
+    51,
+    54,
+    57,
+    60,
+    63,
+    66,
+    69,
+    72,
+    75,
+    78,
+    81,
+    84,
+    87,
+    90,
+    93,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 12500,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1562.5,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 16.666,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 64,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 33.33 Gigabit",
+     "PeakBandwidthInGbps": 33.333
+    }
+   ],
+   "NetworkPerformance": "Up to 33.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 25000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3125.0,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 33.333,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "33.33 Gigabit",
+     "PeakBandwidthInGbps": 33.333
+    }
+   ],
+   "NetworkPerformance": "33.33 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.96xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    },
+    {
+     "BaselineBandwidthInMbps": 150000,
+     "BaselineIops": 720000,
+     "BaselineThroughputInMBps": 18750.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 150000,
+     "MaximumIops": 720000,
+     "MaximumThroughputInMBps": 18750.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 300000,
+    "BaselineIops": 1440000,
+    "BaselineThroughputInMBps": 37500.0,
+    "MaximumBandwidthInMbps": 300000,
+    "MaximumIops": 1440000,
+    "MaximumThroughputInMBps": 37500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.96xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 3145728
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "400 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384,
+   "ValidCores": [
+    12,
+    18,
+    24,
+    30,
+    36,
+    42,
+    48,
+    54,
+    60,
+    66,
+    72,
+    78,
+    84,
+    90,
+    96,
+    102,
+    108,
+    114,
+    120,
+    126,
+    132,
+    138,
+    144,
+    150,
+    156,
+    162,
+    168,
+    174,
+    180,
+    186,
+    192
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1563,
+    "BaselineIops": 7500,
+    "BaselineThroughputInMBps": 195.375,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.large",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 2.083,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 16.67 Gigabit",
+     "PeakBandwidthInGbps": 16.667
+    }
+   ],
+   "NetworkPerformance": "Up to 16.66 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8ib.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 3125,
+    "BaselineIops": 15000,
+    "BaselineThroughputInMBps": 390.625,
+    "MaximumBandwidthInMbps": 25000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3125.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8ib.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 4.166,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 20 Gigabit",
+     "PeakBandwidthInGbps": 20.0
+    }
+   ],
+   "NetworkPerformance": "Up to 20 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
  "r8id.12xlarge": {
   "AutoRecoverySupported": false,
   "BareMetal": false,
@@ -139079,6 +147580,1479 @@
    ]
   }
  },
+ "r8in.12xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 15000,
+    "BaselineIops": 60000,
+    "BaselineThroughputInMBps": 1875.0,
+    "MaximumBandwidthInMbps": 15000,
+    "MaximumIops": 60000,
+    "MaximumThroughputInMBps": 1875.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.12xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 393216
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 12,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 75.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 192,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "75 Gigabit",
+     "PeakBandwidthInGbps": 75.0
+    }
+   ],
+   "NetworkPerformance": "75 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 24,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 48,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.16xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 20000,
+    "BaselineIops": 80000,
+    "BaselineThroughputInMBps": 2500.0,
+    "MaximumBandwidthInMbps": 20000,
+    "MaximumIops": 80000,
+    "MaximumThroughputInMBps": 2500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 48,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.16xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 524288
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 100.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 64,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "100 Gigabit",
+     "PeakBandwidthInGbps": 100.0
+    }
+   ],
+   "NetworkPerformance": "100 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 32,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 64,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16,
+    17,
+    18,
+    19,
+    20,
+    21,
+    22,
+    23,
+    24,
+    25,
+    26,
+    27,
+    28,
+    29,
+    30,
+    31,
+    32
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.24xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 30000,
+    "BaselineIops": 120000,
+    "BaselineThroughputInMBps": 3750.0,
+    "MaximumBandwidthInMbps": 30000,
+    "MaximumIops": 120000,
+    "MaximumThroughputInMBps": 3750.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 64,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.24xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 786432
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 150.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 256,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "150 Gigabit",
+     "PeakBandwidthInGbps": 150.0
+    }
+   ],
+   "NetworkPerformance": "150 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 48,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 96,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.2xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 2500,
+    "BaselineIops": 12000,
+    "BaselineThroughputInMBps": 312.5,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.2xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 65536
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 12.5,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 32,
+     "MaximumEnaQueueCountPerInterface": 8,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 40 Gigabit",
+     "PeakBandwidthInGbps": 40.0
+    }
+   ],
+   "NetworkPerformance": "Up to 40 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 4,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 8,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.32xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 40000,
+    "BaselineIops": 160000,
+    "BaselineThroughputInMBps": 5000.0,
+    "MaximumBandwidthInMbps": 40000,
+    "MaximumIops": 160000,
+    "MaximumThroughputInMBps": 5000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 88,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.32xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1048576
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 16,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 200.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 512,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 16,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "200 Gigabit",
+     "PeakBandwidthInGbps": 200.0
+    }
+   ],
+   "NetworkPerformance": "200 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 64,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 128,
+   "ValidCores": [
+    4,
+    6,
+    8,
+    10,
+    12,
+    14,
+    16,
+    18,
+    20,
+    22,
+    24,
+    26,
+    28,
+    30,
+    32,
+    34,
+    36,
+    38,
+    40,
+    42,
+    44,
+    46,
+    48,
+    50,
+    52,
+    54,
+    56,
+    58,
+    60,
+    62,
+    64
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.48xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 60000,
+    "BaselineIops": 240000,
+    "BaselineThroughputInMBps": 7500.0,
+    "MaximumBandwidthInMbps": 60000,
+    "MaximumIops": 240000,
+    "MaximumThroughputInMBps": 7500.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.48xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 1572864
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 1
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 24,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "300 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 96,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 192,
+   "ValidCores": [
+    6,
+    9,
+    12,
+    15,
+    18,
+    21,
+    24,
+    27,
+    30,
+    33,
+    36,
+    39,
+    42,
+    45,
+    48,
+    51,
+    54,
+    57,
+    60,
+    63,
+    66,
+    69,
+    72,
+    75,
+    78,
+    81,
+    84,
+    87,
+    90,
+    93,
+    96
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.4xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 5000,
+    "BaselineIops": 20000,
+    "BaselineThroughputInMBps": 625.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.4xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 131072
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 25.0,
+     "DefaultEnaQueueCountPerInterface": 8,
+     "MaximumEnaQueueCount": 64,
+     "MaximumEnaQueueCountPerInterface": 16,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "Up to 50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 8,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 16,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.8xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 10000,
+    "BaselineIops": 40000,
+    "BaselineThroughputInMBps": 1250.0,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.8xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 262144
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 50,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 50,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 8,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 50.0,
+     "DefaultEnaQueueCountPerInterface": 16,
+     "MaximumEnaQueueCount": 128,
+     "MaximumEnaQueueCountPerInterface": 32,
+     "MaximumNetworkInterfaces": 8,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "50 Gigabit",
+     "PeakBandwidthInGbps": 50.0
+    }
+   ],
+   "NetworkPerformance": "50 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 16,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 32,
+   "ValidCores": [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10,
+    11,
+    12,
+    13,
+    14,
+    15,
+    16
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.96xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsCards": [
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 0,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    },
+    {
+     "BaselineBandwidthInMbps": 60000,
+     "BaselineIops": 240000,
+     "BaselineThroughputInMBps": 7500.0,
+     "EbsCardIndex": 1,
+     "MaximumBandwidthInMbps": 60000,
+     "MaximumIops": 240000,
+     "MaximumThroughputInMBps": 7500.0
+    }
+   ],
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 120000,
+    "BaselineIops": 480000,
+    "BaselineThroughputInMBps": 15000.0,
+    "MaximumBandwidthInMbps": 120000,
+    "MaximumIops": 480000,
+    "MaximumThroughputInMBps": 15000.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 128,
+   "MaximumEbsCards": 2,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.96xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 3145728
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaInfo": {
+    "MaximumEfaInterfaces": 2
+   },
+   "EfaSupported": true,
+   "EnaSrdSupported": true,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 64,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 64,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 2,
+   "MaximumNetworkInterfaces": 24,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    },
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 300.0,
+     "DefaultEnaQueueCountPerInterface": 32,
+     "MaximumEnaQueueCount": 768,
+     "MaximumEnaQueueCountPerInterface": 128,
+     "MaximumNetworkInterfaces": 12,
+     "NetworkCardIndex": 1,
+     "NetworkPerformance": "300 Gigabit",
+     "PeakBandwidthInGbps": 300.0
+    }
+   ],
+   "NetworkPerformance": "600 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 192,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 384,
+   "ValidCores": [
+    12,
+    18,
+    24,
+    30,
+    36,
+    42,
+    48,
+    54,
+    60,
+    66,
+    72,
+    78,
+    84,
+    90,
+    96,
+    102,
+    108,
+    114,
+    120,
+    126,
+    132,
+    138,
+    144,
+    150,
+    156,
+    162,
+    168,
+    174,
+    180,
+    186,
+    192
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.large": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 650,
+    "BaselineIops": 3600,
+    "BaselineThroughputInMBps": 81.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.large",
+  "MemoryInfo": {
+   "SizeInMiB": 16384
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 20,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 20,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 3.125,
+     "DefaultEnaQueueCountPerInterface": 2,
+     "MaximumEnaQueueCount": 8,
+     "MaximumEnaQueueCountPerInterface": 2,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 25 Gigabit",
+     "PeakBandwidthInGbps": 25.0
+    }
+   ],
+   "NetworkPerformance": "Up to 25 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "unsupported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 1,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 2,
+   "ValidCores": [
+    1
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
+ "r8in.xlarge": {
+  "AutoRecoverySupported": true,
+  "BareMetal": false,
+  "BurstablePerformanceSupported": false,
+  "CurrentGeneration": true,
+  "DedicatedHostsSupported": true,
+  "EbsInfo": {
+   "AttachmentLimitType": "dedicated",
+   "EbsOptimizedInfo": {
+    "BaselineBandwidthInMbps": 1250,
+    "BaselineIops": 6000,
+    "BaselineThroughputInMBps": 156.25,
+    "MaximumBandwidthInMbps": 10000,
+    "MaximumIops": 40000,
+    "MaximumThroughputInMBps": 1250.0
+   },
+   "EbsOptimizedSupport": "default",
+   "EncryptionSupport": "supported",
+   "MaximumEbsAttachments": 32,
+   "NvmeSupport": "required"
+  },
+  "FreeTierEligible": false,
+  "HibernationSupported": false,
+  "Hypervisor": "nitro",
+  "InstanceStorageSupported": false,
+  "InstanceType": "r8in.xlarge",
+  "MemoryInfo": {
+   "SizeInMiB": 32768
+  },
+  "NetworkInfo": {
+   "ConnectionTrackingConfiguration": {
+    "DefaultTcpEstablishedTimeout": 350,
+    "DefaultUdpStreamTimeout": 180,
+    "DefaultUdpTimeout": 30
+   },
+   "DefaultNetworkCardIndex": 0,
+   "EfaSupported": false,
+   "EnaSrdSupported": false,
+   "EnaSupport": "required",
+   "EncryptionInTransitSupported": true,
+   "FlexibleEnaQueuesSupport": "supported",
+   "Ipv4AddressesPerInterface": 30,
+   "Ipv4AddressesPerSecondaryInterface": 0,
+   "Ipv6AddressesPerInterface": 30,
+   "Ipv6Supported": true,
+   "MaximumNetworkCards": 1,
+   "MaximumNetworkInterfaces": 4,
+   "NetworkCards": [
+    {
+     "AdditionalFlexibleNetworkInterfaces": 0,
+     "BaselineBandwidthInGbps": 6.25,
+     "DefaultEnaQueueCountPerInterface": 4,
+     "MaximumEnaQueueCount": 16,
+     "MaximumEnaQueueCountPerInterface": 4,
+     "MaximumNetworkInterfaces": 4,
+     "NetworkCardIndex": 0,
+     "NetworkPerformance": "Up to 30 Gigabit",
+     "PeakBandwidthInGbps": 30.0
+    }
+   ],
+   "NetworkPerformance": "Up to 30 Gigabit",
+   "SecondaryNetworkSupported": false
+  },
+  "NitroEnclavesSupport": "supported",
+  "NitroTpmInfo": {
+   "SupportedVersions": [
+    "2.0"
+   ]
+  },
+  "NitroTpmSupport": "supported",
+  "PhcSupport": "unsupported",
+  "PlacementGroupInfo": {
+   "SupportedStrategies": [
+    "cluster",
+    "partition",
+    "spread"
+   ]
+  },
+  "ProcessorInfo": {
+   "Manufacturer": "Intel",
+   "SupportedArchitectures": [
+    "x86_64"
+   ],
+   "SustainedClockSpeedInGhz": 3.9
+  },
+  "RebootMigrationSupport": "supported",
+  "SupportedBootModes": [
+   "legacy-bios",
+   "uefi"
+  ],
+  "SupportedRootDeviceTypes": [
+   "ebs"
+  ],
+  "SupportedUsageClasses": [
+   "on-demand",
+   "spot"
+  ],
+  "SupportedVirtualizationTypes": [
+   "hvm"
+  ],
+  "VCpuInfo": {
+   "DefaultCores": 2,
+   "DefaultThreadsPerCore": 2,
+   "DefaultVCpus": 4,
+   "ValidCores": [
+    1,
+    2
+   ],
+   "ValidThreadsPerCore": [
+    1,
+    2
+   ]
+  }
+ },
  "t1.micro": {
   "AutoRecoverySupported": true,
   "BareMetal": false,
@@ -139812,7 +149786,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -139921,7 +149895,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -140029,7 +150003,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -140137,7 +150111,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -140245,7 +150219,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -140461,7 +150435,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -141326,7 +151300,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -141439,7 +151413,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -141546,7 +151520,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -141653,7 +151627,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -141760,7 +151734,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -141867,7 +151841,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -141974,7 +151948,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -143721,7 +153695,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -143887,7 +153861,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -147126,7 +157100,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -147262,7 +157236,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -147560,7 +157534,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -147951,7 +157925,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -148228,7 +158202,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,
@@ -148479,7 +158453,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaInfo": {
@@ -148590,7 +158564,7 @@
    "ConnectionTrackingConfiguration": {
     "DefaultTcpEstablishedTimeout": 432000,
     "DefaultUdpStreamTimeout": 180,
-    "DefaultUdpTimeout": 60
+    "DefaultUdpTimeout": 30
    },
    "DefaultNetworkCardIndex": 0,
    "EfaSupported": false,

--- a/tests/test_ec2/test_instance_types.py
+++ b/tests/test_ec2/test_instance_types.py
@@ -37,7 +37,7 @@ def test_describe_instance_types_filter_by_type():
 def test_describe_instance_types_gpu_instance_types():
     client = boto3.client("ec2", "us-east-1")
     instance_types = client.describe_instance_types(
-        InstanceTypes=["p3.2xlarge", "g4ad.8xlarge"]
+        InstanceTypes=["p3dn.24xlarge", "g4ad.8xlarge"]
     )
 
     assert len(instance_types["InstanceTypes"]) == 2
@@ -70,21 +70,21 @@ def test_describe_instance_types_gpu_instance_types():
             ],
             "TotalGpuMemoryInMiB": 16384,
         },
-        "p3.2xlarge": {
+        "p3dn.24xlarge": {
             "Gpus": [
                 {
-                    "Count": 1,
+                    "Count": 8,
                     "GpuPartitionSize": 1.0,
-                    "LogicalGpuCount": 1,
+                    "LogicalGpuCount": 8,
                     "Manufacturer": "NVIDIA",
-                    "MemoryInfo": {"SizeInMiB": 16384},
+                    "MemoryInfo": {"SizeInMiB": 32768},
                     "Name": "V100",
                     "Workloads": [
                         "ml-ai",
                     ],
                 }
             ],
-            "TotalGpuMemoryInMiB": 16384,
+            "TotalGpuMemoryInMiB": 262144,
         },
     }
 


### PR DESCRIPTION
Supercedes #9997 - a test uses a EC2 type that no longer exists, so we have to fix the test as well when updating this data.