### PR TITLE
Events: update CreatePartnerEventSource response

### DIFF
--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -2092,7 +2092,9 @@ class EventsBackend(BaseBackend):
                 f"An api-destination '{name}' does not exist."
             )
 
-    def create_partner_event_source(self, name: str, account_id: str) -> None:
+    def create_partner_event_source(
+        self, name: str, account_id: str
+    ) -> PartnerEventSource:
         # https://docs.aws.amazon.com/eventbridge/latest/onboarding/amazon_eventbridge_partner_onboarding_guide.html
         if name not in self.partner_event_sources:
             self.partner_event_sources[name] = PartnerEventSource(

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -2101,6 +2101,7 @@ class EventsBackend(BaseBackend):
         self.partner_event_sources[name].accounts.append(account_id)
         client_backend = events_backends[account_id][self.region_name]
         client_backend.event_sources[name] = self.partner_event_sources[name]
+        return self.partner_event_sources[name]
 
     def describe_event_source(self, name: str) -> PartnerEventSource:
         return self.event_sources[name]

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -543,11 +543,11 @@ class EventsHandler(BaseResponse):
     def create_partner_event_source(self) -> str:
         name = self._get_param("Name")
         account_id = self._get_param("Account")
-        self.events_backend.create_partner_event_source(
+        partner_event_source = self.events_backend.create_partner_event_source(
             name=name,
             account_id=account_id,
         )
-        return "{}"
+        return json.dumps({"EventSourceArn": partner_event_source.arn})
 
     def describe_event_source(self) -> str:
         name = self._get_param("Name")

--- a/tests/test_events/test_events_partners_integration.py
+++ b/tests/test_events/test_events_partners_integration.py
@@ -34,7 +34,8 @@ def test_describe_partner_event_busses():
     client = boto3.client("events", "us-east-1")
     name = "mypartner/actions/action1"
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": partner_account}):
-        client.create_partner_event_source(Name=name, Account=client_account)
+        resp = client.create_partner_event_source(Name=name, Account=client_account)
+        assert resp["EventSourceArn"] == name
 
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": client_account}):
         resp = client.describe_event_source(Name=name)

--- a/tests/test_events/test_events_partners_integration.py
+++ b/tests/test_events/test_events_partners_integration.py
@@ -12,15 +12,13 @@ from moto import mock_aws, settings
 def test_create_partner_event_bus():
     client_account = "111122223333"
     client = boto3.client("events", "us-east-1")
-    client.create_partner_event_source(
-        Name="mypartner/actions/action1", Account=client_account
-    )
-    resp = client.describe_partner_event_source(Name="mypartner/actions/action1")
-    assert (
-        resp["Arn"]
-        == "arn:aws:events:us-east-1::event-source/aws.partner/mypartner/actions/action1"
-    )
-    assert resp["Name"] == "mypartner/actions/action1"
+    es_name = "mypartner/actions/action1"
+    expected_arn = f"arn:aws:events:us-east-1::event-source/aws.partner/{es_name}"
+    resp = client.create_partner_event_source(Name=es_name, Account=client_account)
+    assert resp["EventSourceArn"] == expected_arn
+    resp = client.describe_partner_event_source(Name=es_name)
+    assert resp["Arn"] == expected_arn
+    assert resp["Name"] == es_name
 
 
 @mock_aws
@@ -34,8 +32,7 @@ def test_describe_partner_event_busses():
     client = boto3.client("events", "us-east-1")
     name = "mypartner/actions/action1"
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": partner_account}):
-        resp = client.create_partner_event_source(Name=name, Account=client_account)
-        assert resp["EventSourceArn"] == name
+        client.create_partner_event_source(Name=name, Account=client_account)
 
     with mock.patch.dict(os.environ, {"MOTO_ACCOUNT_ID": client_account}):
         resp = client.describe_event_source(Name=name)


### PR DESCRIPTION


Per AWS documentation: https://docs.aws.amazon.com/boto3/latest/reference/services/events/client/create_partner_event_source.html

create_partner_event_source returns EventSourceArn which contains the ARN of the created partner event source