### PR TITLE
fix(awslambda): route CloudFormation Lambda paths through get_backend

### DIFF
--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -64,6 +64,7 @@ from .exceptions import (
     ValidationException,
 )
 from .utils import (
+    get_backend,
     make_event_source_mapping_arn,
     make_function_arn,
     make_function_ver_arn,
@@ -236,6 +237,10 @@ class _DockerDataVolumeLayerContext:
             container = self._lambda_func.docker_client.containers.run(
                 "busybox", "sleep 100", volumes=volumes, detach=True
             )
+            # This block only runs when use_docker is True (it pulls a
+            # busybox image), so reading from the Docker-backed
+            # `lambda_backends` directly is intentional and avoids importing
+            # get_backend in a hot path.
             backend: LambdaBackend = lambda_backends[self._lambda_func.account_id][
                 self._lambda_func.region
             ]
@@ -416,7 +421,7 @@ class Permission(CloudFormationModel):
         **kwargs: Any,
     ) -> Permission:
         properties = cloudformation_json["Properties"]
-        backend = lambda_backends[account_id][region_name]
+        backend = get_backend(account_id, region_name)
         fn = backend.get_function(properties["FunctionName"])
         fn.policy.add_statement(raw=json.dumps(properties))
         return Permission(region=region_name)
@@ -534,7 +539,7 @@ class LayerVersion(CloudFormationModel):
             if prop in properties:
                 spec[prop] = properties[prop]
 
-        backend = lambda_backends[account_id][region_name]
+        backend = get_backend(account_id, region_name)
         layer_version = backend.publish_layer_version(spec)
         return layer_version
 
@@ -747,7 +752,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         return json.dumps(self.get_configuration())
 
     def _get_layers_data(self, layers_versions_arns: list[str]) -> list[LayerDataType]:
-        backend = lambda_backends[self.account_id][self.region]
+        backend = get_backend(self.account_id, self.region)
         layer_versions = [
             backend.layers_versions_by_arn(layer_version)
             for layer_version in layers_versions_arns
@@ -1198,7 +1203,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
                 cls._create_zipfile_from_plaintext_code(spec["Code"]["ZipFile"])
             )
 
-        backend = lambda_backends[account_id][region_name]
+        backend = get_backend(account_id, region_name)
         fn = backend.create_function(spec)
         return fn
 
@@ -1242,7 +1247,7 @@ class LambdaFunction(CloudFormationModel, DockerModel):
         return zip_output.read()
 
     def delete(self, account_id: str, region: str) -> None:
-        lambda_backends[account_id][region].delete_function(self.function_name)
+        get_backend(account_id, region).delete_function(self.function_name)
 
     def create_url_config(self, config: dict[str, Any]) -> FunctionUrlConfig:
         self.url_config = FunctionUrlConfig(function=self, config=config)
@@ -1419,7 +1424,7 @@ class EventSourceMapping(CloudFormationModel):
         return {k: v for k, v in response_dict.items() if v is not None}
 
     def delete(self, account_id: str, region_name: str) -> None:
-        lambda_backend = lambda_backends[account_id][region_name]
+        lambda_backend = get_backend(account_id, region_name)
         lambda_backend.delete_event_source_mapping(self.uuid)
 
     @staticmethod
@@ -1437,7 +1442,7 @@ class EventSourceMapping(CloudFormationModel):
         **kwargs: Any,
     ) -> EventSourceMapping:
         properties = cloudformation_json["Properties"]
-        lambda_backend = lambda_backends[account_id][region_name]
+        lambda_backend = get_backend(account_id, region_name)
         return lambda_backend.create_event_source_mapping(properties)
 
     @classmethod
@@ -1451,7 +1456,7 @@ class EventSourceMapping(CloudFormationModel):
     ) -> EventSourceMapping:
         properties = cloudformation_json["Properties"]
         event_source_uuid = original_resource.uuid
-        lambda_backend = lambda_backends[account_id][region_name]
+        lambda_backend = get_backend(account_id, region_name)
         return lambda_backend.update_event_source_mapping(event_source_uuid, properties)  # type: ignore[return-value]
 
     @classmethod
@@ -1463,7 +1468,7 @@ class EventSourceMapping(CloudFormationModel):
         region_name: str,
     ) -> None:
         properties = cloudformation_json["Properties"]
-        lambda_backend = lambda_backends[account_id][region_name]
+        lambda_backend = get_backend(account_id, region_name)
         esms = lambda_backend.list_event_source_mappings(
             event_source_arn=properties["EventSourceArn"],
             function_name=properties["FunctionName"],
@@ -1501,7 +1506,7 @@ class LambdaVersion(CloudFormationModel):
     ) -> LambdaVersion:
         properties = cloudformation_json["Properties"]
         function_name = properties["FunctionName"]
-        func = lambda_backends[account_id][region_name].publish_version(function_name)
+        func = get_backend(account_id, region_name).publish_version(function_name)
         spec = {"Version": func.version}  # type: ignore[union-attr]
         return LambdaVersion(spec)
 

