### PR TITLE
Core: short circuit protocol detection for S3

### DIFF
--- a/moto/core/request.py
+++ b/moto/core/request.py
@@ -40,6 +40,10 @@ def determine_request_protocol(
     service_model: ServiceModel, content_type: str | None = None
 ) -> str:
     protocol = str(service_model.protocol)
+    # Short circuit protocol detection for S3 because the ContentType header
+    # is often set based on the MIME type of the object data being uploaded.
+    if service_model.service_name == "s3":
+        return protocol
     supported_protocols = service_model.metadata.get("protocols", [protocol])
     content_type = content_type if content_type is not None else ""
     if content_type in JSON_TYPES:

--- a/tests/test_s3/test_s3_multipart.py
+++ b/tests/test_s3/test_s3_multipart.py
@@ -1468,3 +1468,20 @@ def test_multipart_response_contains_checksum_attributes():
     (upload,) = bucket.multipart_uploads.all()
     assert upload.checksum_algorithm == "SHA256"
     assert upload.checksum_type == "COMPOSITE"
+
+
+@s3_aws_verified
+@pytest.mark.aws_verified()
+def test_create_multipart_upload_with_content_type(bucket_name=None):
+    # Regression test for https://github.com/getmoto/moto/issues/10010
+    s3_client = boto3.client("s3", "us-east-1")
+    s3_client.create_bucket(Bucket=bucket_name)
+    key = "my-key"
+    resp = s3_client.create_multipart_upload(
+        Bucket=bucket_name,
+        Key=key,
+        ContentType="application/json",
+    )
+    assert resp["Bucket"] == bucket_name
+    assert resp["Key"] == key
+    assert resp["UploadId"]


### PR DESCRIPTION
We can't rely on the ContentType header because it's often set based on the MIME type of the object data being uploaded.

Closes #10010 
Supersedes and Closes #10011 