### PR TITLE
Refactor: ResourceGroupsTaggingAPI

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import itertools
 import math
 from collections import OrderedDict
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.types import Base64EncodedString
 from moto.core.utils import utcnow
 from moto.ec2 import ec2_backends
@@ -1142,7 +1144,9 @@ class FakeAutoScalingGroup(CloudFormationModel):
         return self.warm_pool
 
 
-class AutoScalingBackend(BaseBackend):
+class AutoScalingBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "autoscaling"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.autoscaling_groups: dict[str, FakeAutoScalingGroup] = OrderedDict()
@@ -1975,6 +1979,25 @@ class AutoScalingBackend(BaseBackend):
     def delete_warm_pool(self, group_name: str) -> None:
         group = self.describe_auto_scaling_groups([group_name])[0]
         group.warm_pool = None
+
+    # Resource Groups Tagging API
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        # From the AWS documentation as of 2026-05-24:
+        # The TagResources and UntagResources operations of AWS Resource Groups Tagging API work as
+        # documented with Auto Scaling Groups. However, the GetTagKey, GetTagValues and GetResources
+        # operations aren't supported at this time and return an empty response for this service.
+        # https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/supported-services.html
+        return iter([])
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        group_name = arn.rsplit("autoScalingGroupName/", 1)[-1]
+        self.create_or_update_tags(
+            [{"ResourceId": group_name, "Key": k, "Value": v} for k, v in tags.items()]
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        group_name = arn.rsplit("autoScalingGroupName/", 1)[-1]
+        self.delete_tags([{"ResourceId": group_name, "Key": k} for k in tag_keys])
 
 
 autoscaling_backends = BackendDict(AutoScalingBackend, "autoscaling")

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -16,7 +16,7 @@ import warnings
 import weakref
 import zipfile
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime
 from gzip import GzipFile
 from sys import platform
@@ -29,6 +29,7 @@ from moto.awslambda.policy import Policy
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import JsonRESTError as RESTError
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import iso_8601_datetime_with_nanoseconds, unix_time_millis, utcnow
 from moto.dynamodb import dynamodb_backends
 from moto.dynamodbstreams import dynamodbstreams_backends
@@ -1903,7 +1904,7 @@ class LayerStorage:
         return None
 
 
-class LambdaBackend(BaseBackend):
+class LambdaBackend(BaseBackend, TaggableResourcesMixin):
     """
     Implementation of the AWS Lambda endpoint.
     Invoking functions is supported - they will run inside a Docker container, emulating the real AWS behaviour as closely as possible.
@@ -1983,6 +1984,8 @@ class LambdaBackend(BaseBackend):
         @mock_aws(config={"lambda": {"use_docker": False}})
 
     """
+
+    SERVICE_NAMESPACE = "lambda"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -2468,15 +2471,6 @@ class LambdaBackend(BaseBackend):
         resource = self._get_resource_by_arn(resource_arn)
         return resource.tags
 
-    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
-        resource = self._get_resource_by_arn(resource_arn)
-        resource.tags.update(tags)
-
-    def untag_resource(self, resource_arn: str, tagKeys: list[str]) -> None:
-        resource = self._get_resource_by_arn(resource_arn)
-        for key in tagKeys:
-            resource.tags.pop(key, None)
-
     def add_permission(
         self, function_name: str, qualifier: str, raw: str
     ) -> dict[str, Any]:
@@ -2648,6 +2642,24 @@ class LambdaBackend(BaseBackend):
     ) -> None:
         layer_version = self.get_layer_version(layer_name, str(version_number))
         layer_version.policy.del_statement(sid, revision)
+
+    # Resource Groups Tagging API
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for fn in self.list_functions():
+            yield TaggedResource(
+                arn=fn.function_arn,
+                tags=fn.tags,
+                resource_type="lambda:function",
+            )
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
+        resource = self._get_resource_by_arn(resource_arn)
+        resource.tags.update(tags)
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        resource = self._get_resource_by_arn(resource_arn)
+        for key in tag_keys:
+            resource.tags.pop(key, None)
 
 
 def do_validate_s3() -> bool:

--- a/moto/core/resource_tagging.py
+++ b/moto/core/resource_tagging.py
@@ -1,0 +1,139 @@
+"""Mixin and helpers for participating in Resource Groups Tagging API operations."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+from moto.core.base_backend import BackendDict
+from moto.utilities.utils import get_partition
+
+
+@dataclass
+class TaggedResource:
+    arn: str
+    tags: dict[str, str]
+    resource_type: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+class TaggableResourcesMixin:
+    """Mix into a service backend to participate in Resource Groups Tagging API.
+
+    Subclasses must set `SERVICE_NAMESPACE` (the AWS service identifier used in
+    ARNs, e.g. "rds") and override `iter_tagged_resources`. `tag_resource`
+    and `untag_resource` only need overriding if the service supports the
+    cross-service TagResources / UntagResources operations.
+    """
+
+    SERVICE_NAMESPACE: ClassVar[str] = ""
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        if not getattr(cls, "SERVICE_NAMESPACE", ""):
+            raise TypeError(
+                f"{cls.__name__} mixes in TaggableResourcesMixin but does not set SERVICE_NAMESPACE"
+            )
+
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        """Yield every taggable resource owned by this backend.
+
+        The central code applies tag filters and resource-type filters, so implementations
+        should yield resources unconditionally (even those with no tags).
+        """
+        return iter(())
+
+    def owns_arn(self, arn: str) -> bool:
+        """Return True if this backend should handle tag/untag for `arn`.
+
+        Default matches `arn:<partition>:<SERVICE_NAME>:`. Override when the ARN scheme
+        doesn't match the service name (e.g. ELBv2 uses `elasticloadbalancing`).
+        """
+        return arn.startswith(f"arn:{self.partition}:{self.SERVICE_NAMESPACE}:")  # type: ignore[attr-defined]
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement tag_resource"
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement untag_resource"
+        )
+
+
+def iter_taggable_backends(
+    account_id: str, region_name: str
+) -> Iterator[TaggableResourcesMixin]:
+    """Yield every in-use TaggableResourcesMixin backend for the given account/region.
+
+    Walks a list of BackendDicts that have at least one account-specific backend created.
+    Services the user has never touched are skipped (as they have no resources to report).
+    """
+    for backend_dict in list(BackendDict._instances):  # type: ignore[misc]
+        if not isinstance(backend_dict.backend, type):
+            continue
+        if not issubclass(backend_dict.backend, TaggableResourcesMixin):
+            continue
+        if account_id not in backend_dict:
+            continue
+        account_specific_backend = backend_dict[account_id]
+        if (
+            region_name in account_specific_backend
+            or region_name in account_specific_backend.regions
+        ):
+            yield account_specific_backend[region_name]
+            continue
+        # Yield global services keyed by partition (e.g. S3).
+        partition = get_partition(region_name)
+        if partition in account_specific_backend.keys():
+            yield account_specific_backend[partition]
+
+
+def match_resource_type(
+    resource_type: str, resource_type_filters: list[str] | None
+) -> bool:
+    """Return True if `resource_type` (e.g. "rds:cluster") satisfies the filters.
+
+    A filter of "rds" matches every "rds:*" resource type; a filter of
+    "rds:cluster" matches only that exact resource type. If no filters
+    are provided, all resource types match.
+    """
+    if not resource_type_filters:
+        return True
+    service = resource_type.split(":", 1)[0]
+    for f in resource_type_filters:
+        if f == resource_type or f == service:
+            return True
+    return False
+
+
+def make_tag_matcher(
+    tag_filters: list[dict[str, Any]] | None,
+) -> Callable[[dict[str, str]], bool]:
+    """Return a predicate matching the GetResources TagFilters semantics.
+
+    A filter is satisfied when:
+      - if no Values are given: any tag with a matching Key is present
+      - if Values are given: a tag with a matching Key and a Value in Values is present.
+    All filters must be satisfied (AND when multiple filters, OR when multiple values).
+    """
+    filters = list(tag_filters or [])
+
+    def matches(tags: dict[str, str]) -> bool:
+        if not filters:
+            return True
+        tags_by_key: dict[str, list[str]] = {}
+        for tag_key, tag_value in tags.items():
+            tags_by_key.setdefault(tag_key, []).append(tag_value)
+        for f in filters:
+            key = f["Key"]
+            values = f.get("Values") or []
+            if key not in tags_by_key:
+                return False
+            if values and not any(v in tags_by_key[key] for v in values):
+                return False
+        return True
+
+    return matches

--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -1,4 +1,8 @@
+from collections.abc import Iterator
+from typing import Any
+
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 
 from ..exceptions import (
     EC2ClientError,
@@ -80,6 +84,7 @@ class SettingsBackend:
 
 class EC2Backend(
     BaseBackend,
+    TaggableResourcesMixin,
     InstanceBackend,
     InstanceTypeBackend,
     InstanceTypeOfferingBackend,
@@ -133,6 +138,8 @@ class EC2Backend(
     .. note:: You must set `MOTO_AMIS_PATH` before importing moto.
 
     """