--- a/moto/cloudformation/custom_model.py
+++ b/moto/cloudformation/custom_model.py
@@ -3,7 +3,7 @@ import threading
 from typing import Any
 
 from moto import settings
-from moto.awslambda import lambda_backends
+from moto.awslambda.utils import get_backend as get_lambda_backend
 from moto.core.common_models import CloudFormationModel
 from moto.moto_api._internal import mock_random
 
@@ -49,7 +49,7 @@ class CustomModel(CloudFormationModel):
         properties = cloudformation_json["Properties"]
         service_token = properties["ServiceToken"]
 
-        backend = lambda_backends[account_id][region_name]
+        backend = get_lambda_backend(account_id, region_name)
         fn = backend.get_function(service_token)
 
         request_id = str(mock_random.uuid4())

--- a/tests/test_awslambda_simple/test_lambda_cloudformation.py
+++ b/tests/test_awslambda_simple/test_lambda_cloudformation.py
@@ -1,0 +1,182 @@
+"""Regression tests for #9852: Lambdas created via CloudFormation must respect
+the `lambda.use_docker: False` config option so they land in the simple
+backend instead of pulling Docker images on hosts without Docker.
+"""
+
+import io
+import zipfile
+from string import Template
+from unittest import SkipTest
+from uuid import uuid4
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+
+from moto import mock_aws, settings
+
+# Copy of tests/test_awslambda/test_awslambda_cloudformation
+# Except that we verify the CloudFormation entry points respect the
+# use_docker=False config and do not require Docker.
+
+if settings.TEST_SERVER_MODE:
+    raise SkipTest("No point in testing awslambda_simple in ServerMode")
+
+
+def _process_lambda(func_str):
+    zip_output = io.BytesIO()
+    zip_file = zipfile.ZipFile(zip_output, "w", zipfile.ZIP_DEFLATED)
+    zip_file.writestr("lambda_function.py", func_str)
+    zip_file.close()
+    zip_output.seek(0)
+    return zip_output.read()
+
+
+def get_zip_file():
+    return _process_lambda("def lambda_handler(event, context):\n    return event\n")
+
+
+template = Template(
+    """{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "LF3ABOV": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Handler": "$handler",
+                "Role": "$role_arn",
+                "Runtime": "$runtime",
+                "Code": {
+                    "S3Bucket": "$bucket_name",
+                    "S3Key": "$key"
+                }
+            }
+        }
+    }
+}"""
+)
+
+
+def _get_role_arn():
+    iam = boto3.client("iam", region_name="us-east-1")
+    try:
+        iam.create_role(
+            RoleName="my-role",
+            AssumeRolePolicyDocument="some policy",
+            Path="/my-path/",
+        )
+    except ClientError:
+        pass
+    return iam.get_role(RoleName="my-role")["Role"]["Arn"]
+
+
+def _create_stack(cf, s3) -> dict:
+    bucket_name = f"bucket-{uuid4().hex[:8]}"
+    s3.create_bucket(Bucket=bucket_name)
+    s3.put_object(Bucket=bucket_name, Key="test.zip", Body=get_zip_file())
+    body = template.substitute(
+        handler="lambda_function.lambda_handler",
+        role_arn=_get_role_arn(),
+        runtime="python3.11",
+        bucket_name=bucket_name,
+        key="test.zip",
+    )
+    stack_name = f"stack{uuid4().hex[:6]}"
+    stack = cf.create_stack(StackName=stack_name, TemplateBody=body)
+    return stack
+
+
+def _get_created_function_name(cf, stack) -> str:
+    stack_id = stack["StackId"]
+    resources = cf.list_stack_resources(StackName=stack_id)["StackResourceSummaries"]
+    return resources[0]["PhysicalResourceId"]
+
+
+@mock_aws(config={"lambda": {"use_docker": False}})
+def test_lambda_function_can_be_created_by_cloudformation_without_docker():
+    s3 = boto3.client("s3", "us-east-1")
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+    lmbda = boto3.client("lambda", region_name="us-east-1")
+
+    stack = _create_stack(cf, s3)
+    created_fn_name = _get_created_function_name(cf, stack)
+
+    # The function must be visible through the regular Lambda API
+    # (which uses the same get_backend() router).
+    created_fn = lmbda.get_function(FunctionName=created_fn_name)
+    assert created_fn["Configuration"]["Handler"] == "lambda_function.lambda_handler"
+    assert created_fn["Configuration"]["Runtime"] == "python3.11"
+
+    # And invocation must succeed without Docker.
+    result = lmbda.invoke(FunctionName=created_fn_name)
+    assert result["StatusCode"] == 200
+
+
+@mock_aws(config={"lambda": {"use_docker": False}})
+def test_lambda_function_can_be_deleted_by_cloudformation_without_docker():
+    s3 = boto3.client("s3", "us-east-1")
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+    lmbda = boto3.client("lambda", region_name="us-east-1")
+
+    stack = _create_stack(cf, s3)
+    created_fn_name = _get_created_function_name(cf, stack)
+    # Pre-condition: visible
+    lmbda.get_function(FunctionName=created_fn_name)
+
+    cf.delete_stack(StackName=stack["StackId"])
+
+    with pytest.raises(ClientError) as err:
+        lmbda.get_function(FunctionName=created_fn_name)
+    assert err.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+event_source_mapping_template = Template(
+    """{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Resources": {
+        "$resource_name": {
+            "Type": "AWS::Lambda::EventSourceMapping",
+            "Properties": {
+                "BatchSize": $batch_size,
+                "EventSourceArn": "$event_source_arn",
+                "FunctionName": "$function_name",
+                "Enabled": $enabled
+            }
+        }
+    }
+}"""
+)
+
+
+@mock_aws(config={"lambda": {"use_docker": False}})
+def test_event_source_mapping_create_and_delete_by_cloudformation_without_docker():
+    sqs = boto3.resource("sqs", region_name="us-east-1")
+    s3 = boto3.client("s3", "us-east-1")
+    cf = boto3.client("cloudformation", region_name="us-east-1")
+    lmbda = boto3.client("lambda", region_name="us-east-1")
+
+    queue = sqs.create_queue(QueueName=uuid4().hex[:6])
+    lambda_stack = _create_stack(cf, s3)
+    created_fn_name = _get_created_function_name(cf, lambda_stack)
+
+    esm_body = event_source_mapping_template.substitute(
+        resource_name="Foo",
+        batch_size=1,
+        event_source_arn=queue.attributes["QueueArn"],
+        function_name=created_fn_name,
+        enabled="true",
+    )
+    esm_stack = cf.create_stack(
+        StackName=f"esm{uuid4().hex[:6]}", TemplateBody=esm_body
+    )
+
+    event_sources = lmbda.list_event_source_mappings(FunctionName=created_fn_name)
+    assert len(event_sources["EventSourceMappings"]) == 1
+    assert (
+        event_sources["EventSourceMappings"][0]["EventSourceArn"]
+        == queue.attributes["QueueArn"]
+    )
+
+    cf.delete_stack(StackName=esm_stack["StackId"])
+    event_sources = lmbda.list_event_source_mappings(FunctionName=created_fn_name)
+    assert len(event_sources["EventSourceMappings"]) == 0


