### PR TITLE
Admin: fix flaky tests (hopefully)

### DIFF
--- a/tests/test_awslambda/test_lambda_invoke.py
+++ b/tests/test_awslambda/test_lambda_invoke.py
@@ -295,7 +295,7 @@ if not settings.TEST_DECORATOR_MODE:
             Handler="lambda_function.lambda_handler",
             Code={"ZipFile": get_test_zip_file2()},
             Description="test lambda function",
-            Timeout=3,
+            Timeout=30,
             MemorySize=128,
             Publish=True,
         )

--- a/tests/test_cloudformation/test_cloudformation_custom_resources.py
+++ b/tests/test_cloudformation/test_cloudformation_custom_resources.py
@@ -61,7 +61,9 @@ def test_create_custom_lambda_resource():
     # Verify CloudWatch contains the correct logs
     log_group_name = get_log_group_name(cf, stack_name)
     success, logs = wait_for_log_msg(
-        expected_msg="Status code: 200", log_group=log_group_name
+        expected_msg="Status code: 200",
+        log_group=log_group_name,
+        wait_time=90,
     )
     assert success, f"Logs should indicate success: \n{logs}"
 

--- a/tests/test_events/test_events_integration.py
+++ b/tests/test_events/test_events_integration.py
@@ -417,16 +417,11 @@ def test_moto_matches_none_value_with_exists_filter():
         ]
     )
 
-    events = sorted(
-        logs_client.filter_log_events(logGroupName=log_group_name)["events"],
-        key=lambda x: x["eventId"],
-    )
+    events = logs_client.filter_log_events(logGroupName=log_group_name)["events"]
     event_details = [json.loads(x["message"])["detail"] for x in events]
-
-    assert event_details == [
-        {"foo": "123", "bar": "123"},
-        {"foo": None, "bar": "123"},
-    ]
+    assert len(event_details) == 2
+    assert {"foo": "123", "bar": "123"} in event_details
+    assert {"foo": None, "bar": "123"} in event_details
 
 
 @mock_aws

--- a/tests/test_s3/test_s3_lambda_integration.py
+++ b/tests/test_s3/test_s3_lambda_integration.py
@@ -44,6 +44,7 @@ def test_objectcreated_put__invokes_lambda(match_events, actual_event):
         Role=get_role_name(),
         Handler="lambda_function.lambda_handler",
         Code={"ZipFile": get_test_zip_file_print_event()},
+        Timeout=30,
     )["FunctionArn"]
 
     # Put Notification
@@ -71,7 +72,7 @@ def test_objectcreated_put__invokes_lambda(match_events, actual_event):
     # Find the output of AWSLambda
     expected_msg = "FINISHED_PRINTING_EVENT"
     log_group = f"/aws/lambda/{function_name}"
-    msg_showed_up, all_logs = wait_for_log_msg(expected_msg, log_group, wait_time=10)
+    msg_showed_up, all_logs = wait_for_log_msg(expected_msg, log_group, wait_time=90)
 
     if actual_event is None:
         # The event should not be fired on POST, as we've only PUT an event for now


### PR DESCRIPTION
The events test had a genuine issue with asserting an ordered list against a (possibly un)ordered list.  The other two tests have been timing out with an increasing frequency, and have had their (relatively short) timeouts increased.  

Hopefully we'll notice fewer CI failures after merging. 🤞 

Edit: Well, the first two CI runs failed... with a different flaky test!  I threw in another commit to adjust the associated timeouts for that test, and we are now green. ✅ 