+
+    SERVICE_NAMESPACE = "ec2"
 
     def __init__(self, region_name: str, account_id: str):
         BaseBackend.__init__(self, region_name, account_id)
@@ -217,6 +224,57 @@ class EC2Backend(
                     association_ids=[resource_id]
                 )
         return True
+
+    # Resource Groups Tagging API
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        resource_collections: dict[str, Any] = {
+            "ec2:customer-gateway": self.customer_gateways.values(),
+            "ec2:flow-logs": self.flow_logs.values(),
+            "ec2:image": self.amis.values(),
+            "ec2:instance": (
+                instance
+                for reservation in self.reservations.values()
+                for instance in reservation.instances
+            ),
+            "ec2:internet-gateway": self.internet_gateways.values(),
+            "ec2:managed-prefix-lists": self.managed_prefix_lists.values(),
+            "ec2:natgateway": self.nat_gateways.values(),
+            "ec2:network-interface": self.enis.values(),
+            "ec2:route-table": self.route_tables.values(),
+            "ec2:security-group": (
+                sg for vpc in self.groups.values() for sg in vpc.values()
+            ),
+            "ec2:snapshot": self.snapshots.values(),
+            "ec2:spot-instance-request": self.spot_instance_requests.values(),
+            "ec2:subnet": (
+                subnet
+                for subnets_by_az in self.subnets.values()
+                for subnet in subnets_by_az.values()
+            ),
+            "ec2:transit-gateway": self.transit_gateways.values(),
+            "ec2:transit-gateway-attachment": self.transit_gateway_attachments.values(),
+            "ec2:volume": self.volumes.values(),
+            "ec2:vpc": self.vpcs.values(),
+            "ec2:vpc-peering-connection": self.vpc_pcxs.values(),
+            "ec2:vpn-connection": self.vpn_connections.values(),
+        }
+        for resource_type, resources in resource_collections.items():
+            type_part = resource_type.split(":", 1)[1]
+            for resource in resources:
+                yield TaggedResource(
+                    arn=f"arn:{self.partition}:ec2:{self.region_name}:{self.account_id}:{type_part}/{resource.id}",
+                    tags=dict(self.tags.get(resource.id, {})),
+                    resource_type=resource_type,
+                )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        resource_id = arn.rsplit("/", 1)[-1]
+        self.create_tags([resource_id], tags)
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        resource_id = arn.rsplit("/", 1)[-1]
+        tags_to_delete = dict.fromkeys(tag_keys, "")
+        self.delete_tags([resource_id], tags_to_delete)
 
 
 ec2_backends = BackendDict(EC2Backend, "ec2")

