### PR TITLE
S3: Make CreateMultipartUpload compatible with Java SDK

### DIFF
--- a/moto/s3/2006-03-01/service-2.moto-extras.json
+++ b/moto/s3/2006-03-01/service-2.moto-extras.json
@@ -10,6 +10,11 @@
           "resultWrapper": "CopyObjectResult"
         }
       },
+      "CreateMultipartUpload": {
+        "output": {
+          "resultWrapper": "InitiateMultipartUploadResult"
+        }
+      },
       "DeleteObjects": {
         "output": {
           "resultWrapper": "DeleteResult"

--- a/other_langs/tests_java/pom.xml
+++ b/other_langs/tests_java/pom.xml
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>bom</artifactId>
-      <version>2.43.2</version>
+      <version>2.44.0</version>
       <type>pom</type>
       <scope>import</scope>
     </dependency>
@@ -67,6 +67,15 @@
           <artifactId>apache-client</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3-transfer-manager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk.crt</groupId>
+      <artifactId>aws-crt</artifactId>
+      <version>0.45.2</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>

--- a/other_langs/tests_java/src/test/java/moto/tests/S3Test.java
+++ b/other_langs/tests_java/src/test/java/moto/tests/S3Test.java
@@ -1,11 +1,21 @@
 package moto.tests;
 
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.transfer.s3.S3TransferManager;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -65,5 +75,35 @@ class S3Test
         // Delete Bucket
         DeleteBucketRequest deleteBucketRequest = DeleteBucketRequest.builder().bucket(bucketName).build();
         s3Client.deleteBucket(deleteBucketRequest);
+    }
+
+    @Test
+    void upload_file_using_transfer_manager() {
+        var inputStream = new ByteArrayInputStream("test-content".getBytes());
+        var client = S3AsyncClient.crtBuilder()
+                .forcePathStyle(true)
+                .endpointOverride(URI.create("http://localhost:5000"))
+                .region(Region.of("eu-central-1"))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create("test", "test")))
+                .build();
+
+        client.createBucket(builder -> builder.bucket("test-bucket"));
+
+        var transferManager = S3TransferManager.builder()
+                .s3Client(client)
+                .build();
+        var executor = Executors.newSingleThreadExecutor();
+        var body = AsyncRequestBody.fromInputStream(inputStream, null, executor);
+
+        var upload = transferManager.upload(builder -> builder
+                .requestBody(body)
+                .putObjectRequest(req -> req.bucket("test-bucket").key("test-key"))
+                .build());
+
+        upload.completionFuture().join();
+        executor.shutdown();
+        transferManager.close();
+        client.close();
     }
 }


### PR DESCRIPTION
Fixes #10015

### Description

The XML response for the `CreateMultipartUpload` had the wrong value - in Moto 5.1.x it was `InitiateMultipartUploadResult`, but in 5.2 it changed to `CreateMultipartUploadResponse`.

Most SDK's do not care about the exact value, but Java does - and because it cannot parse the response, the user gets an error: 
> Upload Id not found in create-multipart-upload response

### Tests

The Java test included in this PR verifies the fix - it passes on Moto 5.1.x, fails on Moto 5.2.0, and passes again with this change.
