### PR TITLE
Support full parameter ARN lookups in SSM get_parameters

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1879,7 +1879,10 @@ class SimpleSystemManagerBackend(BaseBackend):
             )
 
         for name in set(names):
-            if name.split(":")[0] in self._parameters:
+            lookup_name = name
+            if lookup_name.startswith(self.ssm_prefix):
+                lookup_name = lookup_name.replace(self.ssm_prefix, "")
+            if lookup_name.split(":")[0] in self._parameters:
                 try:
                     param = self.get_parameter(name)
 

--- a/tests/test_ssm/test_ssm.py
+++ b/tests/test_ssm/test_ssm.py
@@ -662,6 +662,31 @@ def test_get_parameter(param):
     )
 
 
+@pytest.mark.parametrize(
+    "param",
+    ["/test", "arn:aws:ssm:us-east-1:123456789012:parameter/test"],
+)
+@mock_aws
+def test_get_parameters_by_arn(param):
+    # Setup
+    client = boto3.client("ssm", region_name=SSM_REGION)
+    client.put_parameter(
+        Name="/test", Description="A test parameter", Value="value", Type="String"
+    )
+
+    # Execute
+    response = client.get_parameters(Names=[param], WithDecryption=False)
+
+    # Verify
+    assert response["InvalidParameters"] == []
+    assert len(response["Parameters"]) == 1
+    parameter = response["Parameters"][0]
+    assert parameter["Name"] == "/test"
+    assert parameter["Value"] == "value"
+    assert parameter["Type"] == "String"
+    assert parameter["ARN"] == (f"arn:aws:ssm:us-east-1:{ACCOUNT_ID}:parameter/test")
+
+
 @mock_aws
 def test_get_parameter_with_version_and_labels():
     client = boto3.client("ssm", region_name=SSM_REGION)


### PR DESCRIPTION
Fixes #9396

## Problem

`SimpleSystemManagerBackend.get_parameter()` (single lookup) strips the SSM ARN prefix before resolving a parameter, so it accepts both a bare name (`/test`) and a full ARN (`arn:aws:ssm:<region>:<account>:parameter/test`). This was added so callers can fetch a parameter by its ARN.

`get_parameters()` (the batch variant used by the `GetParameters` API) was never updated to match. It guards the lookup with:

```python
if name.split(":")[0] in self._parameters:
```

When `name` is a full ARN, `name.split(":")[0]` is `"arn"`, which is never a stored parameter, so the ARN is skipped and ends up in the response's `InvalidParameters` list. The reporter in #9396 hit this: `get_parameter` works by ARN but `get_parameters` does not.

## Fix

Strip the ARN prefix the same way `get_parameter()` does before performing the membership check, so batch lookups by ARN resolve consistently with single lookups. The original name is still passed through to `get_parameter()` (which handles version/label suffixes) and used as the result key, so `InvalidParameters` detection in the response layer is unaffected.

## Testing

- Added `test_get_parameters_by_arn`, parametrized over a bare name and a full ARN, mirroring the existing `test_get_parameter` regression test. It fails before the change (the ARN form is returned under `InvalidParameters`) and passes after.
- `pytest tests/test_ssm/` — 180 passed.
- `black --check` and `ruff check` clean on the changed files; `mypy moto/ssm/models.py` reports no issues.