### PR DESCRIPTION
Closes #9852

## What

When a user sets \`{\"lambda\": {\"use_docker\": False}}\` to skip Docker (e.g. on CI runners or hosts without DinD), the regular Lambda boto3 API already routes through \`awslambda.utils.get_backend()\` so functions land in the simple \`LambdaSimpleBackend\` and \`invoke\` returns without touching Docker. CloudFormation entry points, however, still indexed \`lambda_backends[...]\` directly, so any \`AWS::Lambda::Function\`, \`AWS::Lambda::EventSourceMapping\`, or custom resource that goes through CloudFormation tried to use the Docker-backed code path and crashed with \`error running docker\` on hosts where Docker is not reachable.

This is the missing CloudFormation half of the same fix bblommers described in https://github.com/getmoto/moto/issues/9852#issuecomment-2728802907 (\"Marking it as an enhancement to also make this work with CloudFormation\").

## Change

Replace the direct \`lambda_backends[account_id][region_name]\` lookups in the CFN entry points with \`get_backend(account_id, region_name)\` so they pick the same backend the regular API already picks:

- \`Permission.create_from_cloudformation_json\`
- \`LayerVersion.create_from_cloudformation_json\`
- \`LambdaFunction.create_from_cloudformation_json\`
- \`LambdaFunction.delete\` (called by stack deletion)
- \`LambdaFunction._get_layers_data\` (so a function created in the simple backend resolves its layers from the same backend)
- \`EventSourceMapping.create_from_cloudformation_json\`
- \`EventSourceMapping.update_from_cloudformation_json\`
- \`EventSourceMapping.delete_from_cloudformation_json\`
- \`EventSourceMapping.delete\`
- \`LambdaVersion.create_from_cloudformation_json\`
- \`CustomModel.create_from_cloudformation_json\` in \`moto/cloudformation/custom_model.py\` (CFN custom resource Lambdas)

The one remaining \`lambda_backends[...]\` index inside \`_load_layers\` is intentional: that block only runs when \`use_docker=True\` (it pulls a busybox image), so the simple backend never reaches it. Added an inline comment so future readers don't \"fix\" it.

## Tests

New \`tests/test_awslambda_simple/test_lambda_cloudformation.py\` covering:

- \`AWS::Lambda::Function\` create via CFN under \`use_docker=False\`: stack succeeds, \`get_function\` resolves through the simple backend, \`invoke\` returns 200 without touching Docker.
- \`AWS::Lambda::Function\` delete via CFN under \`use_docker=False\`: \`delete_stack\` removes the function from the simple backend.
- \`AWS::Lambda::EventSourceMapping\` create+delete via CFN under \`use_docker=False\`: ESM is visible through \`list_event_source_mappings\` and removed on stack delete.

Verified the three new tests fail without the fix (\`git stash\` then run), pass with it, and all seven existing \`test_awslambda_cloudformation.py\` tests still pass.

Linted with \`ruff check\` and \`ruff format\`.