### PR TITLE
Route53: update_health_check() should handle falsy values correctly

### DIFF
--- a/moto/route53/models.py
+++ b/moto/route53/models.py
@@ -848,31 +848,31 @@ class Route53Backend(BaseBackend):
         if not health_check:
             raise NoSuchHealthCheck(health_check_id)
 
-        if health_check_args.get("ip_address"):
+        if health_check_args.get("ip_address") is not None:
             health_check.ip_address = health_check_args.get("ip_address")
-        if health_check_args.get("port"):
+        if health_check_args.get("port") is not None:
             health_check.port = health_check_args.get("port")
-        if health_check_args.get("resource_path"):
+        if health_check_args.get("resource_path") is not None:
             health_check.resource_path = health_check_args.get("resource_path")
-        if health_check_args.get("fqdn"):
+        if health_check_args.get("fqdn") is not None:
             health_check.fqdn = health_check_args.get("fqdn")
-        if health_check_args.get("search_string"):
+        if health_check_args.get("search_string") is not None:
             health_check.search_string = health_check_args.get("search_string")
-        if health_check_args.get("request_interval"):
+        if health_check_args.get("request_interval") is not None:
             health_check.request_interval = health_check_args.get("request_interval")
-        if health_check_args.get("failure_threshold"):
+        if health_check_args.get("failure_threshold") is not None:
             health_check.failure_threshold = health_check_args.get("failure_threshold")
-        if health_check_args.get("health_threshold"):
+        if health_check_args.get("health_threshold") is not None:
             health_check.health_threshold = health_check_args.get("health_threshold")
-        if health_check_args.get("inverted"):
+        if health_check_args.get("inverted") is not None:
             health_check.inverted = health_check_args.get("inverted")
-        if health_check_args.get("disabled"):
+        if health_check_args.get("disabled") is not None:
             health_check.disabled = health_check_args.get("disabled")
-        if health_check_args.get("enable_sni"):
+        if health_check_args.get("enable_sni") is not None:
             health_check.enable_sni = health_check_args.get("enable_sni")
-        if health_check_args.get("children"):
+        if health_check_args.get("children") is not None:
             health_check.set_children(health_check_args.get("children", []))
-        if health_check_args.get("regions"):
+        if health_check_args.get("regions") is not None:
             health_check.set_regions(health_check_args.get("regions", []))
 
         return health_check

--- a/tests/test_route53/test_route53_healthchecks.py
+++ b/tests/test_route53/test_route53_healthchecks.py
@@ -248,15 +248,16 @@ def test_delete_health_checks():
 
 
 @mock_aws
-def test_update_health_check():
+@pytest.mark.parametrize("original_value", [True, False])
+def test_update_health_check(original_value):
     client = boto3.client("route53", region_name="us-east-1")
 
     hc_id = client.create_health_check(
         CallerReference="callref",
         HealthCheckConfig={
             "Type": "CALCULATED",
-            "Inverted": False,
-            "Disabled": False,
+            "Inverted": original_value,
+            "Disabled": original_value,
             "HealthThreshold": 1,
         },
     )["HealthCheck"]["Id"]
@@ -269,8 +270,9 @@ def test_update_health_check():
         FullyQualifiedDomainName="example.com",
         SearchString="search",
         FailureThreshold=123,
-        Inverted=False,
-        Disabled=False,
+        Inverted=not original_value,
+        Disabled=not original_value,
+        EnableSNI=not original_value,
         HealthThreshold=13,
         ChildHealthChecks=["child"],
         Regions=["us-east-1", "us-east-2", "us-west-1"],
@@ -283,8 +285,9 @@ def test_update_health_check():
     assert config["ResourcePath"] == "rp"
     assert config["FullyQualifiedDomainName"] == "example.com"
     assert config["SearchString"] == "search"
-    assert config["Inverted"] is False
-    assert config["Disabled"] is False
+    assert config["Inverted"] is not original_value
+    assert config["Disabled"] is not original_value
+    assert config["EnableSNI"] is not original_value
     assert config["ChildHealthChecks"] == ["child"]
     assert config["Regions"] == ["us-east-1", "us-east-2", "us-west-1"]
 


### PR DESCRIPTION
Fixes #10013 

Values should always be updated if they are not None. The user only mentioned the boolean values not being set, but this applies to all falsy values - `[]`, `0` are also valid values.