### PR TITLE
fix(acm): Preserve default cert_options when partial options are provided

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -617,7 +617,7 @@ class AWSCertificateManagerBackend(BaseBackend):
         self._certificates[cert.arn] = cert
 
         if cert_options:
-            self._certificates[cert.arn].cert_options = cert_options
+            self._certificates[cert.arn].cert_options.update(cert_options)
 
         if tags:
             cert.tags.add(tags)

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -546,6 +546,25 @@ def test_request_exportable_certificate():
 
 
 @mock_aws
+def test_request_certificate_options_without_export_defaults_to_disabled():
+    client = boto3.client("acm", region_name="eu-central-1")
+
+    resp = client.request_certificate(
+        DomainName="example.com",
+        Options={"CertificateTransparencyLoggingPreference": "DISABLED"},
+    )
+    arn = resp["CertificateArn"]
+
+    cert = client.describe_certificate(CertificateArn=arn)["Certificate"]
+    assert cert["Options"]["Export"] == "DISABLED"
+    assert cert["Options"]["CertificateTransparencyLoggingPreference"] == "DISABLED"
+
+    summary = client.list_certificates()["CertificateSummaryList"]
+    assert len(summary) == 1
+    assert summary[0]["Exported"] is False
+
+
+@mock_aws
 def test_list_certificates_with_key_types_filter():
     client = boto3.client("acm", region_name="us-east-1")
     arn = _import_cert(client)

--- a/tests/test_acm/test_acm.py
+++ b/tests/test_acm/test_acm.py
@@ -560,8 +560,9 @@ def test_request_certificate_options_without_export_defaults_to_disabled():
     assert cert["Options"]["CertificateTransparencyLoggingPreference"] == "DISABLED"
 
     summary = client.list_certificates()["CertificateSummaryList"]
-    assert len(summary) == 1
-    assert summary[0]["Exported"] is False
+    matching = [c for c in summary if c["CertificateArn"] == arn]
+    assert len(matching) == 1
+    assert matching[0]["Exported"] is False
 
 
 @mock_aws


### PR DESCRIPTION
Current behaviour is that the entire certificate options object is updated with whatever the user passes in during creation but this doesn't respect the defaults and can result in HTTP 500 errors later.

For example creating a certificate with just `CertificateTransparencyLoggingPreference` set results in a `KeyError` when listing the cert as moto tries to read the non-existent `Export` key.