### PR TITLE
Add support for Amazon Event Stream response serialization

### DIFF
--- a/moto/core/eventstream.py
+++ b/moto/core/eventstream.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from binascii import crc32
+from collections.abc import Iterator, Mapping
+from datetime import datetime
+from struct import pack
+from typing import TYPE_CHECKING, Any
+
+from moto.core.model import StructureShape
+
+if TYPE_CHECKING:
+    from moto.core.model import Shape
+    from moto.core.serialize import BaseEventStreamSerializer
+
+
+class EncodeUtils:
+    """Packing utility functions used in the encoder."""
+
+    UINT8_BYTE_FORMAT = "!B"
+    UINT16_BYTE_FORMAT = "!H"
+    UINT32_BYTE_FORMAT = "!I"
+    INT8_BYTE_FORMAT = "!b"
+    INT16_BYTE_FORMAT = "!h"
+    INT32_BYTE_FORMAT = "!i"
+    INT64_BYTE_FORMAT = "!q"
+    PRELUDE_BYTE_FORMAT = "!II"
+
+    @staticmethod
+    def pack_uint8(data: int) -> bytes:
+        packed = pack(EncodeUtils.UINT8_BYTE_FORMAT, data)
+        return packed
+
+    @staticmethod
+    def pack_uint16(data: int) -> bytes:
+        packed = pack(EncodeUtils.UINT16_BYTE_FORMAT, data)
+        return packed
+
+    @staticmethod
+    def pack_int32(data: int) -> bytes:
+        packed = pack(EncodeUtils.INT32_BYTE_FORMAT, data)
+        return packed
+
+    @staticmethod
+    def pack_int64(data: int) -> bytes:
+        packed = pack(EncodeUtils.INT64_BYTE_FORMAT, data)
+        return packed
+
+    @staticmethod
+    def pack_uint32(data: int) -> bytes:
+        packed = pack(EncodeUtils.UINT32_BYTE_FORMAT, data)
+        return packed
+
+    @staticmethod
+    def pack_byte_array(data: bytes) -> bytes:
+        packed = EncodeUtils.pack_uint16(len(data)) + data
+        return packed
+
+    @staticmethod
+    def pack_utf8_string(data: str) -> bytes:
+        utf8_string = data.encode("utf-8")
+        packed = EncodeUtils.pack_uint16(len(utf8_string)) + utf8_string
+        return packed
+
+    @staticmethod
+    def pack_prelude(total_length: int, header_length: int) -> bytes:
+        packed = pack(EncodeUtils.PRELUDE_BYTE_FORMAT, total_length, header_length)
+        return packed
+
+
+def _calculate_checksum(data: bytes, crc: int = 0) -> int:
+    return crc32(data, crc) & 0xFFFFFFFF
+
+
+class EventStreamEncoder:
+    """Encodes Amazon event-stream binary messages.
+
+    Wire format per
+    https://smithy.io/2.0/aws/amazon-eventstream.html#amazon-event-stream-specification:
+
+        [total_length: u32][headers_length: u32][prelude_crc: u32]
+            [name_len: u8][name][type: u8][value...]    (headers, repeated)
+            [payload bytes]
+        [message_crc: u32]
+
+    Both CRCs are CRC32. The message CRC is computed over the full message up
+    to (but not including) the message CRC itself.
+    """
+
+    PRELUDE_LENGTH = 12
+    MESSAGE_CRC_LENGTH = 4
+
+    HEADER_TYPE_BOOL_TRUE = b"\x00"
+    HEADER_TYPE_BOOL_FALSE = b"\x01"
+    HEADER_TYPE_INT8 = b"\x02"
+    HEADER_TYPE_INT16 = b"\x03"
+    HEADER_TYPE_INT32 = b"\x04"
+    HEADER_TYPE_INT64 = b"\x05"
+    HEADER_TYPE_BYTE_ARRAY = b"\x06"
+    HEADER_TYPE_STRING = b"\x07"
+    HEADER_TYPE_TIMESTAMP = b"\x08"
+    HEADER_TYPE_UUID = b"\x09"
+
+    def encode_event(self, event: EventStreamMessage) -> bytes:
+        return self.encode_message(event.headers, event.payload)
+
+    def encode_message(self, headers: Mapping[str, Any], payload: bytes) -> bytes:
+        headers_bytes = self._encode_headers(headers)
+        prelude = self._encode_prelude(headers_bytes, payload)
+        prelude_crc = _calculate_checksum(prelude)
+        prelude_with_crc = prelude + EncodeUtils.pack_uint32(prelude_crc)
+        message_without_crc = prelude_with_crc + headers_bytes + payload
+        message_crc = _calculate_checksum(message_without_crc)
+        return message_without_crc + EncodeUtils.pack_uint32(message_crc)
+
+    def _encode_headers(self, headers: Mapping[str, Any]) -> bytes:
+        encoded = b""
+        for key, val in headers.items():
+            encoded += self._encode_header_key(key)
+            encoded += self._encode_header_value(val)
+        return encoded
+
+    def _encode_header_key(self, key: str) -> bytes:
+        encoded_key = key.encode("utf-8")
+        if len(encoded_key) > 0xFF:
+            raise ValueError(f"Event-stream header name too long: {encoded_key!r}")
+        return EncodeUtils.pack_uint8(len(encoded_key)) + encoded_key
+
+    def _encode_header_value(self, value: Any) -> bytes:
+        if value is True:
+            return self.HEADER_TYPE_BOOL_TRUE
+        elif value is False:
+            return self.HEADER_TYPE_BOOL_FALSE
+
+        if isinstance(value, int):
+            return self.HEADER_TYPE_INT32 + EncodeUtils.pack_int32(value)
+        elif isinstance(value, str):
+            return self.HEADER_TYPE_STRING + EncodeUtils.pack_utf8_string(value)
+        elif isinstance(value, (bytes, bytearray)):
+            return self.HEADER_TYPE_BYTE_ARRAY + EncodeUtils.pack_byte_array(
+                bytes(value)
+            )
+        elif isinstance(value, datetime):
+            ts_ms = int(value.timestamp() * 1000)
+            return self.HEADER_TYPE_TIMESTAMP + EncodeUtils.pack_int64(ts_ms)
+        raise TypeError(
+            f"Unsupported event-stream header value type: {type(value).__name__}"
+        )
+
+    def _encode_prelude(self, encoded_headers: bytes, payload: bytes) -> bytes:
+        header_length = len(encoded_headers)
+        payload_length = len(payload)
+        total_length = (
+            header_length
+            + payload_length
+            + self.PRELUDE_LENGTH
+            + self.MESSAGE_CRC_LENGTH
+        )
+        return EncodeUtils.pack_prelude(total_length, header_length)
+
+
+MESSAGE_HEADER_VALUE = bool | bytes | int | str | datetime
+MESSAGE_HEADERS_DICT = dict[str, MESSAGE_HEADER_VALUE]
+
+
+class EventStreamMessage:
+    def __init__(self, headers: MESSAGE_HEADERS_DICT, payload: bytes) -> None:
+        self.headers = headers
+        self.payload = payload
+
+
+class EventStream:
+    """Builds an iterator of Amazon Event Stream messages from an operation result.
+
+    The stream uses the operation output shape to locate the modeled event-stream
+    member, converts each single variant event into an `EventStreamMessage`, and
+    delegates payload/body serialization to the provided event-stream serializer.
+    """
+
+    def __init__(
+        self,
+        result: Any,
+        output_shape: StructureShape,
+        serializer: BaseEventStreamSerializer,
+    ) -> None:
+        assert output_shape.event_stream_name is not None
+        self._result: Any = result
+        self._output_shape: StructureShape = output_shape
+        self._eventstream_member_name: str = str(output_shape.event_stream_name)
+        assert isinstance(
+            output_shape.members[self._eventstream_member_name], StructureShape
+        )
+        self._eventstream_member_shape: StructureShape = output_shape.members[
+            output_shape.event_stream_name
+        ]
+        self._serializer: BaseEventStreamSerializer = serializer
+
+    def __iter__(self) -> Iterator[EventStreamMessage]:
+        if self._serializer.initial_response_required:
+            yield self.get_initial_response()
+        event_stream = self._serializer.get_value(
+            self._result, self._eventstream_member_name, self._eventstream_member_shape
+        )
+        if event_stream is not None:
+            for event in event_stream:
+                if not isinstance(event, Mapping) or len(event) != 1:
+                    raise ValueError(
+                        "Each event-stream item must be a single-key mapping "
+                        "of {variant_name: value}"
+                    )
+                variant_name, variant_value = next(iter(event.items()))
+                variant_shape = self._eventstream_member_shape.members[variant_name]
+                assert isinstance(variant_shape, StructureShape)
+                yield self._generate_event(variant_name, variant_value, variant_shape)
+
+    def _generate_event(
+        self, variant_name: str, value: Any, variant_shape: StructureShape
+    ) -> EventStreamMessage:
+        headers: MESSAGE_HEADERS_DICT = {
+            ":message-type": "event",
+            ":event-type": variant_name,
+        }
+        eventpayload_member: tuple[str, Shape] | None = None
+        body_members: list[tuple[str, Shape]] = []
+        for mn, ms in variant_shape.members.items():
+            if ms.serialization.get("eventpayload"):
+                eventpayload_member = (mn, ms)
+            else:
+                body_members.append((mn, ms))
+        payload: bytes = b""
+        content_type: str | None = None
+        if eventpayload_member is not None:
+            mn, ms = eventpayload_member
+            member_value = self._serializer.get_value(value, mn, ms)
+            if ms.type_name == "blob":
+                if member_value is None:
+                    payload = b""
+                elif isinstance(member_value, (bytes, bytearray)):
+                    payload = bytes(member_value)
+                else:
+                    payload = str(member_value).encode("utf-8")
+                content_type = "application/octet-stream"
+            elif ms.type_name == "string":
+                payload = (member_value or "").encode("utf-8")
+                content_type = "text/plain"
+            else:
+                assert isinstance(ms, StructureShape)
+                payload, content_type = self._serializer.serialize_event_payload(
+                    member_value, ms, list(ms.members.items())
+                )
+        elif body_members:
+            payload, content_type = self._serializer.serialize_event_payload(
+                value, variant_shape, body_members
+            )
+        if content_type:
+            headers[":content-type"] = content_type
+        return EventStreamMessage(headers, payload)
+
+    def get_initial_response(self) -> EventStreamMessage:
+        # Initial-response covers any output members not part of the event stream.
+        initial_response_members = [
+            (mn, ms)
+            for mn, ms in self._output_shape.members.items()
+            if mn != self._eventstream_member_name
+        ]
+        payload, content_type = b"", None
+        if initial_response_members:
+            payload, content_type = self._serializer.serialize_event_payload(
+                self._result, self._output_shape, initial_response_members
+            )
+        headers: MESSAGE_HEADERS_DICT = {
+            ":message-type": "event",
+            ":event-type": "initial-response",
+        }
+        if content_type:
+            headers[":content-type"] = content_type
+        return EventStreamMessage(headers, payload)

