### PR TITLE
Utilities: Use importlib to load resources

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -161,7 +161,7 @@ class _DockerDataVolumeContext:
                 with zip2tar(self._lambda_func.code_bytes) as stream:
                     container.put_archive(settings.LAMBDA_DATA_DIR, stream)
                 if settings.is_test_proxy_mode():
-                    ca_cert = load_resource_as_bytes(__name__, "../moto_proxy/ca.crt")
+                    ca_cert = load_resource_as_bytes("moto_proxy/ca.crt")
                     with file2tar(ca_cert, "ca.crt") as cert_stream:
                         container.put_archive(settings.LAMBDA_DATA_DIR, cert_stream)
             finally:

--- a/moto/cognitoidp/models.py
+++ b/moto/cognitoidp/models.py
@@ -446,7 +446,7 @@ class CognitoIdpUserPool(BaseModel):
         self.access_tokens: dict[str, tuple[str, str]] = {}
         self.id_tokens: dict[str, tuple[str, str]] = {}
 
-        jwks_file = load_resource(__name__, "resources/jwks-private.json")
+        jwks_file = load_resource("cognitoidp/resources/jwks-private.json")
         self.json_web_key = jwk.RSAKey.import_key(jwks_file)
 
     @property

--- a/moto/cognitoidp/responses.py
+++ b/moto/cognitoidp/responses.py
@@ -638,7 +638,7 @@ class CognitoIdpResponse(BaseResponse):
 
 class CognitoIdpJsonWebKeyResponse(BaseResponse):
     json_web_key = json.dumps(
-        load_resource(__name__, "resources/jwks-public.json")
+        load_resource("cognitoidp/resources/jwks-public.json")
     ).encode("utf-8")
 
     def __init__(self) -> None:

--- a/moto/config/models.py
+++ b/moto/config/models.py
@@ -84,7 +84,7 @@ CAMEL_TO_SNAKE_REGEX = re.compile(r"(?<!^)(?=[A-Z])")
 
 MAX_TAGS_IN_ARG = 50
 
-MANAGED_RULES = load_resource(__name__, "resources/aws_managed_rules.json")
+MANAGED_RULES = load_resource("config/resources/aws_managed_rules.json")
 MANAGED_RULES_CONSTRAINTS = MANAGED_RULES["ManagedRules"]
 
 DEFAULT_RETENTION_PERIOD = 30

--- a/moto/dynamodb/parsing/reserved_keywords.py
+++ b/moto/dynamodb/parsing/reserved_keywords.py
@@ -21,5 +21,7 @@ class ReservedKeywords:
         """
         Get a list of reserved keywords of DynamoDB
         """
-        reserved_keywords = load_resource_as_str(__name__, "reserved_keywords.txt")
+        reserved_keywords = load_resource_as_str(
+            "dynamodb/parsing/reserved_keywords.txt"
+        )
         return reserved_keywords.split()

--- a/moto/ec2/models/amis.py
+++ b/moto/ec2/models/amis.py
@@ -5,7 +5,7 @@ import os
 import re
 from datetime import datetime
 from os import environ
-from typing import Any, cast
+from typing import Any
 
 from moto import settings
 from moto.core.parse import default_timestamp_parser as parse_timestamp
@@ -30,7 +30,7 @@ if "MOTO_AMIS_PATH" in environ:
     with open(environ["MOTO_AMIS_PATH"], encoding="utf-8") as f:
         AMIS: list[dict[str, Any]] = json.load(f)
 else:
-    AMIS = load_resource(__name__, "../resources/amis.json")
+    AMIS = load_resource("ec2/resources/amis.json")
 
 
 class Ami(TaggedEC2Resource):
@@ -198,12 +198,8 @@ class AmiBackend:
         if "MOTO_AMIS_PATH" not in environ:
             for path in ["latest_amis", "ecs/optimized_amis"]:
                 try:
