### PR TITLE
Core: Disable flaky AWS tests

### DIFF
--- a/tests/test_dynamodb/test_dynamodb_export_table.py
+++ b/tests/test_dynamodb/test_dynamodb_export_table.py
@@ -20,11 +20,8 @@ from . import dynamodb_aws_verified
 @pytest.mark.aws_verified
 @dynamodb_aws_verified(create_table=False)
 @s3_aws_verified
-def test_export_from_missing_table(table_name=None, bucket_name=None):
+def test_export_from_missing_table(account_id, table_name=None, bucket_name=None):
     client = boto3.client("dynamodb", region_name="us-east-1")
-    sts = boto3.client("sts", "us-east-1")
-
-    account_id = sts.get_caller_identity()["Account"]
 
     s3_prefix = "prefix"
     table_arn = f"arn:aws:dynamodb:us-east-1:{account_id}:table/{str(uuid4())}"
@@ -121,7 +118,8 @@ def test_export_backup_to_s3_error(table_name=None, bucket_name=None):
     assert export_details["FailureCode"] == "UNKNOWN"
 
 
-@pytest.mark.aws_verified
+# Verified against AWS, and works consistently - just very slow (10+ minutes), that's why we're disabling it
+# @pytest.mark.aws_verified
 @dynamodb_aws_verified()
 @s3_aws_verified
 def test_export_empty_table(table_name=None, bucket_name=None):
@@ -168,7 +166,8 @@ def test_export_empty_table(table_name=None, bucket_name=None):
             assert file_contents == b""
 
 
-@pytest.mark.aws_verified
+# Verified against AWS, and works consistently - just very slow (10+ minutes), that's why we're disabling it
+# @pytest.mark.aws_verified
 @dynamodb_aws_verified()
 @s3_aws_verified
 def test_export_table(account_id, table_name=None, bucket_name=None):
@@ -235,7 +234,8 @@ def test_export_table(account_id, table_name=None, bucket_name=None):
             assert {"Item": {"pk": {"S": "user3"}, "foo": {"S": "bar"}}} in rows
 
 
-@pytest.mark.aws_verified
+# Verified against AWS, and works consistently - just very slow (10+ minutes), that's why we're disabling it
+# @pytest.mark.aws_verified
 @dynamodb_aws_verified()
 @s3_aws_verified
 def test_list_exports(table_name=None, bucket_name=None):

--- a/tests/test_ec2/test_fleets.py
+++ b/tests/test_ec2/test_fleets.py
@@ -1079,7 +1079,8 @@ def test_version_resolves_to_actual_version_number(version_specified, ec2_client
             ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=True)
 
 
-@pytest.mark.aws_verified
+# Verified against AWS, but flaky - that's why we do not run it against AWS
+# @pytest.mark.aws_verified
 @ec2_aws_verified()
 def test_fleet_uses_data_from_specified_template_version(ec2_client=None):
     with launch_template_context(region=ec2_client.meta.region_name) as ctxt:
@@ -1118,7 +1119,8 @@ def test_fleet_uses_data_from_specified_template_version(ec2_client=None):
             ctxt.ec2.delete_fleets(FleetIds=[fleet_id], TerminateInstances=True)
 
 
-@pytest.mark.aws_verified
+# Verified against AWS, but flaky - that's why we do not run it against AWS
+# @pytest.mark.aws_verified
 @ec2_aws_verified()
 @pytest.mark.parametrize(
     "use_template_name", [False, True], ids=["template-id", "template-name"]

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -3483,7 +3483,8 @@ def test_run_instances__instance_type_override_takes_priority(
 
 
 @ec2_aws_verified()
-@pytest.mark.aws_verified
+# Verified against AWS, but is flaky - that's why we do not run it against AWS
+# @pytest.mark.aws_verified
 def test_run_instances__key_name_from_launch_template(ec2_client=None):
     """KeyName in a launch template is applied when not supplied in RunInstances."""
     ami_id = _get_ami_id(ec2_client)
@@ -3511,7 +3512,8 @@ def test_run_instances__key_name_from_launch_template(ec2_client=None):
 
 
 @ec2_aws_verified()
-@pytest.mark.aws_verified
+# @pytest.mark.aws_verified
+# Verified against AWS, but it's flaky - that's why it's disabled against AWS
 def test_run_instances__security_group_ids_from_launch_template(ec2_client=None):
     """SecurityGroupIds in a launch template are applied when not supplied in RunInstances."""
     ami_id = _get_ami_id(ec2_client)

--- a/tests/test_secretsmanager/test_secretsmanager.py
+++ b/tests/test_secretsmanager/test_secretsmanager.py
@@ -1272,7 +1272,8 @@ def lambda_handler(event, context):
     return _process_lambda(func_str)
 
 
-@pytest.mark.aws_verified
+# Verified to work against AWS, but flaky - that's why it's not enabled against AWS
+# @pytest.mark.aws_verified
 @dynamodb_aws_verified()
 @lambda_aws_verified
 @secretsmanager_aws_verified
@@ -1371,7 +1372,8 @@ def test_rotate_secret_using_lambda(secret=None, iam_role_arn=None, table_name=N
     assert finish_secret["pending_value"]["VersionStages"] == ["AWSPENDING"]
 
 
-@pytest.mark.aws_verified
+# Verified to work against AWS, but flaky - that's why it's not enabled against AWS
+# @pytest.mark.aws_verified
 @dynamodb_aws_verified()
 @lambda_aws_verified
 @secretsmanager_aws_verified


### PR DESCRIPTION
We run all tests marked with `aws_verified` against AWS on a weekly basis, but there are quite a few tests that are flaky. They will typically pass just fine when you run them locally, but fail when running all tests at the same time.

This PR disables a few notorious examples, and also disables some tests that are sturdy, but simply takes too much time.