--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -273,8 +273,7 @@ class EC2Backend(
 
     def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
         resource_id = arn.rsplit("/", 1)[-1]
-        tags_to_delete = dict.fromkeys(tag_keys, "")
-        self.delete_tags([resource_id], tags_to_delete)
+        self.delete_tag_keys([resource_id], tag_keys)
 
 
 ec2_backends = BackendDict(EC2Backend, "ec2")

--- a/moto/ec2/models/tags.py
+++ b/moto/ec2/models/tags.py
@@ -53,6 +53,13 @@ class TagBackend:
                         self.tags[resource_id].pop(tag)
         return True
 
+    def delete_tag_keys(self, resource_ids: list[str], tag_keys: list[str]) -> bool:
+        for resource_id in resource_ids:
+            for tag_key in tag_keys:
+                if tag_key in self.tags[resource_id]:
+                    self.tags[resource_id].pop(tag_key)
+        return True
+
     def describe_tags(
         self, filters: dict[str, list[str]] | None = None
     ) -> list[dict[str, str]]:

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -8,7 +8,7 @@ import re
 import string
 import uuid
 from collections import OrderedDict, defaultdict
-from collections.abc import Iterable, MutableMapping
+from collections.abc import Iterable, Iterator, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -24,11 +24,13 @@ from typing import (
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import unix_time, utcnow
 from moto.ec2.models import ec2_backends
 from moto.kms.models import KmsBackend, kms_backends
 from moto.moto_api._internal import mock_random as random
 from moto.secretsmanager.models import FakeSecret, SecretsManagerBackend
+from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import ARN_PARTITION_REGEX, CaseInsensitiveDict, load_resource
 
 from .exceptions import (
@@ -2321,7 +2323,9 @@ class DBShardGroup(RDSBaseModel):
         self.tags = tags or []
 
 
-class RDSBackend(BaseBackend):
+class RDSBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "rds"
+
     @property
     def SNAPSHOT_QUOTA(self) -> int:
         return int(os.environ.get("MOTO_RDS_SNAPSHOT_LIMIT", 1000))
@@ -4355,6 +4359,29 @@ class RDSBackend(BaseBackend):
 
     def _is_cluster(self, arn: str) -> bool:
         return arn.split(":")[-2] == "cluster"
+
+    # Resource Groups Tagging API
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        resource_map: dict[str, Iterable[Any]] = {
+            "rds:cluster": self.clusters.values(),
+            "rds:cluster-snapshot": self.cluster_snapshots.values(),
+            "rds:db": self.databases.values(),
+            "rds:db-proxy": self.db_proxies.values(),
+            "rds:snapshot": self.database_snapshots.values(),
+        }
+        for resource_type, resources in resource_map.items():
+            for resource in resources:
+                yield TaggedResource(
+                    arn=resource.arn,
+                    tags={tag["Key"]: tag["Value"] for tag in resource.get_tags()},
+                    resource_type=resource_type,
+                )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.add_tags_to_resource(arn, TaggingService.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.remove_tags_from_resource(arn, tag_keys)
 
 
 class OptionGroup(RDSBaseModel):

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -4,7 +4,6 @@ from typing import Any
 from moto.acm.models import AWSCertificateManagerBackend, acm_backends
 from moto.appsync.models import AppSyncBackend, appsync_backends
 from moto.athena.models import athena_backends
-from moto.awslambda.models import LambdaBackend, lambda_backends
 from moto.backup.models import BackupBackend, backup_backends
 from moto.clouddirectory import CloudDirectoryBackend, clouddirectory_backends
 from moto.cloudfront.models import CloudFrontBackend, cloudfront_backends
@@ -165,10 +164,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def lambda_backend(self) -> LambdaBackend:
-        return lambda_backends[self.account_id][self.region_name]
 
     @property
     def ecs_backend(self) -> EC2ContainerServiceBackend:
@@ -1422,21 +1417,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "Tags": tags,
                 }
 
-        # Lambda Instance
-        if (
-            not resource_type_filters
-            or "lambda" in resource_type_filters
-            or "lambda:function" in resource_type_filters
-        ):
-            for f in self.lambda_backend.list_functions():
-                tags = format_tags(f.tags)
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {
-                    "ResourceARN": f.function_arn,
-                    "Tags": tags,
-                }
-
         if (
             not resource_type_filters
             or "dynamodb" in resource_type_filters
@@ -1837,8 +1817,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.sagemaker_backend.add_tags(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
                 )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:lambda:"):
-                self.lambda_backend.tag_resource(arn, tags)
             elif arn.startswith(
                 f"arn:{get_partition(self.region_name)}:elasticfilesystem:"
             ):
@@ -1892,9 +1870,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 except NotImplementedError:
                     missing_resources.append(arn)
                 continue
-            if arn.startswith(f"arn:{get_partition(self.region_name)}:lambda:"):
-                self.lambda_backend.untag_resource(arn, tag_keys)
-            elif arn.startswith(
+            if arn.startswith(
                 f"arn:{get_partition(self.region_name)}:elasticfilesystem:"
             ):
                 resource_id = arn.split("/")[-1]

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -50,7 +50,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.s3.models import S3Backend, s3_backends
 from moto.sagemaker.models import SageMakerModelBackend, sagemaker_backends
 from moto.secretsmanager import secretsmanager_backends
 from moto.secretsmanager.models import ReplicaSecret, SecretsManagerBackend
@@ -86,10 +85,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def appsync_backend(self) -> AppSyncBackend:
         return appsync_backends[self.account_id][self.region_name]
-
-    @property
-    def s3_backend(self) -> S3Backend:
-        return s3_backends[self.account_id][self.partition]
 
     @property
     def directconnect_backend(self) -> DirectConnectBackend:
@@ -478,20 +473,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         if not tag_filter(tags):
                             continue
                         yield {"ResourceARN": f"{arn}", "Tags": tags}
-
-        # S3
-        if (
-            not resource_type_filters
-            or "s3" in resource_type_filters
-            or "s3:bucket" in resource_type_filters
-        ):
-            for bucket in self.s3_backend.buckets.values():
-                tags = self.s3_backend.tagger.list_tags_for_resource(bucket.arn)["Tags"]
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-                yield {"ResourceARN": bucket.arn, "Tags": tags}
 
         # Cloud Directory
         if self.clouddirectory_backend:
@@ -1393,11 +1374,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         for backend in iter_taggable_backends(self.account_id, self.region_name):
             for resource in backend.iter_tagged_resources():
                 yield from resource.tags.keys()
-        # S3
-        for bucket in self.s3_backend.buckets.values():
-            tags = self.s3_backend.tagger.get_tag_dict_for_resource(bucket.arn)
-            for key, _ in tags.items():
-                yield key
 
         # Glue
         for tag_dict in self.glue_backend.tagger.tags.values():
@@ -1413,12 +1389,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 for key, value in resource.tags.items():
                     if key == tag_key:
                         yield value
-        # Do S3, resource type s3
-        for bucket in self.s3_backend.buckets.values():
-            tags = self.s3_backend.tagger.get_tag_dict_for_resource(bucket.arn)
-            for key, value in tags.items():
-                if key == tag_key:
-                    yield value
 
         # Glue
         for tag_dict in self.glue_backend.tagger.tags.values():

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -46,7 +46,6 @@ from moto.lexv2models.models import LexModelsV2Backend, lexv2models_backends
 from moto.logs.models import LogsBackend, logs_backends
 from moto.moto_api._internal import mock_random
 from moto.quicksight.models import QuickSightBackend, quicksight_backends
-from moto.rds.models import RDSBackend, rds_backends
 from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
@@ -139,10 +138,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def logs_backend(self) -> LogsBackend:
         return logs_backends[self.account_id][self.region_name]
-
-    @property
-    def rds_backend(self) -> RDSBackend:
-        return rds_backends[self.account_id][self.region_name]
 
     @property
     def fsx_backends(self) -> FSxBackend:
@@ -979,36 +974,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                             "Tags": tags,
                         }
 
-        # RDS resources
-        resource_map: dict[str, dict[str, Any]] = {
-            "rds:cluster": dict(self.rds_backend.clusters),
-            "rds:db": dict(self.rds_backend.databases),
-            "rds:snapshot": dict(self.rds_backend.database_snapshots),
-            "rds:cluster-snapshot": dict(self.rds_backend.cluster_snapshots),
-            "rds:db-proxy": self.rds_backend.db_proxies,
-        }
-        for resource_type, resource_source in resource_map.items():
-            if (
-                not resource_type_filters
-                or "rds" in resource_type_filters
-                or resource_type in resource_type_filters
-            ):
-                for resource in resource_source.values():
-                    tags = resource.get_tags()
-                    if not tags or not tag_filter(tags):
-                        continue
-                    yield {
-                        "ResourceARN": resource.arn,
-                        "Tags": tags,
-                    }
-
-        # RDS Reserved Database Instance
-        # RDS Option Group
-        # RDS Parameter Group
-        # RDS Security Group
-        # RDS Subnet Group
-        # RDS Event Subscription
-
         # RedShift Cluster
         # RedShift Hardware security module (HSM) client certificate
         # RedShift HSM connection
@@ -1646,15 +1611,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 except NotImplementedError:
                     missing_resources.append(arn)
                 continue
-            if arn.startswith(
-                f"arn:{get_partition(self.region_name)}:rds:"
-            ) or arn.startswith(f"arn:{get_partition(self.region_name)}:snapshot:"):
-                self.rds_backend.add_tags_to_resource(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
-                )
-            elif arn.startswith(
-                f"arn:{get_partition(self.region_name)}:workspaces-web:"
-            ):
+            if arn.startswith(f"arn:{get_partition(self.region_name)}:workspaces-web:"):
                 resource_id = arn.split("/")[-1]
                 self.workspacesweb_backends.create_tags(  # type: ignore[union-attr]
                     resource_id, TaggingService.convert_dict_to_tags_input(tags)
@@ -1737,8 +1694,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.quicksight_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:elasticache:"):
                 self.elasticache_backend.remove_tags_from_resource(arn, tag_keys)
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:rds:"):
-                self.rds_backend.remove_tags_from_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
                 self.sesv2_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:cloudfront:"):

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -23,7 +23,6 @@ from moto.core.resource_tagging import (
 from moto.directconnect.models import DirectConnectBackend, directconnect_backends
 from moto.dms.models import DatabaseMigrationServiceBackend, dms_backends
 from moto.dynamodb.models import DynamoDBBackend, dynamodb_backends
-from moto.ec2 import ec2_backends
 from moto.ecs.models import EC2ContainerServiceBackend, ecs_backends
 from moto.efs.models import EFSBackend, efs_backends
 from moto.elasticache.models import ElastiCacheBackend, elasticache_backends
@@ -100,10 +99,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def dms_backend(self) -> DatabaseMigrationServiceBackend:
         return dms_backends[self.account_id][self.region_name]
-
-    @property
-    def ec2_backend(self) -> Any:  # type: ignore[misc]
-        return ec2_backends[self.account_id][self.region_name]
 
     @property
     def efs_backend(self) -> EFSBackend:
@@ -695,57 +690,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     if not tag_filter(tags):
                         continue
                     yield {"ResourceARN": f"{task_definition.arn}", "Tags": tags}
-
-        # EC2 Resources
-        ec2_resource_types = {
-            "ec2:image": self.ec2_backend.amis.values(),
-            "ec2:instance": (
-                instance
-                for reservation in self.ec2_backend.reservations.values()
-                for instance in reservation.instances
-            ),
-            "ec2:network-interface": self.ec2_backend.enis.values(),
-            "ec2:security-group": (
-                sg for vpc in self.ec2_backend.groups.values() for sg in vpc.values()
-            ),
-            "ec2:snapshot": self.ec2_backend.snapshots.values(),
-            "ec2:volume": self.ec2_backend.volumes.values(),
-            "ec2:vpc": self.ec2_backend.vpcs.values(),
-            "ec2:subnet": (
-                subnet
-                for subnet in self.ec2_backend.subnets.values()
-                for subnet in subnet.values()
-            ),
-            "ec2:vpc-peering-connection": self.ec2_backend.vpc_pcxs.values(),
-            "ec2:transit-gateway": self.ec2_backend.transit_gateways.values(),
-            "ec2:transit-gateway-attachment": self.ec2_backend.transit_gateway_attachments.values(),
-            "ec2:route-table": self.ec2_backend.route_tables.values(),
-            "ec2:customer-gateway": self.ec2_backend.customer_gateways.values(),
-            "ec2:vpn-connection": self.ec2_backend.vpn_connections.values(),
-            "ec2:natgateway": self.ec2_backend.nat_gateways.values(),
-            "ec2:internet-gateway": self.ec2_backend.internet_gateways.values(),
-            "ec2:managed-prefix-lists": self.ec2_backend.managed_prefix_lists.values(),
-            "ec2:flow-logs": self.ec2_backend.flow_logs.values(),
-            "ec2:spot-instance-request": self.ec2_backend.spot_instance_requests.values(),
-            # TODO: "ec2:reserved-instance": ...,
-        }
-
-        for resource_type, resources in ec2_resource_types.items():
-            if (
-                not resource_type_filters
-                or "ec2" in resource_type_filters
-                or resource_type in resource_type_filters
-            ):
-                for resource in resources:
-                    tags = format_tags(self.ec2_backend.tags.get(resource.id, {}))
-                    if not tags or not tag_filter(tags):
-                        continue
-                    resource_type_part = resource_type.split(":", 1)[1]
-                    resource_arn = f"arn:{self.partition}:ec2:{self.region_name}:{self.account_id}:{resource_type_part}/{resource.id}"
-                    yield {
-                        "ResourceARN": resource_arn,
-                        "Tags": tags,
-                    }
 
         # EFS, resource type elasticfilesystem:access-point
         if (
@@ -1490,49 +1434,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             for key, _ in tags.items():
                 yield key
 
-        # EC2 tags
-        def get_ec2_keys(res_id: str) -> list[dict[str, str]]:
-            result = []
-            for key in self.ec2_backend.tags.get(res_id, {}):
-                result.append(key)
-            return result
-
-        # EC2 AMI, resource type ec2:image
-        for ami in self.ec2_backend.amis.values():
-            for key in get_ec2_keys(ami.id):  # type: ignore[assignment]
-                yield key
-
-        # EC2 Instance, resource type ec2:instance
-        for reservation in self.ec2_backend.reservations.values():
-            for instance in reservation.instances:
-                for key in get_ec2_keys(instance.id):  # type: ignore[assignment]
-                    yield key
-
-        # EC2 NetworkInterface, resource type ec2:network-interface
-        for eni in self.ec2_backend.enis.values():
-            for key in get_ec2_keys(eni.id):  # type: ignore[assignment]
-                yield key
-
-        # TODO EC2 ReservedInstance
-
-        # EC2 SecurityGroup, resource type ec2:security-group
-        for vpc in self.ec2_backend.groups.values():
-            for sg in vpc.values():
-                for key in get_ec2_keys(sg.id):  # type: ignore[assignment]
-                    yield key
-
-        # EC2 Snapshot, resource type ec2:snapshot
-        for snapshot in self.ec2_backend.snapshots.values():
-            for key in get_ec2_keys(snapshot.id):  # type: ignore[assignment]
-                yield key
-
-        # TODO EC2 SpotInstanceRequest
-
-        # EC2 Volume, resource type ec2:volume
-        for volume in self.ec2_backend.volumes.values():
-            for key in get_ec2_keys(volume.id):  # type: ignore[assignment]
-                yield key
-
         # Glue
         for tag_dict in self.glue_backend.tagger.tags.values():
             yield from tag_dict.keys()
@@ -1553,50 +1454,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             for key, value in tags.items():
                 if key == tag_key:
                     yield value
-
-        # EC2 tags
-        def get_ec2_values(res_id: str) -> list[dict[str, str]]:
-            result = []
-            for key, value in self.ec2_backend.tags.get(res_id, {}).items():
-                if key == tag_key:
-                    result.append(value)
-            return result
-
-        # EC2 AMI, resource type ec2:image
-        for ami in self.ec2_backend.amis.values():
-            for value in get_ec2_values(ami.id):  # type: ignore[assignment]
-                yield value
-
-        # EC2 Instance, resource type ec2:instance
-        for reservation in self.ec2_backend.reservations.values():
-            for instance in reservation.instances:
-                for value in get_ec2_values(instance.id):  # type: ignore[assignment]
-                    yield value
-
-        # EC2 NetworkInterface, resource type ec2:network-interface
-        for eni in self.ec2_backend.enis.values():
-            for value in get_ec2_values(eni.id):  # type: ignore[assignment]
-                yield value
-
-        # TODO EC2 ReservedInstance
-
-        # EC2 SecurityGroup, resource type ec2:security-group
-        for vpc in self.ec2_backend.groups.values():
-            for sg in vpc.values():
-                for value in get_ec2_values(sg.id):  # type: ignore[assignment]
-                    yield value
-
-        # EC2 Snapshot, resource type ec2:snapshot
-        for snapshot in self.ec2_backend.snapshots.values():
-            for value in get_ec2_values(snapshot.id):  # type: ignore[assignment]
-                yield value
-
-        # TODO EC2 SpotInstanceRequest
-
-        # EC2 Volume, resource type ec2:volume
-        for volume in self.ec2_backend.volumes.values():
-            for value in get_ec2_values(volume.id):  # type: ignore[assignment]
-                yield value
 
         # Glue
         for tag_dict in self.glue_backend.tagger.tags.values():

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -15,6 +15,12 @@ from moto.connectcampaigns.models import (
     connectcampaigns_backends,
 )
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.resource_tagging import (
+    TaggableResourcesMixin,
+    iter_taggable_backends,
+    make_tag_matcher,
+    match_resource_type,
+)
 from moto.directconnect.models import DirectConnectBackend, directconnect_backends
 from moto.dms.models import DatabaseMigrationServiceBackend, dms_backends
 from moto.dynamodb.models import DynamoDBBackend, dynamodb_backends
@@ -286,6 +292,19 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     def sesv2_backend(self) -> SESV2Backend:
         return sesv2_backends[self.account_id][self.region_name]
 
+    def _get_backend_for_resource(
+        self, resource_arn: str
+    ) -> TaggableResourcesMixin | None:
+        backend = next(
+            (
+                b
+                for b in iter_taggable_backends(self.account_id, self.region_name)
+                if b.owns_arn(resource_arn)
+            ),
+            None,
+        )
+        return backend
+
     def _get_resources_generator(
         self,
         tag_filters: list[dict[str, Any]] | None = None,
@@ -341,6 +360,22 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 result.append({"Key": tag[keys[0]], "Value": tag[keys[1]]})
             return result
 
+        # Services opted in via TaggableResourcesMixin
+        tag_matcher = make_tag_matcher(tag_filters)
+        for backend in iter_taggable_backends(self.account_id, self.region_name):
+            for resource in backend.iter_tagged_resources():
+                if not resource.tags:
+                    continue
+                if not match_resource_type(
+                    resource.resource_type, resource_type_filters
+                ):
+                    continue
+                if not tag_matcher(resource.tags):
+                    continue
+                yield {
+                    "ResourceARN": resource.arn,
+                    "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
+                }
         # ACM
         if not resource_type_filters or "acm" in resource_type_filters:
             for certificate in self.acm_backend._certificates.values():
@@ -507,9 +542,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             try:
                 from moto.cloudformation import cloudformation_backends
 
-                backend = cloudformation_backends[self.account_id][self.region_name]
+                cf_backend = cloudformation_backends[self.account_id][self.region_name]
 
-                for stack in backend.stacks.values():
+                for stack in cf_backend.stacks.values():
                     tags = format_tags(stack.tags)
                     if not tag_filter(tags):
                         continue
@@ -1465,6 +1500,10 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Look at
         # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 
+        # Services opted in via TaggableResourcesMixin
+        for backend in iter_taggable_backends(self.account_id, self.region_name):
+            for resource in backend.iter_tagged_resources():
+                yield from resource.tags.keys()
         # S3
         for bucket in self.s3_backend.buckets.values():
             tags = self.s3_backend.tagger.get_tag_dict_for_resource(bucket.arn)
@@ -1522,6 +1561,12 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Look at
         # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
 
+        # Services opted in via TaggableResourcesMixin
+        for backend in iter_taggable_backends(self.account_id, self.region_name):
+            for resource in backend.iter_tagged_resources():
+                for key, value in resource.tags.items():
+                    if key == tag_key:
+                        yield value
         # Do S3, resource type s3
         for bucket in self.s3_backend.buckets.values():
             tags = self.s3_backend.tagger.get_tag_dict_for_resource(bucket.arn)
@@ -1757,6 +1802,13 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         }
 
         for arn in resource_arns:
+            backend_for_arn = self._get_backend_for_resource(arn)
+            if backend_for_arn is not None:
+                try:
+                    backend_for_arn.tag_resource(arn, tags)
+                except NotImplementedError:
+                    missing_resources.append(arn)
+                continue
             if arn.startswith(
                 f"arn:{get_partition(self.region_name)}:rds:"
             ) or arn.startswith(f"arn:{get_partition(self.region_name)}:snapshot:"):
@@ -1833,6 +1885,13 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         }
 
         for arn in resource_arn_list:
+            backend_for_arn = self._get_backend_for_resource(arn)
+            if backend_for_arn is not None:
+                try:
+                    backend_for_arn.untag_resource(arn, tag_keys)
+                except NotImplementedError:
+                    missing_resources.append(arn)
+                continue
             if arn.startswith(f"arn:{get_partition(self.region_name)}:lambda:"):
                 self.lambda_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -28,6 +28,7 @@ from moto.core.common_models import (
     CloudFormationModel,
     CloudWatchMetricProvider,
 )
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import (
     ensure_boolean,
     iso_8601_datetime_without_milliseconds_s3,
@@ -1736,7 +1737,7 @@ class FakeBucketInventoryConfiguration(BaseModel):
         self.optional_fields = optional_fields
 
 
-class S3Backend(BaseBackend, CloudWatchMetricProvider):
+class S3Backend(BaseBackend, CloudWatchMetricProvider, TaggableResourcesMixin):
     """
     Custom S3 endpoints are supported, if you are using a S3-compatible storage solution like Ceph.
     Example usage:
@@ -1797,6 +1798,8 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
         S3_IGNORE_SUBDOMAIN_BUCKETNAME=true
 
     """
+
+    SERVICE_NAMESPACE = "s3"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -3276,6 +3279,24 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider):
     ) -> list[FakeBucketInventoryConfiguration]:
         bucket = self.get_bucket(bucket_name)
         return list(bucket.inventory_configs.values())
+
+    # Resource Groups Tagging API
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for bucket in self.buckets.values():
+            yield TaggedResource(
+                arn=bucket.arn,
+                tags=self.tagger.get_tag_dict_for_resource(bucket.arn),
+                resource_type="s3:bucket",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        bucket_name = arn.split(":")[-1]
+        existing = self.tagger.get_tag_dict_for_resource(arn)
+        existing.update(tags)
+        self.put_bucket_tagging(bucket_name, existing)
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 class S3BackendDict(BackendDict[S3Backend]):

--- a/tests/test_autoscaling/test_autoscaling_integration.py
+++ b/tests/test_autoscaling/test_autoscaling_integration.py
@@ -1,0 +1,88 @@
+import boto3
+
+from moto import mock_aws
+from tests import EXAMPLE_AMI_ID
+
+from .utils import setup_networking
+
+
+def _create_tagged_asgs(client, subnet):
+    client.create_launch_configuration(
+        LaunchConfigurationName="rgtapi-lc",
+        ImageId=EXAMPLE_AMI_ID,
+        InstanceType="t2.medium",
+    )
+    client.create_auto_scaling_group(
+        AutoScalingGroupName="rgtapi-asg-1",
+        LaunchConfigurationName="rgtapi-lc",
+        MinSize=0,
+        MaxSize=2,
+        DesiredCapacity=0,
+        Tags=[
+            {"Key": "env", "Value": "prod", "PropagateAtLaunch": True},
+            {"Key": "team", "Value": "platform", "PropagateAtLaunch": False},
+        ],
+        VPCZoneIdentifier=subnet,
+    )
+    client.create_auto_scaling_group(
+        AutoScalingGroupName="rgtapi-asg-2",
+        LaunchConfigurationName="rgtapi-lc",
+        MinSize=0,
+        MaxSize=2,
+        DesiredCapacity=0,
+        Tags=[
+            {"Key": "env", "Value": "dev", "PropagateAtLaunch": True},
+        ],
+        VPCZoneIdentifier=subnet,
+    )
+    client.create_auto_scaling_group(
+        AutoScalingGroupName="rgtapi-asg-untagged",
+        LaunchConfigurationName="rgtapi-lc",
+        MinSize=0,
+        MaxSize=2,
+        DesiredCapacity=0,
+        VPCZoneIdentifier=subnet,
+    )
+
+
+@mock_aws
+def test_rgtapi_tag_resources_updates_autoscaling_group():
+    subnet = setup_networking()["subnet1"]
+    asg = boto3.client("autoscaling", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_asgs(asg, subnet)
+
+    resp = asg.describe_auto_scaling_groups(AutoScalingGroupNames=["rgtapi-asg-1"])
+    arn = resp["AutoScalingGroups"][0]["AutoScalingGroupARN"]
+
+    resp = rtapi.tag_resources(
+        ResourceARNList=[arn], Tags={"owner": "dataops", "env": "staging"}
+    )
+    assert resp.get("FailedResourcesMap", {}) == {}
+
+    resp = asg.describe_auto_scaling_groups(AutoScalingGroupNames=["rgtapi-asg-1"])
+    tags = resp["AutoScalingGroups"][0]["Tags"]
+    by_key = {t["Key"]: t for t in tags}
+    assert by_key["owner"]["Value"] == "dataops"
+    # Existing tag should be updated in place.
+    assert by_key["env"]["Value"] == "staging"
+    # Pre-existing tags survive.
+    assert by_key["team"]["Value"] == "platform"
+
+
+@mock_aws
+def test_rgtapi_untag_resources_removes_autoscaling_tags():
+    subnet = setup_networking()["subnet1"]
+    asg = boto3.client("autoscaling", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_asgs(asg, subnet)
+
+    resp = asg.describe_auto_scaling_groups(AutoScalingGroupNames=["rgtapi-asg-1"])
+    arn = resp["AutoScalingGroups"][0]["AutoScalingGroupARN"]
+
+    rtapi.untag_resources(ResourceARNList=[arn], TagKeys=["env"])
+
+    resp = asg.describe_auto_scaling_groups(AutoScalingGroupNames=["rgtapi-asg-1"])
+    tags = resp["AutoScalingGroups"][0]["Tags"]
+    assert "env" not in {t["Key"] for t in tags}
+    assert "team" in {t["Key"] for t in tags}

--- a/tests/test_core/test_resource_tagging.py
+++ b/tests/test_core/test_resource_tagging.py
@@ -1,0 +1,102 @@
+from unittest import SkipTest
+
+import pytest
+
+from moto import mock_aws, settings
+from moto.core.resource_tagging import (
+    TaggableResourcesMixin,
+    TaggedResource,
+    iter_taggable_backends,
+    make_tag_matcher,
+    match_resource_type,
+)
+
+
+class TestInitSubclassValidation:
+    def test_subclass_without_service_namespace_raises(self) -> None:
+        with pytest.raises(TypeError, match="SERVICE_NAMESPACE"):
+
+            class Bad(TaggableResourcesMixin):
+                pass
+
+    def test_subclass_with_service_namespace_is_accepted(self) -> None:
+        class Good(TaggableResourcesMixin):
+            SERVICE_NAMESPACE = "test"
+
+        assert Good.SERVICE_NAMESPACE == "test"
+
+
+class TestMatchResourceType:
+    def test_no_filters_matches_all(self) -> None:
+        assert match_resource_type("rds:cluster", None)
+        assert match_resource_type("rds:cluster", [])
+
+    def test_service_prefix_matches_subtype(self) -> None:
+        assert match_resource_type("rds:cluster", ["rds"])
+        assert match_resource_type("rds:db", ["rds"])
+
+    def test_exact_subtype_matches(self) -> None:
+        assert match_resource_type("rds:cluster", ["rds:cluster"])
+
+    def test_exact_subtype_filter_rejects_other_subtypes(self) -> None:
+        assert not match_resource_type("rds:db", ["rds:cluster"])
+
+    def test_unrelated_filter_rejects(self) -> None:
+        assert not match_resource_type("rds:cluster", ["lambda"])
+
+    def test_multiple_filters_or(self) -> None:
+        assert match_resource_type("rds:cluster", ["lambda", "rds"])
+        assert match_resource_type("lambda:function", ["lambda", "rds"])
+        assert not match_resource_type("s3:bucket", ["lambda", "rds"])
+
+
+class TestMakeTagMatcher:
+    def test_no_filters_matches_anything(self) -> None:
+        match = make_tag_matcher(None)
+        assert match({})
+        assert match({"k": "v"})
+
+    def test_key_only_filter(self) -> None:
+        match = make_tag_matcher([{"Key": "env"}])
+        assert match({"env": "prod"})
+        assert not match({"owner": "team"})
+
+    def test_key_and_value_filter(self) -> None:
+        match = make_tag_matcher([{"Key": "env", "Values": ["prod"]}])
+        assert match({"env": "prod"})
+        assert not match({"env": "dev"})
+
+    def test_multi_value_filter_is_or(self) -> None:
+        match = make_tag_matcher([{"Key": "env", "Values": ["prod", "stage"]}])
+        assert match({"env": "stage"})
+        assert not match({"env": "dev"})
+
+    def test_multiple_filters_are_and(self) -> None:
+        match = make_tag_matcher([{"Key": "env", "Values": ["prod"]}, {"Key": "team"}])
+        assert match({"env": "prod", "team": "billing"})
+        assert not match({"env": "prod"})
+
+
+@mock_aws
+def test_iter_taggable_backends_skips_untouched_accounts() -> None:
+    if settings.TEST_SERVER_MODE:
+        raise SkipTest("No direct access to backends in Server Mode")
+
+    # Account that's never been touched by any service should yield nothing.
+    other_account = list(iter_taggable_backends("999999999999", "us-east-1"))
+    assert other_account == []
+
+
+def test_default_owns_arn() -> None:
+    class FakeBackend(TaggableResourcesMixin):
+        SERVICE_NAMESPACE = "rds"
+        partition = "aws"
+
+    backend = FakeBackend()
+    assert backend.owns_arn("arn:aws:rds:us-east-1:123456789012:cluster:foo")
+    assert not backend.owns_arn("arn:aws:s3:::bucket")
+
+
+def test_tagged_resource_dataclass_defaults() -> None:
+    r = TaggedResource(arn="arn", tags={}, resource_type="rds:db")
+    assert r.extra == {}

--- a/tests/test_ec2/test_ec2_integration.py
+++ b/tests/test_ec2/test_ec2_integration.py
@@ -45,3 +45,60 @@ def test_run_instance_with_encrypted_ebs():
     assert volumes["Volumes"][0]["Size"] == 50
     assert volumes["Volumes"][0]["Encrypted"] is True
     assert volumes["Volumes"][0]["KmsKeyId"] == key_id
+
+
+@mock_aws
+def test_rgtapi_tag_and_untag_resources_for_ec2_instance() -> None:
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    instance = ec2.run_instances(
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1, InstanceType="t2.micro"
+    )["Instances"][0]
+    instance_id = instance["InstanceId"]
+    arn = f"arn:aws:ec2:us-east-1:123456789012:instance/{instance_id}"
+
+    rtapi.tag_resources(
+        ResourceARNList=[arn],
+        Tags={"env": "prod", "owner": "platform"},
+    )
+
+    described = ec2.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
+        "Instances"
+    ][0]
+    by_key = {t["Key"]: t["Value"] for t in described["Tags"]}
+    assert by_key["env"] == "prod"
+    assert by_key["owner"] == "platform"
+
+    rtapi.untag_resources(ResourceARNList=[arn], TagKeys=["env"])
+
+    described = ec2.describe_instances(InstanceIds=[instance_id])["Reservations"][0][
+        "Instances"
+    ][0]
+    keys = {t["Key"] for t in described["Tags"]}
+    assert "env" not in keys
+    assert "owner" in keys
+
+
+@mock_aws
+def test_rgtapi_tag_and_untag_resources_for_ec2_vpc() -> None:
+    ec2 = boto3.client("ec2", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    vpc_id = ec2.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+    arn = f"arn:aws:ec2:us-east-1:123456789012:vpc/{vpc_id}"
+
+    rtapi.tag_resources(
+        ResourceARNList=[arn],
+        Tags={"tier": "network", "team": "platform"},
+    )
+
+    described = ec2.describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0]
+    by_key = {t["Key"]: t["Value"] for t in described["Tags"]}
+    assert by_key["tier"] == "network"
+    assert by_key["team"] == "platform"
+
+    rtapi.untag_resources(ResourceARNList=[arn], TagKeys=["tier", "team"])
+
+    described = ec2.describe_vpcs(VpcIds=[vpc_id])["Vpcs"][0]
+    assert "Tags" not in described or all(
+        t["Key"] not in {"tier", "team"} for t in described.get("Tags", [])
+    )

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -1259,29 +1259,25 @@ def test_get_resources_ssm():
 @mock_aws
 def test_tag_resources_for_unknown_service():
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
+    unknown_arn = "arn:aws:unknown:us-west-2:123456789012:resource/unknown-resource"
     missing_resources = rtapi.tag_resources(
-        ResourceARNList=["arn:aws:service_x"], Tags={"key1": "k", "key2": "v"}
+        ResourceARNList=[unknown_arn], Tags={"key1": "k", "key2": "v"}
     )["FailedResourcesMap"]
 
-    assert "arn:aws:service_x" in missing_resources
-    assert (
-        missing_resources["arn:aws:service_x"]["ErrorCode"]
-        == "InternalServiceException"
-    )
+    assert unknown_arn in missing_resources
+    assert missing_resources[unknown_arn]["ErrorCode"] == "InternalServiceException"
 
 
 @mock_aws
 def test_untag_resources_for_unknown_service():
     rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-west-2")
+    unknown_arn = "arn:aws:unknown:us-west-2:123456789012:resource/unknown-resource"
     missing_resources = rtapi.untag_resources(
-        ResourceARNList=["arn:aws:service_x"], TagKeys=["key1", "key2"]
+        ResourceARNList=[unknown_arn], TagKeys=["key1", "key2"]
     )["FailedResourcesMap"]
 
-    assert "arn:aws:service_x" in missing_resources
-    assert (
-        missing_resources["arn:aws:service_x"]["ErrorCode"]
-        == "InternalServiceException"
-    )
+    assert unknown_arn in missing_resources
+    assert missing_resources[unknown_arn]["ErrorCode"] == "InternalServiceException"
 
 
 @mock_aws

--- a/tests/test_s3/test_s3_integration.py
+++ b/tests/test_s3/test_s3_integration.py
@@ -1,0 +1,154 @@
+import boto3
+import pytest
+
+from moto import mock_aws
+
+
+def _create_tagged_buckets(s3, region):
+    create_args = {"Bucket": "rgtapi-bucket-1"}
+    if region != "us-east-1":
+        create_args["CreateBucketConfiguration"] = {"LocationConstraint": region}
+    s3.create_bucket(**create_args)
+    s3.put_bucket_tagging(
+        Bucket="rgtapi-bucket-1",
+        Tagging={
+            "TagSet": [
+                {"Key": "env", "Value": "prod"},
+                {"Key": "team", "Value": "platform"},
+            ]
+        },
+    )
+
+    create_args = {"Bucket": "rgtapi-bucket-2"}
+    if region != "us-east-1":
+        create_args["CreateBucketConfiguration"] = {"LocationConstraint": region}
+    s3.create_bucket(**create_args)
+    s3.put_bucket_tagging(
+        Bucket="rgtapi-bucket-2",
+        Tagging={"TagSet": [{"Key": "env", "Value": "dev"}]},
+    )
+
+    # Untagged bucket should not be returned by GetResources.
+    create_args = {"Bucket": "rgtapi-bucket-untagged"}
+    if region != "us-east-1":
+        create_args["CreateBucketConfiguration"] = {"LocationConstraint": region}
+    s3.create_bucket(**create_args)
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_rgtapi_get_resources_returns_s3_buckets():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_buckets(s3, "us-east-1")
+
+    result = rtapi.get_resources(ResourceTypeFilters=["s3:bucket"])
+    by_arn = {r["ResourceARN"]: r["Tags"] for r in result["ResourceTagMappingList"]}
+
+    assert len(by_arn) == 2
+    assert "arn:aws:s3:::rgtapi-bucket-1" in by_arn
+    assert "arn:aws:s3:::rgtapi-bucket-2" in by_arn
+    assert {"Key": "env", "Value": "prod"} in by_arn["arn:aws:s3:::rgtapi-bucket-1"]
+    assert {"Key": "team", "Value": "platform"} in by_arn[
+        "arn:aws:s3:::rgtapi-bucket-1"
+    ]
+    assert by_arn["arn:aws:s3:::rgtapi-bucket-2"] == [{"Key": "env", "Value": "dev"}]
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_rgtapi_get_resources_service_prefix_matches_s3():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_buckets(s3, "us-east-1")
+
+    result = rtapi.get_resources(ResourceTypeFilters=["s3"])
+    arns = {r["ResourceARN"] for r in result["ResourceTagMappingList"]}
+    assert "arn:aws:s3:::rgtapi-bucket-1" in arns
+    assert "arn:aws:s3:::rgtapi-bucket-2" in arns
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_rgtapi_get_resources_filters_s3_by_tag_value():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_buckets(s3, "us-east-1")
+
+    result = rtapi.get_resources(
+        ResourceTypeFilters=["s3:bucket"],
+        TagFilters=[{"Key": "env", "Values": ["prod"]}],
+    )
+    arns = [r["ResourceARN"] for r in result["ResourceTagMappingList"]]
+    assert arns == ["arn:aws:s3:::rgtapi-bucket-1"]
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_rgtapi_s3_visible_from_other_region():
+    # S3 is partition-global; buckets created in us-east-1 must be visible
+    # to a rgtapi client in any other region in the same partition.
+    s3 = boto3.client("s3", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-west-1")
+    _create_tagged_buckets(s3, "us-east-1")
+
+    result = rtapi.get_resources(ResourceTypeFilters=["s3:bucket"])
+    arns = {r["ResourceARN"] for r in result["ResourceTagMappingList"]}
+    assert "arn:aws:s3:::rgtapi-bucket-1" in arns
+    assert "arn:aws:s3:::rgtapi-bucket-2" in arns
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_rgtapi_get_tag_keys_and_values_include_s3():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_buckets(s3, "us-east-1")
+
+    keys = rtapi.get_tag_keys()["TagKeys"]
+    assert "env" in keys
+    assert "team" in keys
+
+    env_values = rtapi.get_tag_values(Key="env")["TagValues"]
+    assert set(env_values) >= {"prod", "dev"}
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_rgtapi_tag_resources_updates_s3_bucket():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_buckets(s3, "us-east-1")
+    arn = "arn:aws:s3:::rgtapi-bucket-1"
+
+    response = rtapi.tag_resources(
+        ResourceARNList=[arn],
+        Tags={"owner": "dataops", "env": "staging"},
+    )
+    assert response.get("FailedResourcesMap", {}) == {}
+
+    tags = s3.get_bucket_tagging(Bucket="rgtapi-bucket-1")["TagSet"]
+    by_key = {t["Key"]: t["Value"] for t in tags}
+    # New tag added.
+    assert by_key["owner"] == "dataops"
+    # Existing key updated.
+    assert by_key["env"] == "staging"
+    # Pre-existing unrelated tag preserved.
+    assert by_key["team"] == "platform"
+
+
+@mock_aws
+@pytest.mark.requires_clean_slate
+def test_rgtapi_untag_resources_removes_s3_tags():
+    s3 = boto3.client("s3", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    _create_tagged_buckets(s3, "us-east-1")
+    arn = "arn:aws:s3:::rgtapi-bucket-1"
+
+    response = rtapi.untag_resources(ResourceARNList=[arn], TagKeys=["env"])
+    assert response.get("FailedResourcesMap", {}) == {}
+
+    tags = s3.get_bucket_tagging(Bucket="rgtapi-bucket-1")["TagSet"]
+    keys = {t["Key"] for t in tags}
+    assert "env" not in keys
+    assert "team" in keys


### PR DESCRIPTION
Allow service backends to opt in to the Resource Groups Tagging API via a simple interface, obviating the need for the RGTAPI backend to directly import participating backends or manage per-service tagging logic.

Migrates EC2, Lambda, RDS, and S3 as the first consumers to illustrate the benefits and ensure this new method works for key AWS services.  Follow-on PRs will migrate the rest of the existing services, greatly simplifying the RGTAPI backend.

## Key Benefits

- **Eliminates Boilerplate** — Services implement tagging in their own backend; RGTAPI discovers them automatically instead of hardcoding each one.
- **Centralizes Filtering Logic** — Tag filtering and matching now live in one place instead of scattered across services.
- **Auto-Discovery** — `iter_taggable_backends()` dynamically finds all tagging-capable services; adding support requires zero changes to the RGTAPI backend.
- **Better Separation** — RGTAPI handles the higher-level concerns, services handle their own details; both sides of the tagging contract become easier to understand and update.

Closes #9544 