--- a/moto/core/serialize.py
+++ b/moto/core/serialize.py
@@ -57,7 +57,7 @@ import base64
 import calendar
 import json
 from collections import namedtuple
-from collections.abc import Callable, Generator, Mapping, MutableMapping
+from collections.abc import Callable, Generator, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import (
@@ -71,6 +71,7 @@ from botocore.compat import formatdate
 from botocore.utils import is_json_value_header, parse_to_aware_datetime
 
 from moto.core.errors import ErrorShape, get_error_model
+from moto.core.eventstream import EventStream, EventStreamEncoder
 from moto.core.model import (
     ListShape,
     MapShape,
@@ -85,7 +86,7 @@ Serialized = MutableMapping[str, Any]
 
 
 class ResponseDict(TypedDict):
-    body: str
+    body: str | bytes
     headers: MutableMapping[str, str]
     status_code: int
 
@@ -228,6 +229,7 @@ class ResponseSerializer:
     # NOTE: This is no longer necessary because dicts post 3.6 are ordered:
     # https://stackoverflow.com/questions/39980323/are-dictionaries-ordered-in-python-3-6
     MAP_TYPE = dict
+    EVENT_STREAM_SERIALIZER_CLS: type[BaseEventStreamSerializer] | None = None
 
     def __init__(
         self,
@@ -244,6 +246,11 @@ class ResponseSerializer:
             value_picker = DefaultAttributePicker()
         self._value_picker = value_picker
         self._timestamp_serializer = TimestampSerializer(self.DEFAULT_TIMESTAMP_FORMAT)
+        self._event_stream_serializer = None
+        if self.EVENT_STREAM_SERIALIZER_CLS is not None:
+            self._event_stream_serializer = self.EVENT_STREAM_SERIALIZER_CLS(
+                operation_model
+            )
         self.operation_name = str(operation_model.name)
         self.path = [self.operation_name]
 
@@ -261,6 +268,8 @@ class ResponseSerializer:
         resp = self._create_default_response()
         if self._is_error_result(result):
             resp = self._serialize_error(resp, result)
+        elif self.operation_model.has_event_stream_output:
+            resp = self._serialize_event_stream_result(resp, result)
         else:
             resp = self._serialize_result(resp, result)
         return resp
@@ -286,6 +295,24 @@ class ResponseSerializer:
         return self._serialized_result_to_response(
             resp, result, output_shape, serialized_result
         )
+
+    def _serialize_event_stream_result(
+        self, resp: ResponseDict, result: Any
+    ) -> ResponseDict:
+        output_shape = self.operation_model.output_shape
+        assert isinstance(output_shape, StructureShape)
+
+        def serialized_event_stream() -> Iterable[bytes]:
+            serializer = self._event_stream_serializer
+            assert isinstance(serializer, BaseEventStreamSerializer)
+            event_stream = EventStream(result, output_shape, serializer)
+            for event in event_stream:
+                yield EventStreamEncoder().encode_event(event)
+
+        # TODO: Allow for actual streaming bodies by returning iterator as body.
+        resp["body"] = b"".join(serialized_event_stream())
+        resp["headers"]["Content-Type"] = "application/vnd.amazon.eventstream"
+        return resp
 
     def _serialized_error_to_response(
         self,
@@ -798,9 +825,71 @@ class BaseRestSerializer(ResponseSerializer):
             super()._serialize_structure_member(serialized, value, shape, key)
 
 
+class BaseEventStreamSerializer(ResponseSerializer):
+    @property
+    def initial_response_required(self) -> bool:
+        serviced_model = self.operation_model.service_model
+        protocol = serviced_model.protocol
+        return protocol == "json"
+
+    def serialize_event_payload(
+        self,
+        value: Any,
+        parent_shape: StructureShape,
+        body_members: list[tuple[str, Shape]],
+    ) -> tuple[bytes, str | None]:
+        raise NotImplementedError("Must be implemented in subclass.")
+
+
+class EventStreamJSONSerializer(BaseEventStreamSerializer, BaseJSONSerializer):
+    EVENT_STREAM_PAYLOAD_CONTENT_TYPE = "application/json"
+
+    def serialize_event_payload(
+        self,
+        value: Any,
+        parent_shape: StructureShape,
+        body_members: list[tuple[str, Shape]],
+    ) -> tuple[bytes, str | None]:
+        wrapper: MutableMapping[str, Any] = self.MAP_TYPE()
+        for mn, ms in body_members:
+            ms.parent = parent_shape  # type: ignore[attr-defined]
+            self._serialize_structure_member(wrapper, value, ms, mn)
+        return (
+            json.dumps(wrapper).encode(self.DEFAULT_ENCODING),
+            self.EVENT_STREAM_PAYLOAD_CONTENT_TYPE,
+        )
+
+
+class EventStreamXMLSerializer(BaseEventStreamSerializer, BaseXMLSerializer):
+    EVENT_STREAM_PAYLOAD_CONTENT_TYPE = "text/xml"
+
+    def serialize_event_payload(
+        self,
+        value: Any,
+        parent_shape: StructureShape,
+        body_members: list[tuple[str, Shape]],
+    ) -> tuple[bytes, str | None]:
+        inner: MutableMapping[str, Any] = self.MAP_TYPE()
+        for mn, ms in body_members:
+            ms.parent = parent_shape  # type: ignore[attr-defined]
+            self._serialize_structure_member(inner, value, ms, mn)
+        wrapped = {self.get_serialized_name(parent_shape, parent_shape.name): inner}
+        # Event payloads are not full XML documents — no `<?xml ... ?>` prolog.
+        rendered = xmltodict.unparse(
+            wrapped,
+            full_document=False,
+            short_empty_elements=True,
+            pretty=False,
+        )
+        return rendered.encode(
+            self.DEFAULT_ENCODING
+        ), self.EVENT_STREAM_PAYLOAD_CONTENT_TYPE
+
+
 class RestXMLSerializer(BaseRestSerializer, BaseXMLSerializer):
     CONTENT_TYPE = "application/xml"
     DEFAULT_TIMESTAMP_FORMAT = TimestampSerializer.TIMESTAMP_FORMAT_ISO8601
+    EVENT_STREAM_SERIALIZER_CLS = EventStreamXMLSerializer
 
     def _serialize_body(self, body: Mapping[str, Any]) -> str:
         body_serialized = xmltodict.unparse(
@@ -815,10 +904,11 @@ class RestXMLSerializer(BaseRestSerializer, BaseXMLSerializer):
 class RestJSONSerializer(BaseRestSerializer, BaseJSONSerializer):
     CONTENT_TYPE = "application/json"
     REQUIRES_EMPTY_BODY = True
+    EVENT_STREAM_SERIALIZER_CLS = EventStreamJSONSerializer
 
 
 class JSONSerializer(BaseJSONSerializer):
-    pass
+    EVENT_STREAM_SERIALIZER_CLS = EventStreamJSONSerializer
 
 
 class QuerySerializer(BaseXMLSerializer):

--- a/moto/core/versions.py
+++ b/moto/core/versions.py
@@ -5,6 +5,7 @@ from moto.utilities.distutils_version import LooseVersion
 
 PYTHON_VERSION_INFO = sys.version_info
 PYTHON_311 = sys.version_info >= (3, 11)
+BOTOCORE_VERSION = version("botocore")
 RESPONSES_VERSION = version("responses")
 WERKZEUG_VERSION = version("werkzeug")
 

--- a/moto/s3/responses.py
+++ b/moto/s3/responses.py
@@ -86,7 +86,6 @@ from .models import (
     get_canned_acl,
     s3_backends,
 )
-from .select_object_content import serialize_select
 from .utils import (
     ARCHIVE_STORAGE_CLASSES,
     bucket_name_from_url,
@@ -3200,7 +3199,22 @@ class S3Response(BaseResponse):
             results, bytes_scanned = self.backend.select_object_content(
                 bucket_name, key_name, select_query, input_details, output_details
             )
-            return 200, {}, serialize_select(results, bytes_scanned)
+            bytes_returned = sum(len(line) for line in results)
+            event_stream = [
+                {"Records": {"Payload": b"".join(results)}},
+                {
+                    "Stats": {
+                        "Details": {
+                            "BytesScanned": bytes_scanned,
+                            "BytesProcessed": bytes_scanned,
+                            "BytesReturned": bytes_returned,
+                        }
+                    }
+                },
+                {"End": {}},
+            ]
+            self.data["Action"] = "SelectObjectContent"
+            return self.serialized(ActionResult({"Payload": event_stream}))
 
         else:
             raise NotImplementedError(

--- a/moto/s3/select_object_content.py
+++ b/moto/s3/select_object_content.py
@@ -1,5 +1,3 @@
-import binascii
-import struct
 from typing import Any
 
 
@@ -9,59 +7,3 @@ def parse_query(text_input: str, query: str) -> tuple[list[dict[str, Any]], int]
     parser = S3SelectParser(source_data=text_input)
     result = parser.parse(query)
     return result, parser.bytes_scanned
-
-
-def _create_header(key: bytes, value: bytes) -> bytes:
-    return struct.pack("b", len(key)) + key + struct.pack("!bh", 7, len(value)) + value
-
-
-def _create_message(
-    content_type: bytes | None, event_type: bytes, payload: bytes
-) -> bytes:
-    headers = _create_header(b":message-type", b"event")
-    headers += _create_header(b":event-type", event_type)
-    if content_type is not None:
-        headers += _create_header(b":content-type", content_type)
-
-    headers_length = struct.pack("!I", len(headers))
-    total_length = struct.pack("!I", len(payload) + len(headers) + 16)
-    prelude = total_length + headers_length
-
-    prelude_crc = struct.pack("!I", binascii.crc32(total_length + headers_length))
-    message_crc = struct.pack(
-        "!I", binascii.crc32(prelude + prelude_crc + headers + payload)
-    )
-
-    return prelude + prelude_crc + headers + payload + message_crc
-
-
-def _create_stats_message(bytes_scanned: int, bytes_returned: int) -> bytes:
-    stats = f"<Stats><BytesScanned>{bytes_scanned}</BytesScanned><BytesProcessed>{bytes_scanned}</BytesProcessed><BytesReturned>{bytes_returned}</BytesReturned></Stats>"
-    return _create_message(
-        content_type=b"text/xml", event_type=b"Stats", payload=stats.encode("utf-8")
-    )
-
-
-def _create_data_message(payload: bytes) -> bytes:
-    # https://docs.aws.amazon.com/AmazonS3/latest/API/RESTSelectObjectAppendix.html
-    return _create_message(
-        content_type=b"application/octet-stream", event_type=b"Records", payload=payload
-    )
-
-
-def _create_end_message() -> bytes:
-    return _create_message(content_type=None, event_type=b"End", payload=b"")
-
-
-def serialize_select(data_list: list[bytes], bytes_scanned: int) -> bytes:
-    bytes_returned = 0
-    all_data = b""
-    for data in data_list:
-        bytes_returned += len(data)
-        all_data += data
-    response = _create_data_message(all_data)
-    return (
-        response
-        + _create_stats_message(bytes_scanned, bytes_returned)
-        + _create_end_message()
-    )

--- a/tests/test_core/test_eventstream_serialization.py
+++ b/tests/test_core/test_eventstream_serialization.py
@@ -1,0 +1,292 @@
+import struct
+from datetime import datetime, timezone
+from unittest import SkipTest
+
+import pytest
+from botocore.eventstream import ChecksumMismatch, EventStreamBuffer
+
+from moto.core.serialize import (
+    EventStreamEncoder,
+    JSONSerializer,
+    RestJSONSerializer,
+    S3Serializer,
+)
+from moto.core.utils import get_service_model
+from moto.core.versions import BOTOCORE_VERSION, LooseVersion
+
+
+def _decode(message_bytes: bytes):  # type: ignore
+    buf = EventStreamBuffer()
+    buf.add_data(message_bytes)
+    return list(buf)
+
+
+def test_framer_encodes_basic_message_with_string_headers() -> None:
+    encoded = EventStreamEncoder().encode_message(
+        {":message-type": "event", ":event-type": "End"}, b""
+    )
+    [msg] = _decode(encoded)
+    assert msg.headers == {":message-type": "event", ":event-type": "End"}
+    assert msg.payload == b""
+
+
+def test_framer_encodes_payload_and_content_type_header() -> None:
+    payload = b"<Stats><BytesScanned>10</BytesScanned></Stats>"
+    encoded = EventStreamEncoder().encode_message(
+        {
+            ":message-type": "event",
+            ":event-type": "Stats",
+            ":content-type": "text/xml",
+        },
+        payload,
+    )
+    [msg] = _decode(encoded)
+    assert msg.headers[":content-type"] == "text/xml"
+    assert msg.payload == payload
+
+
+def test_framer_supports_all_modeled_header_types() -> None:
+    encoded = EventStreamEncoder().encode_message(
+        {
+            "true": True,
+            "false": False,
+            "int": 7,
+            "string": "hello",
+            "bytes": b"\x01\x02\x03",
+            "ts": datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc),
+        },
+        b"",
+    )
+    [msg] = _decode(encoded)
+    assert msg.headers["true"] is True
+    assert msg.headers["false"] is False
+    assert msg.headers["int"] == 7
+    assert msg.headers["string"] == "hello"
+    assert msg.headers["bytes"] == b"\x01\x02\x03"
+    # botocore decodes timestamps as the int64 it stored (ms since epoch).
+    assert msg.headers["ts"] == int(
+        datetime(2024, 1, 2, 3, 4, 5, tzinfo=timezone.utc).timestamp() * 1000
+    )
+
+
+def test_framer_rejects_overlong_header_name() -> None:
+    too_long = "x" * 300
+    with pytest.raises(ValueError):
+        EventStreamEncoder().encode_message({too_long: "v"}, b"")
+
+
+def test_framer_message_crc_detects_corruption() -> None:
+    encoded = bytearray(
+        EventStreamEncoder().encode_message(
+            {":message-type": "event", ":event-type": "End"}, b""
+        )
+    )
+    # Flip a byte inside the headers and confirm botocore's decoder raises.
+    encoded[20] ^= 0xFF
+    buf = EventStreamBuffer()
+    buf.add_data(bytes(encoded))
+    with pytest.raises(ChecksumMismatch):
+        list(buf)
+
+
+def test_framer_total_length_matches_prelude() -> None:
+    payload = b"hello"
+    encoded = EventStreamEncoder().encode_message(
+        {":message-type": "event", ":event-type": "X"}, payload
+    )
+    total_length = struct.unpack("!I", encoded[:4])[0]
+    assert total_length == len(encoded)
+
+
+def test_s3_select_object_content_serialization() -> None:
+    operation_model = get_service_model("s3").operation_model("SelectObjectContent")
+    serializer = S3Serializer(operation_model=operation_model)
+    result = {
+        "Payload": [
+            {"Records": {"Payload": b"row1\nrow2\n"}},
+            {
+                "Stats": {
+                    "Details": {
+                        "BytesScanned": 100,
+                        "BytesProcessed": 100,
+                        "BytesReturned": 10,
+                    }
+                }
+            },
+            {"End": {}},
+        ]
+    }
+    response = serializer.serialize(result)
+    assert response["status_code"] == 200
+    assert response["headers"]["Content-Type"] == "application/vnd.amazon.eventstream"
+    body = response["body"]
+    assert isinstance(body, bytes)
+    messages = _decode(body)
+    assert [m.headers[":event-type"] for m in messages] == ["Records", "Stats", "End"]
+    assert messages[0].headers[":content-type"] == "application/octet-stream"
+    assert messages[0].payload == b"row1\nrow2\n"
+    assert messages[1].headers[":content-type"] == "text/xml"
+    assert b"<BytesScanned>100</BytesScanned>" in messages[1].payload
+    assert b"<BytesReturned>10</BytesReturned>" in messages[1].payload
+    assert ":content-type" not in messages[2].headers
+    assert messages[2].payload == b""
+
+
+def test_logs_start_live_tail_json_event_stream() -> None:
+    if LooseVersion(BOTOCORE_VERSION) < LooseVersion("1.33.13"):
+        raise SkipTest(
+            "StartLiveTail operation is not available in older Botocore versions."
+        )
+    operation_model = get_service_model("logs").operation_model("StartLiveTail")
+    serializer = JSONSerializer(operation_model=operation_model)
+    result = {
+        "responseStream": [
+            {
+                "sessionStart": {
+                    "requestId": "req-1",
+                    "sessionId": "sess-1",
+                    "logGroupIdentifiers": ["arn:aws:logs:::lg"],
+                    "logStreamNames": [],
+                    "logStreamNamePrefixes": [],
+                    "logEventFilterPattern": "",
+                }
+            },
+            {
+                "sessionUpdate": {
+                    "sessionMetadata": {"sampled": False},
+                    "sessionResults": [
+                        {
+                            "logStreamName": "stream-1",
+                            "logGroupIdentifier": "arn:aws:logs:::lg",
+                            "message": "hello",
+                            "timestamp": 1700000000000,
+                            "ingestionTime": 1700000000000,
+                        }
+                    ],
+                }
+            },
+        ]
+    }
+    response = serializer.serialize(result)
+    assert response["headers"]["Content-Type"] == "application/vnd.amazon.eventstream"
+    body = response["body"]
+    assert isinstance(body, bytes)
+    messages = _decode(body)
+    initial_response = messages[0]
+    assert initial_response.headers[":event-type"] == "initial-response"
+    messages = messages[1:]
+    assert [m.headers[":event-type"] for m in messages] == [
+        "sessionStart",
+        "sessionUpdate",
+    ]
+    for msg in messages:
+        assert msg.headers[":content-type"] == "application/json"
+    import json
+
+    start_payload = json.loads(messages[0].payload)
+    assert start_payload["requestId"] == "req-1"
+    update_payload = json.loads(messages[1].payload)
+    assert update_payload["sessionResults"][0]["logStreamName"] == "stream-1"
+
+
+def test_polly_start_speech_synthesis_stream_event_stream() -> None:
+    if LooseVersion(BOTOCORE_VERSION) < LooseVersion("1.42.72"):
+        raise SkipTest(
+            "StartSpeechSynthesisStream operation is not available in older Botocore versions."
+        )
+    operation_model = get_service_model("polly").operation_model(
+        "StartSpeechSynthesisStream"
+    )
+    serializer = RestJSONSerializer(operation_model=operation_model)
+    audio_chunk = b"\x00\x01\x02audio-bytes"
+    result = {
+        "EventStream": [
+            {"AudioEvent": {"AudioChunk": audio_chunk}},
+            {"StreamClosedEvent": {"RequestCharacters": 42}},
+        ]
+    }
+    response = serializer.serialize(result)
+    assert response["headers"]["Content-Type"] == "application/vnd.amazon.eventstream"
+    body = response["body"]
+    assert isinstance(body, bytes)
+    messages = _decode(body)
+    assert [m.headers[":event-type"] for m in messages] == [
+        "AudioEvent",
+        "StreamClosedEvent",
+    ]
+    assert messages[0].headers[":content-type"] == "application/octet-stream"
+    assert messages[0].payload == audio_chunk
+    assert messages[1].headers[":content-type"] == "application/json"
+    import json
+
+    closed_payload = json.loads(messages[1].payload)
+    assert closed_payload["RequestCharacters"] == 42
+
+
+def test_initial_response_emitted_for_non_stream_output_members() -> None:
+    """Synthetic operation: output has both an event-stream member and a regular
+    member, exercising the initial-response branch."""
+    from moto.core.model import ServiceModel
+
+    model = {
+        "metadata": {
+            "protocol": "json",
+            "apiVersion": "2024-01-01",
+            "endpointPrefix": "test",
+        },
+        "documentation": "",
+        "operations": {
+            "Op": {
+                "name": "Op",
+                "http": {"method": "POST", "requestUri": "/"},
+                "output": {"shape": "OpOutput"},
+            }
+        },
+        "shapes": {
+            "OpOutput": {
+                "type": "structure",
+                "members": {
+                    "Greeting": {"shape": "StringType"},
+                    "Stream": {"shape": "EventUnion"},
+                },
+            },
+            "EventUnion": {
+                "type": "structure",
+                "eventstream": True,
+                "members": {
+                    "Tick": {"shape": "TickEvent"},
+                    "String": {"shape": "StringEvent"},
+                },
+            },
+            "TickEvent": {
+                "type": "structure",
+                "event": True,
+                "members": {"value": {"shape": "StringType"}},
+            },
+            "StringEvent": {
+                "type": "structure",
+                "members": {"value": {"shape": "StringType", "eventpayload": True}},
+                "event": True,
+            },
+            "StringType": {"type": "string"},
+        },
+    }
+    service_model = ServiceModel(model)
+    operation_model = service_model.operation_model("Op")
+    serializer = JSONSerializer(operation_model=operation_model)
+    result = {
+        "Greeting": "hi",
+        "Stream": [{"Tick": {"value": "one"}}, {"String": {"value": "two"}}],
+    }
+    response = serializer.serialize(result)
+    messages = _decode(response["body"])  # type: ignore
+    assert messages[0].headers[":event-type"] == "initial-response"
+    import json
+
+    assert json.loads(messages[0].payload) == {"Greeting": "hi"}
+    assert messages[1].headers[":event-type"] == "Tick"
+    assert json.loads(messages[1].payload) == {"value": "one"}
+
+    assert messages[2].headers[":event-type"] == "String"
+    assert messages[2].headers[":content-type"] == "text/plain"
+    assert messages[2].payload == b"two"


### PR DESCRIPTION
This PR adds comprehensive event stream serialization support to Moto. It introduces a new `EventStream` encoder and wire-format handler that implements the [Amazon Event Stream specification](https://smithy.io/2.0/aws/amazon-eventstream.html). 

This PR also migrates S3's `SelectObjectContent` operation to use the new standardized event-stream pipeline and lays the groundwork for other AWS services (like CloudWatch Logs) to return event stream responses.
