### PR TITLE
[DS] - add enable_radius and disable_radius support  

### DIFF
--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -155,7 +155,7 @@ class Directory(BaseModel):
         self.stage_last_updated_date_time = unix_time()
         self.ldaps_settings_info: list[LdapsSettingInfo] = []
         self.radius_settings: dict[str, Any] | None = None
-        self.radius_status: str = "Disabled"
+        self.radius_status: str | None = None
         self.trusts: list[Trust] = []
         self.settings = (
             copy.deepcopy(SETTINGS_ENTRIES_MODEL)
@@ -256,14 +256,14 @@ class Directory(BaseModel):
                 setting.ldaps_status = "Disabled"
 
     def enable_radius(self, radius_settings: dict[str, Any]) -> None:
-        """Store RADIUS settings"""
+        """Store RADIUS settings and mark as completed."""
         self.radius_settings = radius_settings
-        self.radius_status = "Enabled"
+        self.radius_status = "Completed"
 
     def disable_radius(self) -> None:
-        """Clear RADIUS settings"""
+        """Clear RADIUS settings and status."""
         self.radius_settings = None
-        self.radius_status = "Disabled"
+        self.radius_status = None
 
     def to_dict(self) -> dict[str, Any]:
         """Create a dictionary of attributes for Directory."""
@@ -297,7 +297,8 @@ class Directory(BaseModel):
             attributes["ConnectSettings"]["CustomerDnsIps"] = None
 
         attributes["RadiusSettings"] = self.radius_settings or {}
-        attributes["RadiusStatus"] = self.radius_status
+        if self.radius_status:
+            attributes["RadiusStatus"] = self.radius_status
         return attributes
 
 

--- a/moto/ds/models.py
+++ b/moto/ds/models.py
@@ -154,6 +154,8 @@ class Directory(BaseModel):
         self.launch_time = unix_time()
         self.stage_last_updated_date_time = unix_time()
         self.ldaps_settings_info: list[LdapsSettingInfo] = []
+        self.radius_settings: dict[str, Any] | None = None
+        self.radius_status: str = "Disabled"
         self.trusts: list[Trust] = []
         self.settings = (
             copy.deepcopy(SETTINGS_ENTRIES_MODEL)
@@ -253,6 +255,16 @@ class Directory(BaseModel):
             for setting in self.ldaps_settings_info:
                 setting.ldaps_status = "Disabled"
 
+    def enable_radius(self, radius_settings: dict[str, Any]) -> None:
+        """Store RADIUS settings"""
+        self.radius_settings = radius_settings
+        self.radius_status = "Enabled"
+
+    def disable_radius(self) -> None:
+        """Clear RADIUS settings"""
+        self.radius_settings = None
+        self.radius_status = "Disabled"
+
     def to_dict(self) -> dict[str, Any]:
         """Create a dictionary of attributes for Directory."""
         attributes = {
@@ -283,6 +295,9 @@ class Directory(BaseModel):
         else:
             attributes["ConnectSettings"] = self.connect_settings
             attributes["ConnectSettings"]["CustomerDnsIps"] = None
+
+        attributes["RadiusSettings"] = self.radius_settings or {}
+        attributes["RadiusStatus"] = self.radius_status
         return attributes
 
 
@@ -718,6 +733,18 @@ class DirectoryServiceBackend(BaseBackend):
         self._validate_directory_id(directory_id)
         directory = self.directories[directory_id]
         directory.enable_ldaps(False)
+
+    def enable_radius(self, directory_id: str, radius_settings: dict[str, Any]) -> None:
+        """Enable RADIUS for a directory."""
+        self._validate_directory_id(directory_id)
+        directory = self.directories[directory_id]
+        directory.enable_radius(radius_settings)
+
+    def disable_radius(self, directory_id: str) -> None:
+        """Disable RADIUS for a directory."""
+        self._validate_directory_id(directory_id)
+        directory = self.directories[directory_id]
+        directory.disable_radius()
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def describe_settings(

--- a/moto/ds/responses.py
+++ b/moto/ds/responses.py
@@ -241,6 +241,20 @@ class DirectoryServiceResponse(BaseResponse):
         )
         return ""
 
+    def enable_radius(self) -> str:
+        directory_id = self._get_param("DirectoryId")
+        radius_settings = self._get_param("RadiusSettings")
+        self.ds_backend.enable_radius(
+            directory_id=directory_id,
+            radius_settings=radius_settings,
+        )
+        return ""
+
+    def disable_radius(self) -> str:
+        directory_id = self._get_param("DirectoryId")
+        self.ds_backend.disable_radius(directory_id=directory_id)
+        return ""
+
     def describe_settings(self) -> str:
         directory_id = self._get_param("DirectoryId")
         status = self._get_param("Status")

--- a/tests/test_ds/test_ds_ad_connect.py
+++ b/tests/test_ds/test_ds_ad_connect.py
@@ -318,3 +318,60 @@ def test_enable_describe_disable_ldaps():
     ]
     assert len(ldaps) == 1
     assert ldaps[0]["LDAPSStatus"] == "Disabled"
+
+
+@mock_aws
+def test_enable_radius():
+    """Test enable_radius and disable_radius for AD Connector."""
+    client = boto3.client("ds", region_name=TEST_REGION)
+    ec2_client = boto3.client("ec2", region_name=TEST_REGION)
+
+    directory_id = create_test_ad_connector(client, ec2_client)
+
+    radius_settings = {
+        "RadiusServers": ["1.2.3.4"],
+        "RadiusPort": 1812,
+        "RadiusTimeout": 30,
+        "RadiusRetries": 3,
+        "SharedSecret": "supersecret",
+        "AuthenticationProtocol": "PAP",
+        "DisplayLabel": "MFA",
+        "UseSameUsername": False,
+    }
+    client.enable_radius(DirectoryId=directory_id, RadiusSettings=radius_settings)
+
+    directory = client.describe_directories(DirectoryIds=[directory_id])[
+        "DirectoryDescriptions"
+    ][0]
+    assert directory["RadiusStatus"] == "Completed"
+    assert directory["RadiusSettings"]["RadiusServers"] == ["1.2.3.4"]
+    assert directory["RadiusSettings"]["RadiusPort"] == 1812
+    assert directory["RadiusSettings"]["AuthenticationProtocol"] == "PAP"
+
+
+@mock_aws
+def test_disable_radius():
+    """Test disabling RADIUS after enabling it for AD Connector."""
+    client = boto3.client("ds", region_name=TEST_REGION)
+    ec2_client = boto3.client("ec2", region_name=TEST_REGION)
+
+    directory_id = create_test_ad_connector(client, ec2_client)
+
+    radius_settings = {
+        "RadiusServers": ["1.2.3.4"],
+        "RadiusPort": 1812,
+        "RadiusTimeout": 30,
+        "RadiusRetries": 3,
+        "SharedSecret": "supersecret",
+        "AuthenticationProtocol": "PAP",
+        "DisplayLabel": "MFA",
+        "UseSameUsername": False,
+    }
+    client.enable_radius(DirectoryId=directory_id, RadiusSettings=radius_settings)
+    client.disable_radius(DirectoryId=directory_id)
+
+    directory = client.describe_directories(DirectoryIds=[directory_id])[
+        "DirectoryDescriptions"
+    ][0]
+    assert "RadiusStatus" not in directory
+    assert directory["RadiusSettings"] == {}

--- a/tests/test_ds/test_ds_microsoft_ad.py
+++ b/tests/test_ds/test_ds_microsoft_ad.py
@@ -298,3 +298,60 @@ def test_update_settings():
         (s for s in new_directory_settings if s["Name"] == "TLS_1_0"), None
     )
     assert new_tls_1_0_setting["AppliedValue"] == "Disable"
+
+
+@mock_aws
+def test_enable_radius():
+    """Test enabling RADIUS for MicrosoftAD and verifying settings are stored."""
+    client = boto3.client("ds", region_name=TEST_REGION)
+    ec2_client = boto3.client("ec2", region_name=TEST_REGION)
+
+    directory_id = create_test_microsoft_ad(client, ec2_client)
+
+    radius_settings = {
+        "RadiusServers": ["10.0.0.1"],
+        "RadiusPort": 1812,
+        "RadiusTimeout": 30,
+        "RadiusRetries": 3,
+        "SharedSecret": "supersecret",
+        "AuthenticationProtocol": "MS-CHAPv2",
+        "DisplayLabel": "MFA",
+        "UseSameUsername": True,
+    }
+    client.enable_radius(DirectoryId=directory_id, RadiusSettings=radius_settings)
+
+    directory = client.describe_directories(DirectoryIds=[directory_id])[
+        "DirectoryDescriptions"
+    ][0]
+    assert directory["RadiusStatus"] == "Completed"
+    assert directory["RadiusSettings"]["RadiusServers"] == ["10.0.0.1"]
+    assert directory["RadiusSettings"]["RadiusPort"] == 1812
+    assert directory["RadiusSettings"]["AuthenticationProtocol"] == "MS-CHAPv2"
+
+
+@mock_aws
+def test_disable_radius():
+    """Test disabling RADIUS after enabling it for MicrosoftAD."""
+    client = boto3.client("ds", region_name=TEST_REGION)
+    ec2_client = boto3.client("ec2", region_name=TEST_REGION)
+
+    directory_id = create_test_microsoft_ad(client, ec2_client)
+
+    radius_settings = {
+        "RadiusServers": ["10.0.0.1"],
+        "RadiusPort": 1812,
+        "RadiusTimeout": 30,
+        "RadiusRetries": 3,
+        "SharedSecret": "supersecret",
+        "AuthenticationProtocol": "MS-CHAPv2",
+        "DisplayLabel": "MFA",
+        "UseSameUsername": True,
+    }
+    client.enable_radius(DirectoryId=directory_id, RadiusSettings=radius_settings)
+    client.disable_radius(DirectoryId=directory_id)
+
+    directory = client.describe_directories(DirectoryIds=[directory_id])[
+        "DirectoryDescriptions"
+    ][0]
+    assert "RadiusStatus" not in directory
+    assert directory["RadiusSettings"] == {}


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                              
                                                                                                                                                                                                          
  - Adds `enable_radius` and `disable_radius` API support to moto's Directory Service backend                                                                                                             
  - `RadiusSettings` and `RadiusStatus` are now returned in `describe_directories` for all directory types                                                                                                
  - Covers both ADConnector and MicrosoftAD directories                                                                                                                                                   
                                                                                                                                                                                                          
  ## Changes                                                                                                                                                                                              
                                                                                                                                                                                                          
  - `moto/ds/models.py` — added `radius_settings`/`radius_status` to `Directory`, `enable_radius`/`disable_radius` methods on `Directory` and `DirectoryServiceBackend`                                   
  - `moto/ds/responses.py` — wired up `enable_radius` and `disable_radius` request handlers
  - `tests/test_ds/test_ds_ad_connect.py` — tests for ADConnector RADIUS enable/disable                                                                                                                   
  - `tests/test_ds/test_ds_microsoft_ad.py` — tests for MicrosoftAD RADIUS enable/disable   

 ## Notes
 - `DisplayLabel` and `UseSameUsername` are not currently used attributes but they are part of the RadiusSettings data type so added them anyways
 -  `SimpleAD` does not support RADIUS