-                    latest_amis = cast(
-                        list[dict[str, Any]],
-                        load_resource(
-                            __name__,
-                            f"../resources/{path}/{self.region_name}.json",  # type: ignore[attr-defined]
-                        ),
+                    latest_amis: list[dict[str, Any]] = load_resource(
+                        f"ec2/resources/{path}/{self.region_name}.json",  # type: ignore[attr-defined]
                     )
                     for ami in latest_amis:
                         ami_id = ami["ami_id"]

--- a/moto/ec2/models/instance_types.py
+++ b/moto/ec2/models/instance_types.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from os import listdir
 from typing import Any
@@ -7,22 +8,20 @@ from moto.utilities.utils import load_resource
 from ..exceptions import InvalidFilter, InvalidInstanceTypeError
 from ..utils import generic_filter
 
-INSTANCE_TYPES: dict[str, Any] = load_resource(
-    __name__, "../resources/instance_types.json"
-)
+INSTANCE_TYPES: dict[str, Any] = load_resource("ec2/resources/instance_types.json")
 INSTANCE_FAMILIES = list({i.split(".")[0] for i in INSTANCE_TYPES.keys()})
 
-root = pathlib.Path(__file__).parent
-offerings_path = "../resources/instance_type_offerings"
+root = pathlib.Path(__file__).parent.parent
+offerings_path = "resources/instance_type_offerings"
 INSTANCE_TYPE_OFFERINGS: dict[str, Any] = {}
 for _location_type in listdir(root / offerings_path):
     INSTANCE_TYPE_OFFERINGS[_location_type] = {}
     for data_file in listdir(root / offerings_path / _location_type):
         # data_file = {region}.{content_type}
         # E.g.: us-east-1.json or eu-west-1.json.gz
-        full_path = offerings_path + "/" + _location_type + "/" + data_file
+        full_path = os.path.join("ec2", offerings_path, _location_type, data_file)
         _region = data_file.split(".")[0]
-        res = load_resource(__name__, full_path)
+        res = load_resource(full_path)
         for instance in res:
             instance["LocationType"] = _location_type
         INSTANCE_TYPE_OFFERINGS[_location_type][_region] = res

--- a/moto/emr/models.py
+++ b/moto/emr/models.py
@@ -845,19 +845,17 @@ class ElasticMapReduceBackend(BaseBackend):
     @cached_property
     def _release_labels(self) -> list[str]:
         """Returns all available release labels in this region"""
-        return load_resource(
-            __name__, f"resources/release-labels-{self.region_name}.json"
-        )
+        return load_resource(f"emr/resources/release-labels-{self.region_name}.json")
 
     @cache
     def _get_instance_type_names(self, release_label: str) -> list[str]:
         """Returns all instance type names that can be used with this release label"""
-        return load_resource(__name__, f"resources/instance-types-{release_label}.json")
+        return load_resource(f"emr/resources/instance-types-{release_label}.json")
 
     @cached_property
     def _instance_types(self) -> dict[str, Any]:
         """Returns a dictionary of {instance-type-name: instance-type-details}"""
-        return load_resource(__name__, "resources/instance_types.json")
+        return load_resource("emr/resources/instance_types.json")
 
     @property
     def ec2_backend(self) -> EC2Backend:

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -2509,9 +2509,7 @@ class RDSBackend(BaseBackend):
     def db_cluster_options(self, engine) -> list[dict[str, Any]]:  # type: ignore
         from moto.rds.utils import decode_orderable_db_instance
 
-        decoded_options = load_resource(
-            __name__, f"resources/cluster_options/{engine}.json"
-        )
+        decoded_options = load_resource(f"rds/resources/cluster_options/{engine}.json")
         self._db_cluster_options = [
             decode_orderable_db_instance(option) for option in decoded_options
         ]
@@ -3209,7 +3207,7 @@ class RDSBackend(BaseBackend):
         filtered_options = []
         try:
             options = load_resource(
-                __name__, f"resources/option_group_options/{engine_name}.json"
+                f"rds/resources/option_group_options/{engine_name}.json"
             )
         except (FileNotFoundError, TypeError):
             raise InvalidParameterValue(f"Invalid DB engine: {engine_name}")

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import hashlib
 import json
+import os
 import re
 from collections import defaultdict
 from collections.abc import Iterator
@@ -71,23 +72,23 @@ class ParameterDict(defaultdict[str, list["Parameter"]]):
                 self.latest_amis_loaded = True
         if key.startswith("/aws/service/global-infrastructure/regions"):
             if not self.latest_region_defaults_loaded:
-                self._load_tree_parameters(path="resources/regions.json")
+                self._load_tree_parameters(path="regions.json")
                 self.latest_region_defaults_loaded = True
         if key.startswith("/aws/service/global-infrastructure/services"):
             if not self.latest_service_defaults_loaded:
-                self._load_tree_parameters(path="resources/services.json")
+                self._load_tree_parameters(path="services.json")
                 self.latest_service_defaults_loaded = True
         if key.startswith("/aws/service/ecs/optimized-ami"):
             if not self.latest_ecs_amis_loaded:
                 self._load_tree_parameters(
-                    f"resources/ecs/optimized_amis/{self.region_name}.json"
+                    f"ecs/optimized_amis/{self.region_name}.json"
                 )
                 self.latest_ecs_amis_loaded = True
 
     def _load_latest_amis(self) -> None:
         try:
             latest_amis_linux = load_resource(
-                __name__, f"resources/ami-amazon-linux-latest/{self.region_name}.json"
+                f"ssm/resources/ami-amazon-linux-latest/{self.region_name}.json"
             )
         except FileNotFoundError:
             latest_amis_linux = []
@@ -110,7 +111,9 @@ class ParameterDict(defaultdict[str, list["Parameter"]]):
 
     def _load_tree_parameters(self, path: str) -> None:
         try:
-            params = convert_to_params(load_resource(__name__, path))
+            params = convert_to_params(
+                load_resource(os.path.join("ssm", "resources", path))
+            )
         except FileNotFoundError:
             params = []
 
@@ -1256,7 +1259,7 @@ class FakePatchGroup:
     def _load_latest_baselines(self) -> None:
         try:
             latest_patch_baselines = load_resource(
-                __name__, "resources/default_baselines.json"
+                "ssm/resources/default_baselines.json"
             )
         except FileNotFoundError:
             latest_patch_baselines = {}

--- a/moto/support/models.py
+++ b/moto/support/models.py
@@ -6,8 +6,7 @@ from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.utils import load_resource
 
-checks_json = "resources/describe_trusted_advisor_checks.json"
-ADVISOR_CHECKS = load_resource(__name__, checks_json)
+ADVISOR_CHECKS = load_resource("support/resources/describe_trusted_advisor_checks.json")
 
 
 class SupportCase(ManagedState):

--- a/moto/utilities/utils.py
+++ b/moto/utilities/utils.py
@@ -1,8 +1,8 @@
 import gzip
 import hashlib
 import json
-import pkgutil
 from collections.abc import Iterator, MutableMapping
+from importlib import resources
 from typing import Any, TypeVar
 from uuid import UUID
 
@@ -40,29 +40,31 @@ def str2bool(v: Any) -> bool | None:
     return None
 
 
-def load_resource(package: str, resource: str) -> Any:
+def load_resource(resource: str) -> Any:
     """
     Open a file, and return the contents as JSON.
-    Will try to load a compressed version (resources/file.json.gz) first, if it exists.
+    Will try to load a compressed version (file.json.gz) first, if it exists.
     Usage:
-    load_resource(__name__, "resources/file.json")
+    load_resource("ec2/resources/file.json")
     """
     try:
         compressed_resource = resource
         if not resource.endswith(".gz"):
             compressed_resource = f"{resource}.gz"
-        data = gzip.decompress(pkgutil.get_data(package, compressed_resource))  # type: ignore
+        data: str | bytes = gzip.decompress(load_resource_as_bytes(compressed_resource))
     except FileNotFoundError:
-        data = pkgutil.get_data(package, resource)  # type: ignore
+        data = load_resource_as_str(resource)
     return json.loads(data)
 
 
-def load_resource_as_str(package: str, resource: str) -> str:
-    return load_resource_as_bytes(package, resource).decode("utf-8")
+def load_resource_as_str(resource: str) -> str:
+    resource_path = resources.files("moto") / resource
+    return resource_path.read_text(encoding="utf-8").strip()
 
 
-def load_resource_as_bytes(package: str, resource: str) -> bytes:
-    return pkgutil.get_data(package, resource)  # type: ignore
+def load_resource_as_bytes(resource: str) -> bytes:
+    resource_path = resources.files("moto") / resource
+    return resource_path.read_bytes()
 
 
 def merge_multiple_dicts(*args: Any) -> dict[str, Any]:

--- a/tests/test_cognitoidp/test_cognitoidp.py
+++ b/tests/test_cognitoidp/test_cognitoidp.py
@@ -19,7 +19,7 @@ from botocore.exceptions import ClientError
 from joserfc import jwk, jws, jwt
 
 import moto.cognitoidp.models
-from moto import cognitoidp, mock_aws, settings
+from moto import mock_aws, settings
 from moto.cognitoidp.utils import create_id
 from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from moto.core import set_initial_no_auth_action_count
@@ -27,7 +27,7 @@ from moto.utilities.utils import load_resource
 from tests import allow_aws_request
 from tests.test_cognitoidp import cognitoidp_aws_verified
 
-private_key = load_resource(cognitoidp.__name__, "resources/jwks-private.json")
+private_key = load_resource("cognitoidp/resources/jwks-private.json")
 PUBLIC_KEY = jwk.RSAKey.import_key(private_key)
 
 
@@ -3516,7 +3516,7 @@ def test_user_authentication_flow_mfa_optional(user_pool=None, user_pool_client=
 def test_token_legitimacy():
     conn = boto3.client("cognito-idp", "us-west-2")
 
-    public_key = load_resource(cognitoidp.__name__, "resources/jwks-public.json")
+    public_key = load_resource("cognitoidp/resources/jwks-public.json")
     json_web_key = jwk.RSAKey.import_key(public_key["keys"][0])
 
     for auth_flow in ["ADMIN_NO_SRP_AUTH", "ADMIN_USER_PASSWORD_AUTH"]:

--- a/tests/test_ssm/test_ssm_patch_group.py
+++ b/tests/test_ssm/test_ssm_patch_group.py
@@ -162,9 +162,9 @@ def test_get_patch_baseline_for_patch_group_default():
     region = "us-east-2"
     client = boto3.client("ssm", region_name=region)
     patch_group_name = "test"
-    default_baseline = load_resource(
-        __name__, "../../moto/ssm/resources/default_baselines.json"
-    )[region]["AMAZON_LINUX"]
+    default_baseline = load_resource("ssm/resources/default_baselines.json")[region][
+        "AMAZON_LINUX"
+    ]
 
     resp = client.get_patch_baseline_for_patch_group(
         OperatingSystem="AMAZON_LINUX", PatchGroup=patch_group_name
@@ -222,9 +222,9 @@ def test_deregister_patch_baseline_for_patch_group_default():
     region = "us-east-2"
     client = boto3.client("ssm", region_name=region)
     patch_group_name = "test"
-    default_baseline = load_resource(
-        __name__, "../../moto/ssm/resources/default_baselines.json"
-    )[region]["AMAZON_LINUX"]
+    default_baseline = load_resource("ssm/resources/default_baselines.json")[region][
+        "AMAZON_LINUX"
+    ]
     resp = client.deregister_patch_baseline_for_patch_group(
         BaselineId=default_baseline, PatchGroup=patch_group_name
     )


### PR DESCRIPTION
We were using `pkgutil` to load packaged resources, but the 'modern' way to achieve this is using `from importlib import resources`.

The biggest reason for this is that our usage of `pkgutil` (using the `..` notation to reach parent components) will stop working in later Python versions for security reasons - see https://www.cve.org/CVERecord?id=CVE-2026-3479

With `from importlib import resources` we can simply point to the full path (for example: `ec2/resources/stuff.json`), regardless of where we're loading the resource from, avoiding the need for using `..` altogether.

Fixes #9976

Closes #10022