### PR TITLE
ResourceGroupsTaggingAPI: finalize integration with TaggableResourcesMixin

### DIFF
--- a/moto/acm/models.py
+++ b/moto/acm/models.py
@@ -3,7 +3,7 @@ import calendar
 import datetime
 import ipaddress
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 import cryptography.hazmat.primitives.asymmetric.rsa
@@ -16,6 +16,7 @@ from cryptography.x509 import OID_COMMON_NAME, DNSName, IPAddress, NameOID
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.serialize import parse_to_aware_datetime
 from moto.core.utils import utcnow
 
@@ -461,7 +462,9 @@ class AccountConfiguration:
         return {"ExpiryEvents": {"DaysBeforeExpiry": self.days_before_expiry}}
 
 
-class AWSCertificateManagerBackend(BaseBackend):
+class AWSCertificateManagerBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "acm"
+
     MIN_PASSPHRASE_LEN = 4
 
     def __init__(self, region_name: str, account_id: str):
@@ -674,6 +677,23 @@ class AWSCertificateManagerBackend(BaseBackend):
         self._account_config = AccountConfiguration(days_before_expiry)
         if idempotency_token is not None:
             self._set_idempotency_token_arn(idempotency_token, "account_config")
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for cert in self._certificates.values():
+            yield TaggedResource(
+                arn=cert.arn,
+                tags={k: v or "" for k, v in cert.tags.items()},
+                resource_type="acm:certificate",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.add_tags_to_certificate(
+            arn, [{"Key": k, "Value": v} for k, v in tags.items()]
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.remove_tags_from_certificate(arn, [{"Key": k} for k in tag_keys])  # type: ignore[list-item]
 
 
 acm_backends = BackendDict(AWSCertificateManagerBackend, "acm")

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import base64
 import json
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
@@ -490,8 +491,10 @@ class EventsAPI(BaseModel):
 
 
 # region: AppSyncBackend
-class AppSyncBackend(BaseBackend):
+class AppSyncBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of AppSync APIs."""
+
+    SERVICE_NAMESPACE = "appsync"
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
@@ -627,14 +630,6 @@ class AppSyncBackend(BaseBackend):
 
     def get_schema_creation_status(self, api_id: str) -> Any:
         return self.graphql_apis[api_id].get_schema_status()
-
-    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
-        self.tagger.tag_resource(
-            resource_arn, TaggingService.convert_dict_to_tags_input(tags)
-        )
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
@@ -796,6 +791,23 @@ class AppSyncBackend(BaseBackend):
         if api_id not in self.events_apis:
             raise EventsAPINotFound(api_id)
         return self.events_apis[api_id]
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for api in self.graphql_apis.values():
+            yield TaggedResource(
+                arn=api.arn,
+                tags=self.tagger.get_tag_dict_for_resource(api.arn),
+                resource_type="appsync:apis",
+            )
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(
+            resource_arn, TaggingService.convert_dict_to_tags_input(tags)
+        )
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
 
 # endregion

--- a/moto/athena/models.py
+++ b/moto/athena/models.py
@@ -1,5 +1,6 @@
 import re
 import time
+from collections.abc import Iterable, Iterator
 from datetime import datetime
 from typing import Any
 
@@ -10,6 +11,7 @@ from moto.athena.exceptions import (
 )
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.s3.models import s3_backends
@@ -220,7 +222,9 @@ class PreparedStatement(BaseModel):
         self.last_modified_time = datetime.now()
 
 
-class AthenaBackend(BaseBackend):
+class AthenaBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "athena"
+
     PAGINATION_MODEL = {
         "list_named_queries": {
             "input_token": "next_token",
@@ -620,15 +624,26 @@ class AthenaBackend(BaseBackend):
             return self.tagger.list_tags_for_resource(resource_arn)
         return None
 
-    def tag_resource(
-        self, resource_arn: str, tags: list[dict[str, str]]
-    ) -> dict[str, Any]:
-        self.tagger.tag_resource(resource_arn, tags)
-        return {}
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        resource_map: dict[str, Iterable[Any]] = {
+            "athena:capacityreservation": self.capacity_reservations.values(),
+            "athena:datacatalog": self.data_catalogs.values(),
+            "athena:workgroup": self.work_groups.values(),
+        }
+        for resource_type, resources in resource_map.items():
+            for resource in resources:
+                yield TaggedResource(
+                    arn=resource.arn,
+                    tags=self.tagger.get_tag_dict_for_resource(resource.arn),
+                    resource_type=resource_type,
+                )
 
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> dict[str, Any]:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
-        return {}
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 athena_backends = BackendDict(AthenaBackend, "athena")

--- a/moto/athena/responses.py
+++ b/moto/athena/responses.py
@@ -201,16 +201,17 @@ class AthenaResponse(BaseResponse):
     def tag_resource(self) -> str:
         """Handler for tag_resource API call."""
         resource_arn = self._get_param("ResourceARN")
-        tags = self._get_param("Tags")
-        response = self.athena_backend.tag_resource(resource_arn, tags)
-        return json.dumps(response)
+        tags = self._get_param("Tags", [])
+        tags = {tag["Key"]: tag["Value"] for tag in tags}
+        self.athena_backend.tag_resource(resource_arn, tags)
+        return json.dumps({})
 
     def untag_resource(self) -> str:
         """Handler for untag_resource API call."""
         resource_arn = self._get_param("ResourceARN")
-        tag_keys = self._get_param("TagKeys")
-        response = self.athena_backend.untag_resource(resource_arn, tag_keys)
-        return json.dumps(response)
+        tag_keys = self._get_param("TagKeys", [])
+        self.athena_backend.untag_resource(resource_arn, tag_keys)
+        return json.dumps({})
 
     def get_data_catalog(self) -> str:
         name = self._get_param("Name")

--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -1980,7 +1980,7 @@ class AutoScalingBackend(BaseBackend, TaggableResourcesMixin):
         group = self.describe_auto_scaling_groups([group_name])[0]
         group.warm_pool = None
 
-    # Resource Groups Tagging API
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
     def iter_tagged_resources(self) -> Iterator[TaggedResource]:
         # From the AWS documentation as of 2026-05-24:
         # The TagResources and UntagResources operations of AWS Resource Groups Tagging API work as

--- a/moto/awslambda/models.py
+++ b/moto/awslambda/models.py
@@ -2654,7 +2654,7 @@ class LambdaBackend(BaseBackend, TaggableResourcesMixin):
         layer_version = self.get_layer_version(layer_name, str(version_number))
         layer_version.policy.del_statement(sid, revision)
 
-    # Resource Groups Tagging API
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
     def iter_tagged_resources(self) -> Iterator[TaggedResource]:
         for fn in self.list_functions():
             yield TaggedResource(

--- a/moto/backup/models.py
+++ b/moto/backup/models.py
@@ -1,8 +1,10 @@
+from collections.abc import Iterator
 from copy import deepcopy
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
@@ -144,8 +146,10 @@ class Vault(BaseModel):
         return dct
 
 
-class BackupBackend(BaseBackend):
+class BackupBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of Backup APIs."""
+
+    SERVICE_NAMESPACE = "backup"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -328,13 +332,6 @@ class BackupBackend(BaseBackend):
         """
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
-        tags_input = TaggingService.convert_dict_to_tags_input(tags or {})
-        self.tagger.tag_resource(resource_arn, tags_input)
-
-    def untag_resource(self, resource_arn: str, tag_key_list: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_key_list)
-
     def create_report_plan(
         self,
         report_plan_name: str,
@@ -370,6 +367,22 @@ class BackupBackend(BaseBackend):
         Pagination is not yet implemented
         """
         return list(self.report_plans.values())
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for vault in self.vaults.values():
+            yield TaggedResource(
+                arn=vault.backup_vault_arn,
+                tags=self.tagger.get_tag_dict_for_resource(vault.backup_vault_arn),
+                resource_type="backup:backup-vault",
+            )
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
+        tags_input = TaggingService.convert_dict_to_tags_input(tags or {})
+        self.tagger.tag_resource(resource_arn, tags_input)
+
+    def untag_resource(self, resource_arn: str, tag_key_list: list[str]) -> None:
+        self.tagger.untag_resource_using_names(resource_arn, tag_key_list)
 
 
 backup_backends = BackendDict(BackupBackend, "backup")

--- a/moto/clouddirectory/models.py
+++ b/moto/clouddirectory/models.py
@@ -1,9 +1,11 @@
 """CloudDirectoryBackend class with methods for supported APIs."""
 
 import datetime
+from collections.abc import Iterator
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
 
@@ -59,8 +61,10 @@ class Directory(BaseModel):
         }
 
 
-class CloudDirectoryBackend(BaseBackend):
+class CloudDirectoryBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of CloudDirectory APIs."""
+
+    SERVICE_NAMESPACE = "clouddirectory"
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
@@ -130,16 +134,6 @@ class CloudDirectoryBackend(BaseBackend):
             ]
         return directories
 
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(resource_arn, tags)
-        return
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        if not isinstance(tag_keys, list):
-            tag_keys = [tag_keys]
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
-        return
-
     def delete_directory(self, directory_arn: str) -> str:
         directory = self.directories.pop(directory_arn)
         return directory.directory_arn
@@ -155,6 +149,21 @@ class CloudDirectoryBackend(BaseBackend):
     ) -> list[dict[str, str]]:
         tags = self.tagger.list_tags_for_resource(resource_arn)["Tags"]
         return tags
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for directory in self.directories.values():
+            yield TaggedResource(
+                arn=directory.directory_arn,
+                tags=self.tagger.get_tag_dict_for_resource(directory.directory_arn),
+                resource_type="clouddirectory:directory",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 clouddirectory_backends = BackendDict(CloudDirectoryBackend, "clouddirectory")

--- a/moto/clouddirectory/responses.py
+++ b/moto/clouddirectory/responses.py
@@ -81,20 +81,15 @@ class CloudDirectoryResponse(BaseResponse):
 
     def tag_resource(self) -> str:
         resource_arn = self._get_param("ResourceArn")
-        tags = self._get_param("Tags")
-        self.clouddirectory_backend.tag_resource(
-            resource_arn=resource_arn,
-            tags=tags,
-        )
+        tags = self._get_param("Tags", [])
+        tags = {tag["Key"]: tag["Value"] for tag in tags}
+        self.clouddirectory_backend.tag_resource(resource_arn, tags)
         return json.dumps({})
 
     def untag_resource(self) -> str:
         resource_arn = self._get_param("ResourceArn")
-        tag_keys = self._get_param("TagKeys")
-        self.clouddirectory_backend.untag_resource(
-            resource_arn=resource_arn,
-            tag_keys=tag_keys,
-        )
+        tag_keys = self._get_param("TagKeys", [])
+        self.clouddirectory_backend.untag_resource(resource_arn, tag_keys)
         return json.dumps({})
 
     def delete_directory(self) -> str:

--- a/moto/cloudformation/models.py
+++ b/moto/cloudformation/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import timedelta
 from typing import Any
 
@@ -12,6 +12,7 @@ from yaml.scanner import ScannerError
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import iso_8601_datetime_with_milliseconds, utcnow
 from moto.moto_api._internal import mock_random
 from moto.organizations.models import OrganizationsBackend, organizations_backends
@@ -796,12 +797,14 @@ def filter_stacks(
     return filtered_stacks
 
 
-class CloudFormationBackend(BaseBackend):
+class CloudFormationBackend(BaseBackend, TaggableResourcesMixin):
     """
     CustomResources are supported when running Moto in ServerMode.
     Because creating these resources involves running a Lambda-function that informs the MotoServer about the status of the resources, the MotoServer has to be reachable for outside connections.
     This means it has to run inside a Docker-container, or be started using `moto_server -h 0.0.0.0`.
     """
+
+    SERVICE_NAMESPACE = "cloudformation"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -1320,6 +1323,15 @@ class CloudFormationBackend(BaseBackend):
             raise ValidationError(
                 stack.stack_id,
                 message="Export names must be unique across a given region",
+            )
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for stack in self.stacks.values():
+            yield TaggedResource(
+                arn=stack.stack_id,
+                tags=dict(stack.tags or {}),
+                resource_type="cloudformation:stack",
             )
 
 

--- a/moto/cloudfront/models.py
+++ b/moto/cloudfront/models.py
@@ -1,8 +1,10 @@
 import string
+from collections.abc import Iterator
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random as random
 from moto.moto_api._internal.managed_state_model import ManagedState
@@ -350,7 +352,9 @@ class KeyGroup(BaseModel):
         }
 
 
-class CloudFrontBackend(BaseBackend):
+class CloudFrontBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "cloudfront"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.distributions: dict[str, Distribution] = {}
@@ -481,12 +485,6 @@ class CloudFrontBackend(BaseBackend):
     def list_tags_for_resource(self, resource: str) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(resource)
 
-    def tag_resource(self, resource: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(resource, tags)
-
-    def untag_resource(self, resource: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource, tag_keys)
-
     def create_origin_access_control(
         self, config_dict: dict[str, str]
     ) -> OriginAccessControl:
@@ -556,6 +554,21 @@ class CloudFrontBackend(BaseBackend):
         Pagination is not yet implemented
         """
         return list(self.key_groups.values())
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for dist in self.distributions.values():
+            yield TaggedResource(
+                arn=dist.arn,
+                tags=self.tagger.get_tag_dict_for_resource(dist.arn),
+                resource_type="cloudfront:distribution",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 cloudfront_backends = BackendDict(

--- a/moto/cloudfront/responses.py
+++ b/moto/cloudfront/responses.py
@@ -123,14 +123,15 @@ class CloudFrontResponse(BaseResponse):
 
     def tag_resource(self) -> ActionResult:
         resource = self._get_param("Resource")
-        tags = self._get_param("Tags.Items", [])
-        self.backend.tag_resource(resource=resource, tags=tags)
+        tags = self._get_param("Tags.Items", []) or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
+        self.backend.tag_resource(resource, tags)
         return EmptyResult()
 
     def untag_resource(self) -> ActionResult:
         resource = self._get_param("Resource")
-        tag_keys_data = self._get_param("TagKeys.Items", [])
-        self.backend.untag_resource(resource=resource, tag_keys=tag_keys_data)
+        tag_keys_data = self._get_param("TagKeys.Items", []) or []
+        self.backend.untag_resource(resource, tag_keys_data)
         return EmptyResult()
 
     def create_origin_access_control(self) -> ActionResult:

--- a/moto/cloudwatch/models.py
+++ b/moto/cloudwatch/models.py
@@ -1,6 +1,6 @@
 import json
 import math
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 from typing import Any, SupportsFloat
 from uuid import uuid4
@@ -12,6 +12,7 @@ from moto.core.common_models import (
     CloudFormationModel,
     CloudWatchMetricProvider,
 )
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random
 
@@ -504,7 +505,9 @@ class InsightRule(BaseModel):
         self.rule_arn = make_arn_for_rule(region_name, account_id, name)
 
 
-class CloudWatchBackend(BaseBackend):
+class CloudWatchBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "cloudwatch"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.alarms: dict[str, Alarm] = {}
@@ -1011,21 +1014,6 @@ class CloudWatchBackend(BaseBackend):
     def list_tags_for_resource(self, arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(arn)
 
-    def tag_resource(self, arn: str, tags: list[dict[str, str]]) -> None:
-        # From boto3:
-        # Currently, the only CloudWatch resources that can be tagged are alarms and Contributor Insights rules.
-        all_arns = [alarm.alarm_arn for alarm in self.describe_alarms()]
-        if arn not in all_arns:
-            raise ResourceNotFoundException
-
-        self.tagger.tag_resource(arn, tags)
-
-    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
-        if arn not in self.tagger.tags.keys():
-            raise ResourceNotFoundException
-
-        self.tagger.untag_resource_using_names(arn, tag_keys)
-
     def _get_paginated(
         self, metrics: list[MetricDatumBase]
     ) -> tuple[str | None, list[MetricDatumBase]]:
@@ -1175,6 +1163,39 @@ class CloudWatchBackend(BaseBackend):
                     self.insight_rules[rule_name].state = "ENABLED"
 
         return failures
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        partition = self.partition
+        for alarm in self.alarms.values():
+            arn = f"arn:{partition}:cloudwatch:{self.region_name}:{self.account_id}:alarm:{alarm.name}"
+            yield TaggedResource(
+                arn=arn,
+                tags=self.tagger.get_tag_dict_for_resource(arn),
+                resource_type="cloudwatch:alarm",
+            )
+        for rule in self.insight_rules.values():
+            arn = f"arn:{partition}:cloudwatch:{self.region_name}:{self.account_id}:insight-rule/{rule.name}"
+            yield TaggedResource(
+                arn=arn,
+                tags=self.tagger.get_tag_dict_for_resource(arn),
+                resource_type="cloudwatch:insight-rule",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        # From boto3:
+        # Currently, the only CloudWatch resources that can be tagged are alarms and Contributor Insights rules.
+        all_arns = [alarm.alarm_arn for alarm in self.describe_alarms()]
+        if arn not in all_arns:
+            raise ResourceNotFoundException
+
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        if arn not in self.tagger.tags.keys():
+            raise ResourceNotFoundException
+
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 cloudwatch_backends = BackendDict(CloudWatchBackend, "cloudwatch")

--- a/moto/cloudwatch/responses.py
+++ b/moto/cloudwatch/responses.py
@@ -301,6 +301,7 @@ class CloudWatchResponse(BaseResponse):
     def tag_resource(self) -> ActionResult:
         resource_arn = self._get_param("ResourceARN")
         tags = self._get_param("Tags", [])
+        tags = {tag["Key"]: tag["Value"] for tag in tags}
         self.cloudwatch_backend.tag_resource(resource_arn, tags)
         return EmptyResult()
 

--- a/moto/comprehend/models.py
+++ b/moto/comprehend/models.py
@@ -2,12 +2,13 @@
 
 import random
 import uuid
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timezone
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
 
@@ -288,8 +289,15 @@ class ComprehendJob(BaseModel):
             self.job_status = "STOP_REQUESTED"
 
 
-class ComprehendBackend(BaseBackend):
+def _comprehend_job_resource_type(job_type: str) -> str:
+    job_type_path = "".join(f"-{c.lower()}" if c.isupper() else c for c in job_type)
+    return f"comprehend:{job_type_path.lstrip('-')}-job"
+
+
+class ComprehendBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of Comprehend APIs."""
+
+    SERVICE_NAMESPACE = "comprehend"
 
     # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/comprehend/client/detect_key_phrases.html
     detect_key_phrases_languages = [
@@ -384,12 +392,6 @@ class ComprehendBackend(BaseBackend):
 
     def delete_entity_recognizer(self, entity_recognizer_arn: str) -> None:
         self.recognizers.pop(entity_recognizer_arn, None)
-
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(resource_arn, tags)
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def detect_pii_entities(self, text: str, language: str) -> list[dict[str, Any]]:
         if language not in self.detect_pii_entities_languages:
@@ -865,6 +867,49 @@ class ComprehendBackend(BaseBackend):
         self, filter: dict[str, Any] | None
     ) -> list[ComprehendJob]:
         return self._list_jobs("TargetedSentimentDetection", filter)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for classifier in self.classifiers.values():
+            yield TaggedResource(
+                arn=classifier.arn,
+                tags=self.tagger.get_tag_dict_for_resource(classifier.arn),
+                resource_type="comprehend:document-classifier",
+            )
+        for endpoint in self.endpoints.values():
+            yield TaggedResource(
+                arn=endpoint.arn,
+                tags=self.tagger.get_tag_dict_for_resource(endpoint.arn),
+                resource_type="comprehend:endpoint",
+            )
+        for recognizer in self.recognizers.values():
+            yield TaggedResource(
+                arn=recognizer.arn,
+                tags=self.tagger.get_tag_dict_for_resource(recognizer.arn),
+                resource_type="comprehend:entity-recognizer",
+            )
+        for flywheel in self.flywheels.values():
+            yield TaggedResource(
+                arn=flywheel.arn,
+                tags=self.tagger.get_tag_dict_for_resource(flywheel.arn),
+                resource_type="comprehend:flywheel",
+            )
+        for job in self.jobs.values():
+            arn = getattr(job, "job_arn", None)
+            job_type = getattr(job, "job_type", None)
+            if not arn or not job_type:
+                continue
+            yield TaggedResource(
+                arn=arn,
+                tags=self.tagger.get_tag_dict_for_resource(arn),
+                resource_type=_comprehend_job_resource_type(job_type),
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 comprehend_backends = BackendDict(ComprehendBackend, "comprehend")

--- a/moto/comprehend/responses.py
+++ b/moto/comprehend/responses.py
@@ -88,14 +88,15 @@ class ComprehendResponse(BaseResponse):
     def tag_resource(self) -> str:
         params = json.loads(self.body)
         resource_arn = params.get("ResourceArn")
-        tags = params.get("Tags")
+        tags = params.get("Tags") or []
+        tags = {tag["Key"]: tag["Value"] for tag in tags}
         self.comprehend_backend.tag_resource(resource_arn, tags)
         return "{}"
 
     def untag_resource(self) -> str:
         params = json.loads(self.body)
         resource_arn = params.get("ResourceArn")
-        tag_keys = params.get("TagKeys")
+        tag_keys = params.get("TagKeys") or []
         self.comprehend_backend.untag_resource(resource_arn, tag_keys)
         return "{}"
 

--- a/moto/connectcampaigns/models.py
+++ b/moto/connectcampaigns/models.py
@@ -1,12 +1,14 @@
 """ConnectCampaignServiceBackend class with methods for supported APIs."""
 
 import uuid
+from collections.abc import Iterator
 from typing import Any
 from urllib.parse import unquote
 
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
 
@@ -101,7 +103,9 @@ class ConnectInstanceOnboardingJobStatus(BaseModel):
         return result
 
 
-class ConnectCampaignServiceBackend(BaseBackend):
+class ConnectCampaignServiceBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "connect-campaigns"
+
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
         self.campaigns: dict[str, ConnectCampaign] = {}
@@ -268,6 +272,28 @@ class ConnectCampaignServiceBackend(BaseBackend):
         ]
         return campaign_summary_list
 
+    def list_tags_for_resource(self, arn: str) -> dict[str, str]:
+        arn = unquote(arn)
+        campaign = None
+        for c in self.campaigns.values():
+            if c.arn == arn:
+                campaign = c
+                break
+
+        if campaign is None:
+            raise ResourceNotFoundException(f"Resource {arn} not found")
+
+        return self.tagger.get_tag_dict_for_resource(arn)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for campaign in self.campaigns.values():
+            yield TaggedResource(
+                arn=campaign.arn,
+                tags=self.tagger.get_tag_dict_for_resource(campaign.arn),
+                resource_type="connect-campaigns:campaign",
+            )
+
     def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
         arn = unquote(arn)
         campaign = None
@@ -304,19 +330,6 @@ class ConnectCampaignServiceBackend(BaseBackend):
             campaign.tags.pop(tag, None)
         self.tagger.untag_resource_using_names(arn, tag_keys)
         return
-
-    def list_tags_for_resource(self, arn: str) -> dict[str, str]:
-        arn = unquote(arn)
-        campaign = None
-        for c in self.campaigns.values():
-            if c.arn == arn:
-                campaign = c
-                break
-
-        if campaign is None:
-            raise ResourceNotFoundException(f"Resource {arn} not found")
-
-        return self.tagger.get_tag_dict_for_resource(arn)
 
 
 connectcampaigns_backends = BackendDict(

--- a/moto/directconnect/models.py
+++ b/moto/directconnect/models.py
@@ -1,11 +1,13 @@
 """DirectConnectBackend class with methods for supported APIs."""
 
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.tagging_service import TaggingService
 
 from .enums import (
@@ -152,8 +154,10 @@ class LAG(BaseModel):
         }
 
 
-class DirectConnectBackend(BaseBackend):
+class DirectConnectBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of DirectConnect APIs."""
+
+    SERVICE_NAMESPACE = "directconnect"
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
@@ -216,15 +220,9 @@ class DirectConnectBackend(BaseBackend):
             backend=self,
         )
         if tags:
-            self.tag_resource(connection.connection_id, tags)
+            self.tagger.tag_resource(connection.connection_id, tags)
         self.connections[connection.connection_id] = connection
         return connection
-
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(
-            resource_arn,
-            tags=tags if tags else [],
-        )
 
     def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         tags = self.tagger.get_tag_dict_for_resource(resource_arn)
@@ -243,9 +241,6 @@ class DirectConnectBackend(BaseBackend):
             )
 
         return response
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def delete_connection(self, connection_id: str) -> Connection:
         if not connection_id:
@@ -389,7 +384,7 @@ class DirectConnectBackend(BaseBackend):
             lag.connections.append(connection)
 
         if tags:
-            self.tag_resource(lag.lag_id, tags)
+            self.tagger.tag_resource(lag.lag_id, tags)
         self.lags[lag.lag_id] = lag
         return lag
 
@@ -420,6 +415,27 @@ class DirectConnectBackend(BaseBackend):
                 return connection_id, mac_sec_keys.pop(i)
 
         raise MacSecKeyNotFound(secret_arn=secret_arn, connection_id=connection_id)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for connection in self.connections.values():
+            yield TaggedResource(
+                arn=connection.connection_id,
+                tags=self.tagger.get_tag_dict_for_resource(connection.connection_id),
+                resource_type="directconnect:dxcon",
+            )
+        for lag in self.lags.values():
+            yield TaggedResource(
+                arn=lag.lag_id,
+                tags=self.tagger.get_tag_dict_for_resource(lag.lag_id),
+                resource_type="directconnect:dxlag",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, [{"key": k, "value": v} for k, v in tags.items()])
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 directconnect_backends = BackendDict(DirectConnectBackend, "directconnect")

--- a/moto/directconnect/responses.py
+++ b/moto/directconnect/responses.py
@@ -125,17 +125,16 @@ class DirectConnectResponse(BaseResponse):
     def tag_resource(self) -> str:
         params = json.loads(self.body)
         resource_arn = params.get("resourceArn")
-        tags = params.get("tags")
-        self.directconnect_backend.tag_resource(resource_arn=resource_arn, tags=tags)
+        tags = params.get("tags") or []
+        tags = {tag["key"]: tag.get("value") for tag in tags}
+        self.directconnect_backend.tag_resource(resource_arn, tags)
         return json.dumps({})
 
     def untag_resource(self) -> str:
         params = json.loads(self.body)
         resource_arn = params.get("resourceArn")
         tag_keys = params.get("tagKeys", [])
-        self.directconnect_backend.untag_resource(
-            resource_arn=resource_arn, tag_keys=tag_keys
-        )
+        self.directconnect_backend.untag_resource(resource_arn, tag_keys)
         return json.dumps({})
 
     def describe_tags(self) -> str:

--- a/moto/dms/models.py
+++ b/moto/dms/models.py
@@ -1,9 +1,10 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.moto_api._internal.managed_state_model import ManagedState
 from moto.utilities.tagging_service import TaggingService
@@ -18,7 +19,9 @@ from .exceptions import (
 from .utils import filter_tasks, random_id
 
 
-class DatabaseMigrationServiceBackend(BaseBackend):
+class DatabaseMigrationServiceBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "dms"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.replication_tasks: dict[str, FakeReplicationTask] = {}
@@ -506,6 +509,36 @@ class DatabaseMigrationServiceBackend(BaseBackend):
         for connection in connections:
             connection.advance()
         return connections
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for endpoint in self.endpoints.values():
+            yield TaggedResource(
+                arn=endpoint.endpoint_arn,
+                tags=self.tagger.get_tag_dict_for_resource(endpoint.endpoint_arn),
+                resource_type="dms:endpoint",
+                extra={"include_untagged": True},
+            )
+        for replication_instance in self.replication_instances.values():
+            yield TaggedResource(
+                arn=replication_instance.arn,
+                tags=self.tagger.get_tag_dict_for_resource(replication_instance.arn),
+                resource_type="dms:replication-instance",
+                extra={"include_untagged": True},
+            )
+        for replication_task in self.replication_tasks.values():
+            yield TaggedResource(
+                arn=replication_task.arn,
+                tags=self.tagger.get_tag_dict_for_resource(replication_task.arn),
+                resource_type="dms:task",
+                extra={"include_untagged": True},
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, [{"Key": k, "Value": v} for k, v in tags.items()])
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 class Endpoint(BaseModel):

--- a/moto/dynamodb/models/__init__.py
+++ b/moto/dynamodb/models/__init__.py
@@ -1,10 +1,12 @@
 import copy
 import re
 from collections import OrderedDict
+from collections.abc import Iterator
 from typing import Any, Optional
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.exceptions import JsonRESTError
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import unix_time
 from moto.dynamodb.comparisons import (
     create_condition_expression_parser,
@@ -48,7 +50,9 @@ from moto.dynamodb.parsing.expressions import UpdateExpressionParser  # type: ig
 from moto.dynamodb.parsing.validators import UpdateExpressionValidator
 
 
-class DynamoDBBackend(BaseBackend):
+class DynamoDBBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "dynamodb"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.tables: dict[str, Table] = OrderedDict()
@@ -122,18 +126,6 @@ class DynamoDBBackend(BaseBackend):
                 "CachePeriodInMinutes": 1440,
             }
         ]
-
-    def tag_resource(self, table_arn: str, tags: list[dict[str, str]]) -> None:
-        for table in self.tables:
-            if self.tables[table].table_arn == table_arn:
-                self.tables[table].tags.extend(tags)
-
-    def untag_resource(self, table_arn: str, tag_keys: list[str]) -> None:
-        for table in self.tables:
-            if self.tables[table].table_arn == table_arn:
-                self.tables[table].tags = [
-                    tag for tag in self.tables[table].tags if tag["Key"] not in tag_keys
-                ]
 
     def list_tags_of_resource(self, table_arn: str) -> list[dict[str, str]]:
         for table in self.tables:
@@ -1106,6 +1098,28 @@ class DynamoDBBackend(BaseBackend):
                 f"Resource-based policy not found for the provided ResourceArn: Requested update for policy with revision id {expected_revision_id}, but the policy associated to target table {table_name} has revision id {policy.revision_id}."
             )
         self.resource_policies.pop(resource_arn)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for table in self.tables.values():
+            yield TaggedResource(
+                arn=table.table_arn,
+                tags={t["Key"]: t["Value"] for t in (table.tags or [])},
+                resource_type="dynamodb:table",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        new_tags = [{"Key": k, "Value": v} for k, v in tags.items()]
+        for table in self.tables:
+            if self.tables[table].table_arn == arn:
+                self.tables[table].tags.extend(new_tags)
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        for table in self.tables:
+            if self.tables[table].table_arn == arn:
+                self.tables[table].tags = [
+                    tag for tag in self.tables[table].tags if tag["Key"] not in tag_keys
+                ]
 
 
 dynamodb_backends = BackendDict(DynamoDBBackend, "dynamodb")

--- a/moto/dynamodb/responses.py
+++ b/moto/dynamodb/responses.py
@@ -548,14 +548,15 @@ class DynamoHandler(BaseResponse):
 
     def tag_resource(self) -> ActionResult:
         table_arn = self.body["ResourceArn"]
-        tags = self.body["Tags"]
+        tags = self.body.get("Tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
         self.dynamodb_backend.tag_resource(table_arn, tags)
         return EmptyResult()
 
     def untag_resource(self) -> ActionResult:
         table_arn = self.body["ResourceArn"]
-        tags = self.body["TagKeys"]
-        self.dynamodb_backend.untag_resource(table_arn, tags)
+        tag_keys = self.body.get("TagKeys") or []
+        self.dynamodb_backend.untag_resource(table_arn, tag_keys)
         return EmptyResult()
 
     def list_tags_of_resource(self) -> ActionResult:

--- a/moto/ec2/models/__init__.py
+++ b/moto/ec2/models/__init__.py
@@ -225,7 +225,7 @@ class EC2Backend(
                 )
         return True
 
-    # Resource Groups Tagging API
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
     def iter_tagged_resources(self) -> Iterator[TaggedResource]:
         resource_collections: dict[str, Any] = {
             "ec2:customer-gateway": self.customer_gateways.values(),

--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -6,6 +6,7 @@ from typing import Any
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import pascal_to_camelcase, remap_nested_keys, utcnow
 from moto.ec2 import ec2_backends
 from moto.moto_api._internal import mock_random
@@ -888,7 +889,7 @@ class TaskSet(BaseModel):
         self.task_set_arn = f"arn:{get_partition(region_name)}:ecs:{region_name}:{account_id}:task-set/{cluster_name}/{service_name}/{self.id}"
 
 
-class EC2ContainerServiceBackend(BaseBackend):
+class EC2ContainerServiceBackend(BaseBackend, TaggableResourcesMixin):
     """
     ECS resources use the new ARN format by default.
     Use the following environment variable to revert back to the old/short ARN format:
@@ -905,6 +906,8 @@ class EC2ContainerServiceBackend(BaseBackend):
     Set the environment variable MOTO_ECS_SERVICE_FAILED_TASKS to configure the number of failed tasks
     returned in deployments. Defaults to 0.
     """
+
+    SERVICE_NAMESPACE = "ecs"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -2109,11 +2112,6 @@ class EC2ContainerServiceBackend(BaseBackend):
         if definitions:
             return max(definitions.keys())
 
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        parsed_arn = self._parse_resource_arn(resource_arn)
-        resource = self._get_resource(resource_arn, parsed_arn)
-        resource.tags = self._merge_tags(resource.tags or [], tags)
-
     def _merge_tags(
         self, existing_tags: list[dict[str, str]], new_tags: list[dict[str, str]]
     ) -> list[dict[str, str]]:
@@ -2127,11 +2125,6 @@ class EC2ContainerServiceBackend(BaseBackend):
     @staticmethod
     def _get_keys(tags: list[dict[str, str]]) -> list[str]:
         return [tag["key"] for tag in tags]
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        parsed_arn = self._parse_resource_arn(resource_arn)
-        resource = self._get_resource(resource_arn, parsed_arn)
-        resource.tags = [tag for tag in resource.tags if tag["key"] not in tag_keys]
 
     def create_task_set(
         self,
@@ -2389,6 +2382,47 @@ class EC2ContainerServiceBackend(BaseBackend):
             deleted_task_definitions.append(resolved_task_def)
 
         return deleted_task_definitions, failures
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for service in self.services.values():
+            yield TaggedResource(
+                arn=service.physical_resource_id,
+                tags={t["key"]: t["value"] for t in (service.tags or [])},
+                resource_type="ecs:service",
+            )
+        for cluster in self.clusters.values():
+            yield TaggedResource(
+                arn=cluster.arn,
+                tags={t["key"]: t["value"] for t in (cluster.tags or [])},
+                resource_type="ecs:cluster",
+            )
+        for task_dict in self.tasks.values():
+            for task in task_dict.values():
+                yield TaggedResource(
+                    arn=task.task_arn,
+                    tags={t["key"]: t["value"] for t in (task.tags or [])},
+                    resource_type="ecs:task",
+                )
+        for task_definition_dict in self.task_definitions.values():
+            for task_definition in task_definition_dict.values():
+                yield TaggedResource(
+                    arn=task_definition.arn,
+                    tags={t["key"]: t["value"] for t in (task_definition.tags or [])},
+                    resource_type="ecs:task-definition",
+                )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        parsed_arn = self._parse_resource_arn(arn)
+        resource = self._get_resource(arn, parsed_arn)
+        new_tags = [{"key": k, "value": v} for k, v in tags.items()]
+        resource.tags = self._merge_tags(resource.tags or [], new_tags)
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        parsed_arn = self._parse_resource_arn(resource_arn)
+        resource = self._get_resource(resource_arn, parsed_arn)
+        if resource.tags:
+            resource.tags = [tag for tag in resource.tags if tag["key"] not in tag_keys]
 
 
 ecs_backends = BackendDict(EC2ContainerServiceBackend, "ecs")

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -470,7 +470,8 @@ class EC2ContainerServiceResponse(BaseResponse):
 
     def tag_resource(self) -> ActionResult:
         resource_arn = self._get_param("resourceArn")
-        tags = self._get_param("tags")
+        tags = self._get_param("tags") or []
+        tags = {tag["key"]: tag.get("value") for tag in tags}
         self.ecs_backend.tag_resource(resource_arn, tags)
         return EmptyResult()
 

--- a/moto/efs/models.py
+++ b/moto/efs/models.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import camelcase_to_underscores, underscores_to_camelcase
 from moto.ec2 import ec2_backends
 from moto.ec2.exceptions import InvalidSubnetIdError
@@ -413,13 +414,15 @@ class MountTarget(CloudFormationModel):
         efs_backends[account_id][region_name].delete_mount_target(resource_name)
 
 
-class EFSBackend(BaseBackend):
+class EFSBackend(BaseBackend, TaggableResourcesMixin):
     """The backend manager of EFS resources.
 
     This is the state-machine for each region, tracking the file systems, mount targets,
     and eventually access points that are deployed. Creating, updating, and destroying
     such resources should always go through this class.
     """
+
+    SERVICE_NAMESPACE = "elasticfilesystem"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -489,7 +492,7 @@ class EFSBackend(BaseBackend):
             availability_zone_name=availability_zone_name,
             backup=backup,
         )
-        self.tag_resource(fsid, tags)
+        self.tagging_service.tag_resource(fsid, tags)
         self.creation_tokens.add(creation_token)
         return self.file_systems_by_id[fsid]
 
@@ -749,12 +752,6 @@ class EFSBackend(BaseBackend):
     def list_tags_for_resource(self, resource_id: str) -> list[dict[str, str]]:
         return self.tagging_service.list_tags_for_resource(resource_id)["Tags"]
 
-    def tag_resource(self, resource_id: str, tags: list[dict[str, str]]) -> None:
-        self.tagging_service.tag_resource(resource_id, tags)
-
-    def untag_resource(self, resource_id: str, tag_keys: list[str]) -> None:
-        self.tagging_service.untag_resource_using_names(resource_id, tag_keys)
-
     def describe_file_system_policy(self, file_system_id: str) -> str:
         policy = self.file_systems_by_id[file_system_id].file_system_policy
         if not policy:
@@ -766,6 +763,31 @@ class EFSBackend(BaseBackend):
     ) -> None:
         file_system = self.file_systems_by_id[file_system_id]
         file_system.file_system_policy = policy
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for ap in self.access_points.values():
+            yield TaggedResource(
+                arn=ap.access_point_arn,
+                tags=self.tagging_service.get_tag_dict_for_resource(ap.access_point_id),
+                resource_type="elasticfilesystem:access-point",
+            )
+        for fs in self.file_systems_by_id.values():
+            yield TaggedResource(
+                arn=fs.file_system_arn,
+                tags=self.tagging_service.get_tag_dict_for_resource(fs.file_system_id),
+                resource_type="elasticfilesystem:file-system",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        resource_id = arn.rsplit("/", 1)[-1]
+        self.tagging_service.tag_resource(
+            resource_id, self.tagging_service.convert_dict_to_tags_input(tags)
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        resource_id = arn.rsplit("/", 1)[-1]
+        self.tagging_service.untag_resource_using_names(resource_id, tag_keys)
 
 
 efs_backends = BackendDict(EFSBackend, "efs")

--- a/moto/efs/responses.py
+++ b/moto/efs/responses.py
@@ -188,7 +188,8 @@ class EFSResponse(BaseResponse):
 
     def tag_resource(self) -> TYPE_RESPONSE:
         resource_id = self._get_param("ResourceId")
-        tags = self._get_param("Tags")
+        tags = self._get_param("Tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
         self.efs_backend.tag_resource(resource_id, tags)
         return "{}", {"Content-Type": "application/json"}
 

--- a/moto/elasticache/models.py
+++ b/moto/elasticache/models.py
@@ -1,11 +1,13 @@
 import copy
 import random
 import string
+from collections.abc import Iterator
 from re import compile as re_compile
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
@@ -642,8 +644,10 @@ class Snapshot(BaseModel):
         self.vpc_id = vpc_id
 
 
-class ElastiCacheBackend(BaseBackend):
+class ElastiCacheBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of ElastiCache APIs."""
+
+    SERVICE_NAMESPACE = "elasticache"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -1180,6 +1184,34 @@ class ElastiCacheBackend(BaseBackend):
 
             return snapshot
         raise SnapshotNotFound(snapshot_name)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        sources: dict[str, dict[str, Any]] = {
+            "elasticache:cache_clusters": self.cache_clusters,
+            "elasticache:cache_subnet_groups": self.cache_subnet_groups,
+            "elasticache:replication-group": self.replication_groups,
+            "elasticache:snapshots": self.snapshots,
+            "elasticache:users": self.users,
+        }
+        for resource_type, items in sources.items():
+            for resource in items.values():
+                if resource_type == "elasticache:users" and resource.id == "default":
+                    continue
+                yield TaggedResource(
+                    arn=resource.arn,
+                    tags=self.tagging_service.get_tag_dict_for_resource(resource.arn),
+                    resource_type=resource_type,
+                    extra={"include_untagged": True},
+                )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagging_service.tag_resource(
+            arn, [{"Key": k, "Value": v} for k, v in tags.items()]
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagging_service.untag_resource_using_names(arn, tag_keys)
 
 
 elasticache_backends = BackendDict(ElastiCacheBackend, "elasticache")

--- a/moto/elasticbeanstalk/models.py
+++ b/moto/elasticbeanstalk/models.py
@@ -1,7 +1,9 @@
 import weakref
+from collections.abc import Iterator
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 
 from ..core.utils import utcnow
 from .exceptions import (
@@ -96,7 +98,9 @@ class Application(BaseModel):
         return env
 
 
-class EBBackend(BaseBackend):
+class EBBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "elasticbeanstalk"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.applications: dict[str, Application] = {}
@@ -170,6 +174,17 @@ class EBBackend(BaseBackend):
     ) -> None:
         if application_name in self.applications:
             self.applications.pop(application_name)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for app in self.applications.values():
+            for env in app.environments.values():
+                yield TaggedResource(
+                    arn=env.environment_arn,
+                    tags=dict(env.tags or {}),
+                    resource_type="elasticbeanstalk:environment",
+                    extra={"include_untagged": True},
+                )
 
 
 eb_backends = BackendDict(EBBackend, "elasticbeanstalk")

--- a/moto/elb/models.py
+++ b/moto/elb/models.py
@@ -1,11 +1,12 @@
 import datetime
 import re
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.ec2.exceptions import InvalidInstanceIdError
 from moto.ec2.models import ec2_backends
 from moto.moto_api._internal import mock_random
@@ -324,7 +325,9 @@ class LoadBalancer(CloudFormationModel):
         elb_backends[account_id][region].delete_load_balancer(self.name)
 
 
-class ELBBackend(BaseBackend):
+class ELBBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "elasticloadbalancing"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.load_balancers: dict[str, LoadBalancer] = OrderedDict()
@@ -710,6 +713,16 @@ class ELBBackend(BaseBackend):
         load_balancer = self.get_load_balancer(load_balancer_name)
         load_balancer.subnets = [s for s in load_balancer.subnets if s not in subnets]
         return load_balancer.subnets
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for elb in self.load_balancers.values():
+            arn = f"arn:aws:elasticloadbalancing:{self.region_name}:{self.account_id}:loadbalancer/{elb.name}"
+            yield TaggedResource(
+                arn=arn,
+                tags=dict(elb.tags or {}),
+                resource_type="elb:loadbalancer",
+            )
 
 
 def register_certificate(

--- a/moto/elbv2/models.py
+++ b/moto/elbv2/models.py
@@ -1,12 +1,13 @@
 import re
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from typing import Any
 
 from botocore.exceptions import ParamValidationError
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.ec2.models import EC2Backend, ec2_backends
 from moto.ec2.models.subnets import Subnet
@@ -718,7 +719,9 @@ class FakeLoadBalancer(CloudFormationModel):
             raise UnformattedGetAttTemplateException()
 
 
-class ELBv2Backend(BaseBackend):
+class ELBv2Backend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "elasticloadbalancing"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.target_groups: dict[str, FakeTargetGroup] = OrderedDict()
@@ -2038,6 +2041,22 @@ Member must satisfy regular expression pattern: {expression}"
         else:
             raise LoadBalancerNotFoundError()
         return resource
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for lb in self.load_balancers.values():
+            yield TaggedResource(
+                arn=lb.arn,
+                tags=self.tagging_service.get_tag_dict_for_resource(lb.arn),
+                resource_type="elasticloadbalancing:loadbalancer",
+                extra={"include_untagged": True},
+            )
+        for tg in self.target_groups.values():
+            yield TaggedResource(
+                arn=tg.arn,
+                tags=self.tagging_service.get_tag_dict_for_resource(tg.arn),
+                resource_type="elasticloadbalancing:targetgroup",
+            )
 
 
 elbv2_backends = BackendDict(ELBv2Backend, "elbv2")

--- a/moto/events/models.py
+++ b/moto/events/models.py
@@ -7,6 +7,7 @@ import re
 import sys
 import warnings
 from collections import OrderedDict
+from collections.abc import Iterator
 from enum import Enum, unique
 from json import JSONDecodeError
 from operator import eq, ge, gt, le, lt
@@ -18,6 +19,7 @@ from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import JsonRESTError
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import (
     iso_8601_datetime_without_milliseconds,
     unix_time,
@@ -1179,7 +1181,7 @@ class PartnerEventSource(BaseModel):
         }
 
 
-class EventsBackend(BaseBackend):
+class EventsBackend(BaseBackend, TaggableResourcesMixin):
     """
     Some Moto services are configured to generate events and send them to EventBridge. See the AWS documentation here:
     https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-service-event.html
@@ -1194,6 +1196,8 @@ class EventsBackend(BaseBackend):
 
     Please let us know if you want support for an event/target that is not yet listed here.
     """
+
+    SERVICE_NAMESPACE = "events"
 
     ACCOUNT_ID = re.compile(r"^(\d{1,12}|\*)$")
     STATEMENT_ID = re.compile(r"^[a-zA-Z0-9-_]{1,64}$")
@@ -1716,28 +1720,6 @@ class EventsBackend(BaseBackend):
             f"Rule {name} does not exist on EventBus default."
         )
 
-    def tag_resource(self, arn: str, tags: list[dict[str, str]]) -> None:
-        name = arn.split("/")[-1]
-        rules = [bus.rules for bus in self.event_buses.values()]
-        for registry in rules + [self.event_buses]:
-            if name in registry:
-                self.tagger.tag_resource(registry[name].arn, tags)
-                return
-        raise ResourceNotFoundException(
-            f"Rule {name} does not exist on EventBus default."
-        )
-
-    def untag_resource(self, arn: str, tag_names: list[str]) -> None:
-        name = arn.split("/")[-1]
-        rules = [bus.rules for bus in self.event_buses.values()]
-        for registry in rules + [self.event_buses]:
-            if name in registry:
-                self.tagger.untag_resource_using_names(registry[name].arn, tag_names)
-                return
-        raise ResourceNotFoundException(
-            f"Rule {name} does not exist on EventBus default."
-        )
-
     def create_archive(
         self,
         name: str,
@@ -2125,6 +2107,39 @@ class EventsBackend(BaseBackend):
             source = entry["Source"]
             for account_id in self.partner_event_sources[source].accounts:
                 events_backends[account_id][self.region_name].put_events([entry])
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for bus in self.event_buses.values():
+            yield TaggedResource(
+                arn=bus.arn,
+                tags=self.tagger.get_tag_dict_for_resource(bus.arn),
+                resource_type="events:event-bus",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        name = arn.split("/")[-1]
+        rules = [bus.rules for bus in self.event_buses.values()]
+        for registry in rules + [self.event_buses]:
+            if name in registry:
+                self.tagger.tag_resource(
+                    registry[name].arn, self.tagger.convert_dict_to_tags_input(tags)
+                )
+                return
+        raise ResourceNotFoundException(
+            f"Rule {name} does not exist on EventBus default."
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        name = arn.split("/")[-1]
+        rules = [bus.rules for bus in self.event_buses.values()]
+        for registry in rules + [self.event_buses]:
+            if name in registry:
+                self.tagger.untag_resource_using_names(registry[name].arn, tag_keys)
+                return
+        raise ResourceNotFoundException(
+            f"Rule {name} does not exist on EventBus default."
+        )
 
 
 events_backends = BackendDict(EventsBackend, "events")

--- a/moto/events/responses.py
+++ b/moto/events/responses.py
@@ -309,7 +309,8 @@ class EventsHandler(BaseResponse):
 
     def tag_resource(self) -> tuple[str, dict[str, Any]]:
         arn = self._get_param("ResourceARN")
-        tags = self._get_param("Tags")
+        tags = self._get_param("Tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
 
         self.events_backend.tag_resource(arn, tags)
 
@@ -317,9 +318,9 @@ class EventsHandler(BaseResponse):
 
     def untag_resource(self) -> tuple[str, dict[str, Any]]:
         arn = self._get_param("ResourceARN")
-        tags = self._get_param("TagKeys")
+        tag_keys = self._get_param("TagKeys") or []
 
-        self.events_backend.untag_resource(arn, tags)
+        self.events_backend.untag_resource(arn, tag_keys)
 
         return "{}", self.response_headers
 

--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -15,6 +15,7 @@ Incomplete list of unfinished items:
 import io
 import json
 import warnings
+from collections.abc import Iterator
 from gzip import GzipFile
 from time import time
 from typing import Any
@@ -23,6 +24,7 @@ import requests
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.types import Base64EncodedString
 from moto.core.utils import utcnow
 from moto.firehose.exceptions import (
@@ -170,8 +172,10 @@ class DeliveryStream(BaseModel):
         self.last_update_timestamp = utcnow()
 
 
-class FirehoseBackend(BaseBackend):
+class FirehoseBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of Firehose APIs."""
+
+    SERVICE_NAMESPACE = "firehose"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -728,6 +732,22 @@ class FirehoseBackend(BaseBackend):
             delivery_stream.destinations[0]["S3"],
             [{"Data": gzipped_payload}],
         )
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for stream in self.delivery_streams.values():
+            arn = stream.delivery_stream_arn
+            yield TaggedResource(
+                arn=arn,
+                tags=self.tagger.get_tag_dict_for_resource(arn),
+                resource_type="firehose:deliverystream",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, [{"Key": k, "Value": v} for k, v in tags.items()])
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 firehose_backends = BackendDict(FirehoseBackend, "firehose")

--- a/moto/fsx/models.py
+++ b/moto/fsx/models.py
@@ -1,11 +1,13 @@
 """FSxBackend class with methods for supported APIs."""
 
 import time
+from collections.abc import Iterator
 from typing import Any
 from uuid import uuid4
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import filter_resources
@@ -66,7 +68,7 @@ class FileSystem(BaseModel):
         self.open_zfs_configuration = open_zfs_configuration
         self.backend = backend
         if tags:
-            self.backend.tag_resource(self.resource_arn, tags)
+            self.backend.tagger.tag_resource(self.resource_arn, tags)
 
     def to_dict(self) -> dict[str, Any]:
         dct = {
@@ -110,7 +112,7 @@ class Backup(BaseModel):
         self.creation_time = time.time()
         self.backend = backend
         if tags:
-            self.backend.tag_resource(self.resource_arn, tags)
+            self.backend.tagger.tag_resource(self.resource_arn, tags)
 
     def to_dict(self) -> dict[str, Any]:
         dct = {
@@ -126,8 +128,10 @@ class Backup(BaseModel):
         return {k: v for k, v in dct.items() if v is not None}
 
 
-class FSxBackend(BaseBackend):
+class FSxBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of FSx APIs."""
+
+    SERVICE_NAMESPACE = "fsx"
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
@@ -172,7 +176,7 @@ class FSxBackend(BaseBackend):
 
         self.file_systems[file_system_id] = file_system
         if tags:
-            self.tag_resource(resource_arn=file_system.resource_arn, tags=tags)
+            self.tagger.tag_resource(file_system.resource_arn, tags)
         return file_system
 
     @paginate(pagination_model=PAGINATION_MODEL)
@@ -248,7 +252,7 @@ class FSxBackend(BaseBackend):
             )
         self.backups[backup.backup_id] = backup
         if tags:
-            self.tag_resource(resource_arn=backup.resource_arn, tags=tags)
+            self.tagger.tag_resource(backup.resource_arn, tags)
         return backup
 
     def delete_backup(
@@ -291,12 +295,6 @@ class FSxBackend(BaseBackend):
             backups = filter_resources(backups, filter_dict, attr_pairs)
         return backups
 
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(resource_arn, tags)
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
-
     def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         """
         Pagination is not yet implemented
@@ -304,6 +302,27 @@ class FSxBackend(BaseBackend):
         if self.tagger.has_tags(resource_arn):
             return self.tagger.list_tags_for_resource(resource_arn)["Tags"]
         return []
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for backup in self.backups.values():
+            yield TaggedResource(
+                arn=backup.resource_arn,
+                tags=self.tagger.get_tag_dict_for_resource(backup.resource_arn),
+                resource_type="fsx:backup",
+            )
+        for fs in self.file_systems.values():
+            yield TaggedResource(
+                arn=fs.resource_arn,
+                tags=self.tagger.get_tag_dict_for_resource(fs.resource_arn),
+                resource_type="fsx:file-system",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 fsx_backends = BackendDict(FSxBackend, "fsx")

--- a/moto/fsx/responses.py
+++ b/moto/fsx/responses.py
@@ -138,21 +138,16 @@ class FSxResponse(BaseResponse):
     def tag_resource(self) -> TYPE_RESPONSE:
         params = json.loads(self.body)
         resource_arn = params.get("ResourceARN")
-        tags = params.get("Tags")
-        self.fsx_backend.tag_resource(
-            resource_arn=resource_arn,
-            tags=tags,
-        )
+        tags = params.get("Tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
+        self.fsx_backend.tag_resource(resource_arn, tags)
         return 200, {}, json.dumps({})
 
     def untag_resource(self) -> TYPE_RESPONSE:
         params = json.loads(self.body)
         resource_arn = params.get("ResourceARN")
-        tag_keys = params.get("TagKeys")
-        self.fsx_backend.untag_resource(
-            resource_arn=resource_arn,
-            tag_keys=tag_keys,
-        )
+        tag_keys = params.get("TagKeys") or []
+        self.fsx_backend.untag_resource(resource_arn, tag_keys)
         return 200, {}, json.dumps({})
 
     def list_tags_for_resource(self) -> str:

--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -1,11 +1,13 @@
 import hashlib
 import re
 from collections import OrderedDict
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random
 from moto.moto_api._internal.managed_state_model import ManagedState
@@ -151,7 +153,9 @@ class FakeDevEndpoint(BaseModel):
         return response
 
 
-class GlueBackend(BaseBackend):
+class GlueBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "glue"
+
     PAGINATION_MODEL = {
         "get_connections": {
             "input_token": "next_token",
@@ -666,13 +670,6 @@ class GlueBackend(BaseBackend):
 
     def get_tags(self, resource_id: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_id)
-
-    def tag_resource(self, resource_arn: str, tags: dict[str, str] | None) -> None:
-        tag_list = TaggingService.convert_dict_to_tags_input(tags or {})
-        self.tagger.tag_resource(resource_arn, tag_list)
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def create_registry(
         self,
@@ -1646,6 +1643,27 @@ class GlueBackend(BaseBackend):
     def get_security_configurations(self) -> list["FakeSecurityConfiguration"]:
         """Pagination is not yet implemented"""
         return list(self.security_configurations.values())
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for arn, tags in self.tagger.tags.items():
+            # Glue ARNs look like arn:<partition>:glue:<region>:<account>:<type>/<name>
+            try:
+                glue_type = arn.split(":")[-1].split("/")[0]
+            except IndexError:
+                continue
+            yield TaggedResource(
+                arn=arn,
+                tags={k: v or "" for k, v in tags.items()},
+                resource_type=f"glue:{glue_type}",
+            )
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str] | None) -> None:
+        tag_list = TaggingService.convert_dict_to_tags_input(tags or {})
+        self.tagger.tag_resource(resource_arn, tag_list)
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
 
 class FakeSecurityConfiguration(BaseModel):

--- a/moto/kafka/models.py
+++ b/moto/kafka/models.py
@@ -1,11 +1,13 @@
 """KafkaBackend class with methods for supported APIs."""
 
 import uuid
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.kafka.exceptions import BadRequestException, NotFoundException
 from moto.utilities.utils import get_partition
 
@@ -75,8 +77,10 @@ class FakeKafkaCluster(BaseModel):
         return f"arn:{partition}:kafka:{self.region_name}:{self.account_id}:{resource_type}/{self.cluster_id}"
 
 
-class KafkaBackend(BaseBackend):
+class KafkaBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of Kafka APIs."""
+
+    SERVICE_NAMESPACE = "kafka"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -358,6 +362,15 @@ class KafkaBackend(BaseBackend):
 
     def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for cluster in self.clusters.values():
+            yield TaggedResource(
+                arn=cluster.arn,
+                tags=self.tagger.get_tag_dict_for_resource(cluster.arn),
+                resource_type="kafka:cluster",
+            )
 
     def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tags_list = [{"Key": k, "Value": v} for k, v in tags.items()]

--- a/moto/kinesisanalyticsv2/models.py
+++ b/moto/kinesisanalyticsv2/models.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import random
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 
@@ -236,8 +238,10 @@ class Application(BaseModel):
         return updated_dict
 
 
-class KinesisAnalyticsV2Backend(BaseBackend):
+class KinesisAnalyticsV2Backend(BaseBackend, TaggableResourcesMixin):
     """Implementation of KinesisAnalyticsV2 APIs."""
+
+    SERVICE_NAMESPACE = "kinesisanalyticsv2"
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
@@ -272,7 +276,7 @@ class KinesisAnalyticsV2Backend(BaseBackend):
         self.applications[application_name] = app
 
         if tags:
-            self.tag_resource(resource_arn=app.application_arn, tags=tags)
+            self.tagger.tag_resource(app.application_arn, tags)
         return {
             "ApplicationARN": app.application_arn,
             "ApplicationDescription": app.application_description,
@@ -292,9 +296,6 @@ class KinesisAnalyticsV2Backend(BaseBackend):
             "ConditionalToken": app.conditional_token,
             "ApplicationMode": app.application_mode,
         }
-
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(resource_arn, tags)
 
     def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         return self.tagger.list_tags_for_resource(resource_arn)["Tags"]
@@ -337,6 +338,21 @@ class KinesisAnalyticsV2Backend(BaseBackend):
             for app in self.applications.values()
         ]
         return application_summaries
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for app in self.applications.values():
+            yield TaggedResource(
+                arn=app.application_arn,
+                tags=self.tagger.get_tag_dict_for_resource(app.application_arn),
+                resource_type="kinesisanalyticsv2:application",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 kinesisanalyticsv2_backends = BackendDict(

--- a/moto/kinesisanalyticsv2/models.py
+++ b/moto/kinesisanalyticsv2/models.py
@@ -340,6 +340,10 @@ class KinesisAnalyticsV2Backend(BaseBackend, TaggableResourcesMixin):
         return application_summaries
 
     # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def owns_arn(self, arn: str) -> bool:
+        # ARNs use the "kinesisanalytics" namespace, not "kinesisanalyticsv2".
+        return arn.startswith(f"arn:{self.partition}:kinesisanalytics:")
+
     def iter_tagged_resources(self) -> Iterator[TaggedResource]:
         for app in self.applications.values():
             yield TaggedResource(

--- a/moto/kinesisanalyticsv2/responses.py
+++ b/moto/kinesisanalyticsv2/responses.py
@@ -50,10 +50,9 @@ class KinesisAnalyticsV2Response(BaseResponse):
     def tag_resource(self) -> str:
         params = json.loads(self.body)
         resource_arn = params.get("ResourceARN")
-        tags = params.get("Tags")
-        self.kinesisanalyticsv2_backend.tag_resource(
-            resource_arn=resource_arn, tags=tags
-        )
+        tags = params.get("Tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
+        self.kinesisanalyticsv2_backend.tag_resource(resource_arn, tags)
         return json.dumps({})
 
     def describe_application(self) -> str:

--- a/moto/kms/models.py
+++ b/moto/kms/models.py
@@ -1,6 +1,6 @@
 import json
 import os
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from copy import copy
 from datetime import datetime, timedelta
 from typing import Any
@@ -8,6 +8,7 @@ from typing import Any
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
 from moto.core.exceptions import JsonRESTError
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import unix_time, utcnow
 from moto.moto_api._internal import mock_random
 from moto.utilities.paginator import paginate
@@ -342,7 +343,9 @@ class Key(CloudFormationModel):
         raise UnformattedGetAttTemplateException()
 
 
-class KmsBackend(BaseBackend):
+class KmsBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "kms"
+
     PAGINATION_MODEL = {
         "list_key_rotations": {
             "input_token": "next_marker",
@@ -403,7 +406,7 @@ class KmsBackend(BaseBackend):
         )
         self.keys[key.id] = key
         if tags is not None and len(tags) > 0:
-            self.tag_resource(key.id, tags)
+            self.tagger.tag_resource(key.id, tags)
         return key
 
     # https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html#mrk-sync-properties
@@ -683,26 +686,6 @@ class KmsBackend(BaseBackend):
             "The request was rejected because the specified entity or resource could not be found.",
         )
 
-    def tag_resource(self, key_id_or_arn: str, tags: list[dict[str, str]]) -> None:
-        key_id = self.get_key_id(key_id_or_arn)
-        if key_id in self.keys:
-            self.tagger.tag_resource(key_id, tags)
-            return
-        raise JsonRESTError(
-            "NotFoundException",
-            "The request was rejected because the specified entity or resource could not be found.",
-        )
-
-    def untag_resource(self, key_id_or_arn: str, tag_names: list[str]) -> None:
-        key_id = self.get_key_id(key_id_or_arn)
-        if key_id in self.keys:
-            self.tagger.untag_resource_using_names(key_id, tag_names)
-            return
-        raise JsonRESTError(
-            "NotFoundException",
-            "The request was rejected because the specified entity or resource could not be found.",
-        )
-
     def create_grant(
         self,
         key_id: str,
@@ -880,6 +863,35 @@ class KmsBackend(BaseBackend):
 
         if mac != regenerated_mac:
             raise KMSInvalidMacException()
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for key in self.list_keys():
+            yield TaggedResource(
+                arn=key.arn,
+                tags=self.tagger.get_tag_dict_for_resource(key.id),
+                resource_type="kms:key",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        key_id = self.get_key_id(arn)
+        if key_id not in self.keys:
+            raise JsonRESTError(
+                "NotFoundException",
+                "The request was rejected because the specified entity or resource could not be found.",
+            )
+        self.tagger.tag_resource(
+            key_id, [{"TagKey": k, "TagValue": v} for k, v in tags.items()]
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        key_id = self.get_key_id(arn)
+        if key_id not in self.keys:
+            raise JsonRESTError(
+                "NotFoundException",
+                "The request was rejected because the specified entity or resource could not be found.",
+            )
+        self.tagger.untag_resource_using_names(key_id, tag_keys)
 
 
 kms_backends = BackendDict(KmsBackend, "kms")

--- a/moto/kms/responses.py
+++ b/moto/kms/responses.py
@@ -155,7 +155,8 @@ class KmsResponse(BaseResponse):
     def tag_resource(self) -> str:
         """https://docs.aws.amazon.com/kms/latest/APIReference/API_TagResource.html"""
         key_id = self._get_param("KeyId")
-        tags = self._get_param("Tags")
+        tags = self._get_param("Tags") or []
+        tags = {tag["TagKey"]: tag.get("TagValue") for tag in tags}
 
         self._validate_cmk_id(key_id)
 
@@ -165,7 +166,7 @@ class KmsResponse(BaseResponse):
     def untag_resource(self) -> str:
         """https://docs.aws.amazon.com/kms/latest/APIReference/API_UntagResource.html"""
         key_id = self._get_param("KeyId")
-        tag_names = self._get_param("TagKeys")
+        tag_names = self._get_param("TagKeys") or []
 
         self._validate_cmk_id(key_id)
 

--- a/moto/lexv2models/models.py
+++ b/moto/lexv2models/models.py
@@ -1,10 +1,12 @@
 """LexModelsV2Backend class with methods for supported APIs."""
 
 import uuid
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 
 from ..utilities.tagging_service import TaggingService
 
@@ -92,8 +94,10 @@ class FakeResourcePolicy:
         self.revision_id = str(uuid.uuid4())
 
 
-class LexModelsV2Backend(BaseBackend):
+class LexModelsV2Backend(BaseBackend, TaggableResourcesMixin):
     """Implementation of LexModelsV2 APIs."""
+
+    SERVICE_NAMESPACE = "lex"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -383,15 +387,30 @@ class LexModelsV2Backend(BaseBackend):
         rp = self.resource_policies.pop(resource_arn)
         return rp.resource_arn, rp.revision_id
 
+    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
+        return self.tagger.get_tag_dict_for_resource(resource_arn)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for bot in self.bots.values():
+            yield TaggedResource(
+                arn=bot.arn,
+                tags=self.tagger.get_tag_dict_for_resource(bot.arn),
+                resource_type="lexv2:bot",
+            )
+        for alias in self.bot_aliases.values():
+            yield TaggedResource(
+                arn=alias.arn,
+                tags=self.tagger.get_tag_dict_for_resource(alias.arn),
+                resource_type="lexv2:bot-alias",
+            )
+
     def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
         tags_list = [{"Key": k, "Value": v} for k, v in tags.items()]
         self.tagger.tag_resource(resource_arn, tags_list)
 
     def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
         self.tagger.untag_resource_using_names(resource_arn, tag_keys)
-
-    def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
-        return self.tagger.get_tag_dict_for_resource(resource_arn)
 
 
 lexv2models_backends = BackendDict(LexModelsV2Backend, "lexv2-models")

--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1,11 +1,12 @@
 import re
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 from gzip import compress as gzip_compress
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import unix_time_millis, utcnow
 from moto.logs.exceptions import (
     ConflictException,
@@ -927,7 +928,9 @@ class Delivery(BaseModel):
         return dct_items
 
 
-class LogsBackend(BaseBackend):
+class LogsBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "logs"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.groups: dict[str, LogGroup] = {}
@@ -1565,12 +1568,6 @@ class LogsBackend(BaseBackend):
     def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
 
-    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
-        self.tagger.tag_resource(arn, TaggingService.convert_dict_to_tags_input(tags))
-
-    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(arn, tag_keys)
-
     def _find_log_group(
         self, log_group_id: str | None = None, log_group_name: str | None = None
     ) -> LogGroup:
@@ -1867,6 +1864,21 @@ class LogsBackend(BaseBackend):
             )
         self.delivery_sources.pop(name)
         return
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for group in self.groups.values():
+            yield TaggedResource(
+                arn=group.arn,
+                tags=self.tagger.get_tag_dict_for_resource(group.arn),
+                resource_type="logs:loggroup",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, TaggingService.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 logs_backends = BackendDict(LogsBackend, "logs")

--- a/moto/quicksight/models.py
+++ b/moto/quicksight/models.py
@@ -1,7 +1,9 @@
+from collections.abc import Iterator
 from datetime import datetime
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
 
@@ -23,8 +25,10 @@ def _create_id(aws_account_id: str, namespace: str, _id: str) -> str:
     return f"{aws_account_id}:{namespace}:{_id}"
 
 
-class QuickSightBackend(BaseBackend):
+class QuickSightBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of QuickSight APIs."""
+
+    SERVICE_NAMESPACE = "quicksight"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -402,21 +406,42 @@ class QuickSightBackend(BaseBackend):
 
         return data_source_list
 
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(
-            arn=resource_arn,
-            tags=tags,
-        )
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(
-            resource_arn,
-            tag_keys,
-        )
-
     def list_tags_for_resource(self, arn: str) -> list[dict[str, str]]:
         tags = self.tagger.list_tags_for_resource(arn)
         return tags.get("Tags", [])
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for dashboard in self.dashboards.values():
+            yield TaggedResource(
+                arn=dashboard.arn,
+                tags=self.tagger.get_tag_dict_for_resource(dashboard.arn),
+                resource_type="quicksight:dashboards",
+            )
+        for source in self.data_sources.values():
+            yield TaggedResource(
+                arn=source.arn,
+                tags=self.tagger.get_tag_dict_for_resource(source.arn),
+                resource_type="quicksight:data_sources",
+            )
+        for ds in self.data_sets.values():
+            yield TaggedResource(
+                arn=ds.arn,
+                tags=self.tagger.get_tag_dict_for_resource(ds.arn),
+                resource_type="quicksight:data_sets",
+            )
+        for user in self.users.values():
+            yield TaggedResource(
+                arn=user.arn,
+                tags=self.tagger.get_tag_dict_for_resource(user.arn),
+                resource_type="quicksight:users",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 quicksight_backends = BackendDict(QuickSightBackend, "quicksight")

--- a/moto/quicksight/responses.py
+++ b/moto/quicksight/responses.py
@@ -439,7 +439,8 @@ class QuickSightResponse(BaseResponse):
 
     def tag_resource(self) -> str:
         resource_arn = unquote(self._get_param("ResourceArn"))
-        tags = self._get_param("Tags")
+        tags = self._get_param("Tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
 
         self.quicksight_backend.tag_resource(resource_arn, tags)
 

--- a/moto/rds/models.py
+++ b/moto/rds/models.py
@@ -4360,7 +4360,7 @@ class RDSBackend(BaseBackend, TaggableResourcesMixin):
     def _is_cluster(self, arn: str) -> bool:
         return arn.split(":")[-2] == "cluster"
 
-    # Resource Groups Tagging API
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
     def iter_tagged_resources(self) -> Iterator[TaggedResource]:
         resource_map: dict[str, Iterable[Any]] = {
             "rds:cluster": self.clusters.values(),

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -402,22 +402,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "Tags": tags,
                     }
 
-        # CloudFormation
-        if not resource_type_filters or "cloudformation:stack" in resource_type_filters:
-            try:
-                from moto.cloudformation import cloudformation_backends
-
-                cf_backend = cloudformation_backends[self.account_id][self.region_name]
-
-                for stack in cf_backend.stacks.values():
-                    tags = format_tags(stack.tags)
-                    if not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{stack.stack_id}", "Tags": tags}
-
-            except Exception:
-                pass
-
         # Cloudfront
         if (
             not resource_type_filters

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,7 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.sagemaker.models import SageMakerModelBackend, sagemaker_backends
 from moto.secretsmanager import secretsmanager_backends
 from moto.secretsmanager.models import ReplicaSecret, SecretsManagerBackend
 from moto.servicecatalog.models import ServiceCatalogBackend, servicecatalog_backends
@@ -101,10 +100,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         if self.region_name in workspacesweb_backends[self.account_id].regions:
             return workspacesweb_backends[self.account_id][self.region_name]
         return None
-
-    @property
-    def sagemaker_backend(self) -> SageMakerModelBackend:
-        return sagemaker_backends[self.account_id][self.region_name]
 
     @property
     def swf_backend(self) -> SWFBackend:
@@ -545,50 +540,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "Tags": tags,
                 }
 
-        # sagemaker cluster, automljob, compilation-job, domain, model-explainability-job-definition, model-quality-job-definition, and hyper-parameter-tuning-job currently supported
-        sagemaker_resource_map: dict[str, dict[str, Any]] = {
-            "sagemaker:cluster": self.sagemaker_backend.clusters,
-            "sagemaker:automl-job": self.sagemaker_backend.auto_ml_jobs,
-            "sagemaker:compilation-job": self.sagemaker_backend.compilation_jobs,
-            "sagemaker:domain": self.sagemaker_backend.domains,
-            "sagemaker:model-explainability-job-definition": self.sagemaker_backend.model_explainability_job_definitions,
-            "sagemaker:model-quality-job-definition": self.sagemaker_backend.model_quality_job_definitions,
-            "sagemaker:hyper-parameter-tuning-job": self.sagemaker_backend.hyper_parameter_tuning_jobs,
-            "sagemaker:model-bias-job-definition": self.sagemaker_backend.model_bias_job_definitions,
-            "sagemaker:data-quality-job-definition": self.sagemaker_backend.data_quality_job_definitions,
-            "sagemaker:model": self.sagemaker_backend._models,
-            "sagemaker:notebook-instance": self.sagemaker_backend.notebook_instances,
-            "sagemaker:endpoint-config": self.sagemaker_backend.endpoint_configs,
-            "sagemaker:endpoint": self.sagemaker_backend.endpoints,
-            "sagemaker:experiment": self.sagemaker_backend.experiments,
-            "sagemaker:pipeline": self.sagemaker_backend.pipelines,
-            "sagemaker:pipeline-execution": self.sagemaker_backend.pipeline_executions,
-            "sagemaker:processing-job": self.sagemaker_backend.processing_jobs,
-            "sagemaker:trial": self.sagemaker_backend.trials,
-            "sagemaker:trial-component": self.sagemaker_backend.trial_components,
-            "sagemaker:training-job": self.sagemaker_backend.training_jobs,
-            "sagemaker:transform-job": self.sagemaker_backend.transform_jobs,
-            "sagemaker:notebook-instance-lifecycle-config": self.sagemaker_backend.notebook_instance_lifecycle_configurations,
-            "sagemaker:model-card": self.sagemaker_backend.model_cards,
-            "sagemaker:model-package-group": self.sagemaker_backend.model_package_groups,
-            "sagemaker:model-package": self.sagemaker_backend.model_packages,
-            "sagemaker:feature-group": self.sagemaker_backend.feature_groups,
-        }
-        for resource_type, resource_source in sagemaker_resource_map.items():
-            if (
-                not resource_type_filters
-                or "sagemaker" in resource_type_filters
-                or resource_type in resource_type_filters
-            ):
-                for resource in resource_source.values():
-                    tags = self.sagemaker_backend.list_tags(resource.arn)[0]
-                    if not tags or not tag_filter(tags):
-                        continue
-                    yield {
-                        "ResourceARN": resource.arn,
-                        "Tags": tags,
-                    }
-
     def _get_tag_keys_generator(self) -> Iterator[str]:
         # Look at
         # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
@@ -803,10 +754,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 resource_id = arn.split("/")[-1]
                 self.workspaces_backend.create_tags(  # type: ignore[union-attr]
                     resource_id, TaggingService.convert_dict_to_tags_input(tags)
-                )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:sagemaker:"):
-                self.sagemaker_backend.add_tags(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
                 )
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
                 self.sesv2_backend.tag_resource(

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.elasticache.models import ElastiCacheBackend, elasticache_backends
 from moto.elasticbeanstalk.models import EBBackend, eb_backends
 from moto.elb.models import ELBBackend, elb_backends
 from moto.elbv2.models import ELBv2Backend, elbv2_backends
@@ -184,10 +183,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return None
 
     @property
-    def elasticache_backend(self) -> ElastiCacheBackend:
-        return elasticache_backends[self.account_id][self.region_name]
-
-    @property
     def vpclattice_backend(self) -> VPCLatticeBackend:
         return vpclattice_backends[self.account_id][self.region_name]
 
@@ -294,40 +289,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        elasticache_resource_map: dict[str, dict[str, Any]] = {
-            "elasticache:cache_clusters": dict(self.elasticache_backend.cache_clusters),
-            "elasticache:replication-group": dict(
-                self.elasticache_backend.replication_groups
-            ),
-            "elasticache:snapshots": dict(self.elasticache_backend.snapshots),
-            "elasticache:cache_subnet_groups": dict(
-                self.elasticache_backend.cache_subnet_groups
-            ),
-            "elasticache:users": dict(self.elasticache_backend.users),
-        }
-
-        for resource_type, resource_source in elasticache_resource_map.items():
-            if (
-                not resource_type_filters
-                or "elasticache" in resource_type_filters
-                or resource_type in resource_type_filters
-            ):
-                for resource in resource_source.values():
-                    if (
-                        resource_type == "elasticache:users"
-                        and resource.id == "default"
-                    ):
-                        continue
-
-                    tags = (
-                        self.elasticache_backend.tagging_service.list_tags_for_resource(
-                            resource.arn
-                        )["Tags"]
-                    )
-                    if not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{resource.arn}", "Tags": tags}
 
         # ElasticBeanstalk
         if (
@@ -1192,10 +1153,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.quicksight_backend.tag_resource(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
                 )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:elasticache:"):
-                self.elasticache_backend.add_tags_to_resource(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
-                )
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
                 self.sesv2_backend.tag_resource(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
@@ -1232,8 +1189,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             if arn.startswith(f"arn:{get_partition(self.region_name)}:quicksight:"):
                 assert self.quicksight_backend is not None
                 self.quicksight_backend.untag_resource(arn, tag_keys)
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:elasticache:"):
-                self.elasticache_backend.remove_tags_from_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
                 self.sesv2_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -18,7 +18,6 @@ from moto.resourcegroupstaggingapi.exceptions import (
 )
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
-from moto.vpclattice.models import VPCLatticeBackend, vpclattice_backends
 from moto.workspaces.models import WorkSpacesBackend, workspaces_backends
 from moto.workspacesweb.models import WorkSpacesWebBackend, workspacesweb_backends
 
@@ -66,10 +65,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         if self.region_name in workspacesweb_backends[self.account_id].regions:
             return workspacesweb_backends[self.account_id][self.region_name]
         return None
-
-    @property
-    def vpclattice_backend(self) -> VPCLatticeBackend:
-        return vpclattice_backends[self.account_id][self.region_name]
 
     def _get_backend_for_resource(
         self, resource_arn: str
@@ -168,101 +163,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # VPC Lattice
-        if not resource_type_filters or "vpc-lattice" in resource_type_filters:
-            # Service
-            for service in self.vpclattice_backend.services.values():  # type: ignore[assignment]
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(
-                    service.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{service.arn}", "Tags": tags}
-
-            # Service Networks
-            for service_network in self.vpclattice_backend.service_networks.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(
-                    service_network.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{service_network.arn}", "Tags": tags}
-
-            # Service Network VPC Associations
-            for (
-                assoc
-            ) in self.vpclattice_backend.service_network_vpc_associations.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(assoc.arn)[
-                    "Tags"
-                ]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{assoc.arn}", "Tags": tags}
-
-            # Rules
-            for rule in self.vpclattice_backend.rules.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(rule.arn)[
-                    "Tags"
-                ]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{rule.arn}", "Tags": tags}
-
-            # Access Log Subscriptions
-            for sub in self.vpclattice_backend.access_log_subscriptions.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(sub.arn)[
-                    "Tags"
-                ]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{sub.arn}", "Tags": tags}
-
-            # Listener
-            for listener in self.vpclattice_backend.listeners.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(
-                    listener.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{listener.arn}", "Tags": tags}
-
-            # Target Group
-            for vpc_target_group in self.vpclattice_backend.target_groups.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(
-                    vpc_target_group.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{vpc_target_group.arn}", "Tags": tags}
-
-            # Service Network Resource Association
-            for (
-                service_network_resource_association
-            ) in self.vpclattice_backend.service_network_resource_associations.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(
-                    service_network_resource_association.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {
-                    "ResourceARN": f"{service_network_resource_association.arn}",
-                    "Tags": tags,
-                }
-
-            # Service Network Service Association
-            for (
-                service_network_service_association
-            ) in self.vpclattice_backend.service_network_service_associations.values():
-                tags = self.vpclattice_backend.tagger.list_tags_for_resource(
-                    service_network_service_association.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {
-                    "ResourceARN": f"{service_network_service_association.arn}",
-                    "Tags": tags,
-                }
 
         # Workspaces
         if self.workspaces_backend and (

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,7 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.sns.models import SNSBackend, sns_backends
 from moto.sqs.models import SQSBackend, sqs_backends
 from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
 from moto.ssm.utils import parameter_arn
@@ -58,10 +57,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def sns_backend(self) -> SNSBackend:
-        return sns_backends[self.account_id][self.region_name]
 
     @property
     def ssm_backend(self) -> SimpleSystemManagerBackend:
@@ -209,16 +204,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     continue
 
                 yield {"ResourceARN": f"{queue.queue_arn}", "Tags": tags}
-
-        # SNS
-        if not resource_type_filters or "sns" in resource_type_filters:
-            for topic in self.sns_backend.topics.values():
-                tags = format_tags(topic._tags)
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-                yield {"ResourceARN": f"{topic.arn}", "Tags": tags}
 
         # SSM Documents
         if (

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,7 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.stepfunctions.models import StepFunctionBackend, stepfunctions_backends
 from moto.swf.models import SWFBackend, swf_backends
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
@@ -54,10 +53,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def stepfunctions_backend(self) -> StepFunctionBackend:
-        return stepfunctions_backends[self.account_id][self.region_name]
 
     @property
     def workspaces_backend(self) -> WorkSpacesBackend | None:
@@ -178,22 +173,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # Step Functions
-        if not resource_type_filters or "states:stateMachine" in resource_type_filters:
-            for state_machine in self.stepfunctions_backend.state_machines:
-                tags = format_tag_keys(
-                    state_machine.backend.get_tags_list_for_state_machine(
-                        state_machine.arn
-                    ),
-                    [
-                        state_machine.backend.tagger.key_name,
-                        state_machine.backend.tagger.value_name,
-                    ],
-                )
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": state_machine.arn, "Tags": tags}
 
         # SWF
         if (

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,8 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.secretsmanager import secretsmanager_backends
-from moto.secretsmanager.models import ReplicaSecret, SecretsManagerBackend
 from moto.servicecatalog.models import ServiceCatalogBackend, servicecatalog_backends
 from moto.sesv2.models import SESV2Backend, sesv2_backends
 from moto.sns.models import SNSBackend, sns_backends
@@ -62,10 +60,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def secretsmanager_backend(self) -> SecretsManagerBackend:
-        return secretsmanager_backends[self.account_id][self.region_name]
 
     @property
     def sns_backend(self) -> SNSBackend:
@@ -210,24 +204,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # Secrets Manager
-        if (
-            not resource_type_filters
-            or "secretsmanager" in resource_type_filters
-            or "secretsmanager:secret" in resource_type_filters
-        ):
-            for secret in self.secretsmanager_backend.secrets.values():
-                if isinstance(secret, ReplicaSecret):
-                    secret_tags = secret.source.tags
-                else:
-                    secret_tags = secret.tags
-
-                if secret_tags:
-                    formated_tags = format_tag_keys(secret_tags, ["Key", "Value"])
-                    if not formated_tags or not tag_filter(formated_tags):
-                        continue
-                    yield {"ResourceARN": f"{secret.arn}", "Tags": formated_tags}
 
         # SQS
         if (

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.cloudfront.models import CloudFrontBackend, cloudfront_backends
 from moto.cloudwatch.models import CloudWatchBackend, cloudwatch_backends
 from moto.comprehend.models import ComprehendBackend, comprehend_backends
 from moto.connectcampaigns.models import (
@@ -213,10 +212,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return None
 
     @property
-    def cloudfront_backend(self) -> CloudFrontBackend:
-        return cloudfront_backends[self.account_id][self.partition]
-
-    @property
     def swf_backend(self) -> SWFBackend:
         return swf_backends[self.account_id][self.region_name]
 
@@ -401,22 +396,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # Cloudfront
-        if (
-            not resource_type_filters
-            or "cloudfront" in resource_type_filters
-            or "cloudfront:distributions" in resource_type_filters
-        ):
-            for dist in self.cloudfront_backend.distributions.values():
-                tags = self.cloudfront_backend.tagger.list_tags_for_resource(dist.arn)[
-                    "Tags"
-                ]
-                if (
-                    not tag_filter(tags) or len(tags) == 0
-                ):  # Skip if no tags, or invalid filter
-                    continue
-                yield {"ResourceARN": f"{dist.arn}", "Tags": tags}
 
         if self.cloudwatch_backend:
             cloudwatch_resource_map: dict[str, dict[str, Any]] = {
@@ -1447,7 +1426,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self, resource_arns: list[str], tags: dict[str, str]
     ) -> dict[str, dict[str, Any]]:
         """
-        Only CloudFront, DynamoDB, EFS, Elasticache, Lambda, Logs, Quicksight, RDS, SageMaker, SES, and SWF resources are currently supported
+        Only DynamoDB, EFS, Elasticache, Lambda, Logs, Quicksight, RDS, SageMaker, SES, and SWF resources are currently supported
         """
         missing_resources = []
         missing_error: dict[str, Any] = {
@@ -1504,10 +1483,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.sesv2_backend.tag_resource(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
                 )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:cloudfront:"):
-                self.cloudfront_backend.tag_resource(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
-                )
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
                 self.swf_backend.tagger.tag_resource(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
@@ -1520,7 +1495,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self, resource_arn_list: list[str], tag_keys: list[str]
     ) -> dict[str, dict[str, Any]]:
         """
-        Only CloudFront, EFS, Elasticache, Lambda, Quicksight, SES, and SWF resources are currently supported
+        Only EFS, Elasticache, Lambda, Quicksight, SES, and SWF resources are currently supported
         """
         missing_resources = []
         missing_error: dict[str, Any] = {
@@ -1549,8 +1524,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.elasticache_backend.remove_tags_from_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
                 self.sesv2_backend.untag_resource(arn, tag_keys)
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:cloudfront:"):
-                self.cloudfront_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
                 self.swf_backend.tagger.untag_resource_using_names(arn, tag_keys)
             else:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -11,7 +11,6 @@ from moto.core.resource_tagging import (
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
 from moto.kinesis.models import KinesisBackend, kinesis_backends
-from moto.logs.models import LogsBackend, logs_backends
 from moto.moto_api._internal import mock_random
 from moto.quicksight.models import QuickSightBackend, quicksight_backends
 from moto.redshift.models import RedshiftBackend, redshift_backends
@@ -53,10 +52,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def kinesis_backend(self) -> KinesisBackend:
         return kinesis_backends[self.account_id][self.region_name]
-
-    @property
-    def logs_backend(self) -> LogsBackend:
-        return logs_backends[self.account_id][self.region_name]
 
     @property
     def glacier_backend(self) -> GlacierBackend:
@@ -220,21 +215,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Glacier Vault
 
         # Kinesis
-
-        # LOGS
-        if (
-            not resource_type_filters
-            or "logs" in resource_type_filters
-            or "logs:loggroup" in resource_type_filters
-        ):
-            for group in self.logs_backend.groups.values():
-                log_tags = self.logs_backend.list_tags_for_resource(group.arn)
-                tags = format_tags(log_tags)
-
-                if not log_tags or not tag_filter(tags):
-                    # Skip if no tags, or invalid filter
-                    continue
-                yield {"ResourceARN": group.arn, "Tags": tags}
 
         # Quicksight
         if self.quicksight_backend:
@@ -859,8 +839,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.workspaces_backend.create_tags(  # type: ignore[union-attr]
                     resource_id, TaggingService.convert_dict_to_tags_input(tags)
                 )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:logs:"):
-                self.logs_backend.tag_resource(arn, tags)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:sagemaker:"):
                 self.sagemaker_backend.add_tags(
                     arn, TaggingService.convert_dict_to_tags_input(tags)

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.directconnect.models import DirectConnectBackend, directconnect_backends
 from moto.dms.models import DatabaseMigrationServiceBackend, dms_backends
 from moto.dynamodb.models import DynamoDBBackend, dynamodb_backends
 from moto.ecs.models import EC2ContainerServiceBackend, ecs_backends
@@ -56,7 +55,7 @@ from moto.workspaces.models import WorkSpacesBackend, workspaces_backends
 from moto.workspacesweb.models import WorkSpacesWebBackend, workspacesweb_backends
 
 # Left: EC2 RDS ELB Lambda EMR Glacier Kinesis Redshift Route53
-# StorageGateway DynamoDB MachineLearning ACM DirectConnect DirectoryService CloudHSM
+# StorageGateway DynamoDB MachineLearning ACM DirectoryService CloudHSM
 # Inspector Elasticsearch
 
 
@@ -69,10 +68,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def directconnect_backend(self) -> DirectConnectBackend:
-        return directconnect_backends[self.account_id][self.region_name]
 
     @property
     def dms_backend(self) -> DatabaseMigrationServiceBackend:
@@ -319,33 +314,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # Direct Connect
-        if self.directconnect_backend:
-            if not resource_type_filters or "directconnect" in resource_type_filters:
-                directconnect_backend = directconnect_backends[self.account_id][
-                    self.region_name
-                ]
-
-                # Connections
-                for connection in directconnect_backend.connections.values():
-                    tags = directconnect_backend.tagger.list_tags_for_resource(
-                        connection.connection_id
-                    )["Tags"]
-                    tags = format_tag_keys(tags, ["key", "value"])
-                    if not tags or not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{connection.connection_id}", "Tags": tags}
-
-                # LAGs
-                for lag in directconnect_backend.lags.values():
-                    tags = directconnect_backend.tagger.list_tags_for_resource(
-                        lag.lag_id
-                    )["Tags"]
-                    tags = format_tag_keys(tags, ["key", "value"])
-                    if not tags or not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{lag.lag_id}", "Tags": tags}
 
         # DMS
         if not resource_type_filters or "dms:endpoint" in resource_type_filters:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.dms.models import DatabaseMigrationServiceBackend, dms_backends
 from moto.dynamodb.models import DynamoDBBackend, dynamodb_backends
 from moto.ecs.models import EC2ContainerServiceBackend, ecs_backends
 from moto.efs.models import EFSBackend, efs_backends
@@ -68,10 +67,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def dms_backend(self) -> DatabaseMigrationServiceBackend:
-        return dms_backends[self.account_id][self.region_name]
 
     @property
     def efs_backend(self) -> EFSBackend:
@@ -287,7 +282,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         tag_matcher = make_tag_matcher(tag_filters)
         for backend in iter_taggable_backends(self.account_id, self.region_name):
             for resource in backend.iter_tagged_resources():
-                if not resource.tags:
+                if not resource.tags and not resource.extra.get("include_untagged"):
                     continue
                 if not match_resource_type(
                     resource.resource_type, resource_type_filters
@@ -314,37 +309,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # DMS
-        if not resource_type_filters or "dms:endpoint" in resource_type_filters:
-            for endpoint in self.dms_backend.endpoints.values():
-                tags = self.dms_backend.tagger.list_tags_for_resource(
-                    endpoint.endpoint_arn
-                )["Tags"]
-                if not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{endpoint.endpoint_arn}", "Tags": tags}
-
-        if (
-            not resource_type_filters
-            or "dms:replication-instance" in resource_type_filters
-        ):
-            for replication_instance in self.dms_backend.replication_instances.values():
-                tags = self.dms_backend.tagger.list_tags_for_resource(
-                    replication_instance.arn
-                )["Tags"]
-                if not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{replication_instance.arn}", "Tags": tags}
-
-        if not resource_type_filters or "dms:task" in resource_type_filters:
-            for replication_task in self.dms_backend.replication_tasks.values():
-                tags = self.dms_backend.tagger.list_tags_for_resource(
-                    replication_task.arn
-                )["Tags"]
-                if not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{replication_task.arn}", "Tags": tags}
 
         # ECS
         if not resource_type_filters or "ecs:service" in resource_type_filters:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -11,7 +11,6 @@ from moto.core.resource_tagging import (
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
 from moto.kinesis.models import KinesisBackend, kinesis_backends
-from moto.kms.models import KmsBackend, kms_backends
 from moto.lexv2models.models import LexModelsV2Backend, lexv2models_backends
 from moto.logs.models import LogsBackend, logs_backends
 from moto.moto_api._internal import mock_random
@@ -55,10 +54,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def kinesis_backend(self) -> KinesisBackend:
         return kinesis_backends[self.account_id][self.region_name]
-
-    @property
-    def kms_backend(self) -> KmsBackend:
-        return kms_backends[self.account_id][self.region_name]
 
     @property
     def logs_backend(self) -> LogsBackend:
@@ -232,22 +227,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Glacier Vault
 
         # Kinesis
-
-        # KMS
-        if (
-            not resource_type_filters
-            or "kms" in resource_type_filters
-            or "kms:key" in resource_type_filters
-        ):
-            for kms_key in self.kms_backend.list_keys():
-                tags = format_tag_keys(
-                    self.kms_backend.list_resource_tags(kms_key.id).get("Tags", []),
-                    ["TagKey", "TagValue"],
-                )
-                if not tag_filter(tags):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {"ResourceARN": f"{kms_key.arn}", "Tags": tags}
 
         # LexV2
         if self.lexv2_backend:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,7 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.swf.models import SWFBackend, swf_backends
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
 from moto.vpclattice.models import VPCLatticeBackend, vpclattice_backends
@@ -67,10 +66,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         if self.region_name in workspacesweb_backends[self.account_id].regions:
             return workspacesweb_backends[self.account_id][self.region_name]
         return None
-
-    @property
-    def swf_backend(self) -> SWFBackend:
-        return swf_backends[self.account_id][self.region_name]
 
     @property
     def vpclattice_backend(self) -> VPCLatticeBackend:
@@ -173,21 +168,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # SWF
-        if (
-            not resource_type_filters
-            or "swf" in resource_type_filters
-            or "swf:domain" in resource_type_filters
-        ):
-            for domain in self.swf_backend.domains:
-                domain_arn = domain.to_short_dict()["arn"]
-                tags = self.swf_backend.tagger.list_tags_for_resource(domain_arn)[
-                    "Tags"
-                ]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": domain_arn, "Tags": tags}
 
         # VPC Lattice
         if not resource_type_filters or "vpc-lattice" in resource_type_filters:
@@ -562,10 +542,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.workspaces_backend.create_tags(  # type: ignore[union-attr]
                     resource_id, TaggingService.convert_dict_to_tags_input(tags)
                 )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
-                self.swf_backend.tagger.tag_resource(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
-                )
             else:
                 missing_resources.append(arn)
         return dict.fromkeys(missing_resources, missing_error)
@@ -591,10 +567,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 except NotImplementedError:
                     missing_resources.append(arn)
                 continue
-            if arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
-                self.swf_backend.tagger.untag_resource_using_names(arn, tag_keys)
-            else:
-                missing_resources.append(arn)
 
         return dict.fromkeys(missing_resources, missing_error)
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,7 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.servicecatalog.models import ServiceCatalogBackend, servicecatalog_backends
 from moto.sesv2.models import SESV2Backend, sesv2_backends
 from moto.sns.models import SNSBackend, sns_backends
 from moto.sqs.models import SQSBackend, sqs_backends
@@ -72,10 +71,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def sqs_backend(self) -> SQSBackend:
         return sqs_backends[self.account_id][self.region_name]
-
-    @property
-    def servicecatalog_backend(self) -> ServiceCatalogBackend:
-        return servicecatalog_backends[self.account_id][self.region_name]
 
     @property
     def stepfunctions_backend(self) -> StepFunctionBackend:
@@ -219,26 +214,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     continue
 
                 yield {"ResourceARN": f"{queue.queue_arn}", "Tags": tags}
-
-        # Service Catalog
-        if not resource_type_filters or "servicecatalog" in resource_type_filters:
-            # Portfolio
-            for portfolio in self.servicecatalog_backend.portfolios.values():
-                tags = self.servicecatalog_backend.tagger.list_tags_for_resource(
-                    portfolio.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{portfolio.arn}", "Tags": tags}
-
-            # Product
-            for product in self.servicecatalog_backend.products.values():
-                tags = self.servicecatalog_backend.tagger.list_tags_for_resource(
-                    product.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{product.arn}", "Tags": tags}
 
         if self.sesv2_backend:
             sesv2_resource_map: dict[str, dict[str, Any]] = {

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -10,7 +10,6 @@ from moto.core.resource_tagging import (
 )
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
-from moto.glue.models import GlueBackend, glue_backends
 from moto.kafka.models import KafkaBackend, kafka_backends
 from moto.kinesis.models import KinesisBackend, kinesis_backends
 from moto.kinesisanalyticsv2.models import (
@@ -57,10 +56,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def glue_backend(self) -> GlueBackend:
-        return glue_backends[self.account_id][self.region_name]
 
     @property
     def kinesis_backend(self) -> KinesisBackend:
@@ -248,29 +243,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # EMR Cluster
 
         # Glacier Vault
-
-        # Glue
-        if not resource_type_filters or any(
-            ("glue" in _type) for _type in resource_type_filters
-        ):
-            if not resource_type_filters or "glue" in resource_type_filters:
-                arns_starting_with = [
-                    f"arn:{get_partition(self.region_name)}:glue:{self.region_name}:{self.account_id}:"
-                ]
-            else:
-                arns_starting_with = []
-                for resource_type in resource_type_filters:
-                    if resource_type.startswith("glue:"):
-                        glue_type = resource_type.split(":")[-1]
-                        arns_starting_with.append(
-                            f"arn:{get_partition(self.region_name)}:glue:{self.region_name}:{self.account_id}:{glue_type}"
-                        )
-            for glue_arn in self.glue_backend.tagger.tags.keys():
-                if any(glue_arn.startswith(arn) for arn in arns_starting_with):
-                    tags = self.glue_backend.tagger.list_tags_for_resource(glue_arn)[
-                        "Tags"
-                    ]
-                    yield {"ResourceARN": glue_arn, "Tags": tags}
 
         # Kinesis
 
@@ -778,10 +750,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             for resource in backend.iter_tagged_resources():
                 yield from resource.tags.keys()
 
-        # Glue
-        for tag_dict in self.glue_backend.tagger.tags.values():
-            yield from tag_dict.keys()
-
     def _get_tag_values_generator(self, tag_key: str) -> Iterator[str]:
         # Look at
         # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
@@ -792,12 +760,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 for key, value in resource.tags.items():
                     if key == tag_key:
                         yield value
-
-        # Glue
-        for tag_dict in self.glue_backend.tagger.tags.values():
-            for key, tag_value in tag_dict.items():
-                if key == tag_key and tag_value is not None:
-                    yield tag_value
 
     def get_resources(
         self,

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.backup.models import BackupBackend, backup_backends
 from moto.clouddirectory import CloudDirectoryBackend, clouddirectory_backends
 from moto.cloudfront.models import CloudFrontBackend, cloudfront_backends
 from moto.cloudwatch.models import CloudWatchBackend, cloudwatch_backends
@@ -176,10 +175,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return stepfunctions_backends[self.account_id][self.region_name]
 
     @property
-    def backup_backend(self) -> BackupBackend:
-        return backup_backends[self.account_id][self.region_name]
-
-    @property
     def dynamodb_backend(self) -> DynamoDBBackend:
         return dynamodb_backends[self.account_id][self.region_name]
 
@@ -345,19 +340,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "ResourceARN": resource.arn,
                     "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
                 }
-
-        # Backup
-        if not resource_type_filters or "backup" in resource_type_filters:
-            for vault in self.backup_backend.vaults.values():
-                tags = self.backup_backend.tagger.list_tags_for_resource(
-                    vault.backup_vault_arn
-                )["Tags"]
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {"ResourceARN": f"{vault.backup_vault_arn}", "Tags": tags}
 
         # Comprehend
         if self.comprehend_backend:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -12,7 +12,6 @@ from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
 from moto.kinesis.models import KinesisBackend, kinesis_backends
 from moto.moto_api._internal import mock_random
-from moto.quicksight.models import QuickSightBackend, quicksight_backends
 from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
@@ -112,12 +111,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return swf_backends[self.account_id][self.region_name]
 
     @property
-    def quicksight_backend(self) -> QuickSightBackend | None:
-        if self.region_name in quicksight_backends[self.account_id].regions:
-            return quicksight_backends[self.account_id][self.region_name]
-        return None
-
-    @property
     def vpclattice_backend(self) -> VPCLatticeBackend:
         return vpclattice_backends[self.account_id][self.region_name]
 
@@ -215,34 +208,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Glacier Vault
 
         # Kinesis
-
-        # Quicksight
-        if self.quicksight_backend:
-            quicksight_resource_map: dict[str, dict[str, Any]] = {
-                "quicksight:dashboards": dict(self.quicksight_backend.dashboards),
-                "quicksight:data_sources": dict(self.quicksight_backend.data_sources),
-                "quicksight:data_sets": dict(self.quicksight_backend.data_sets),
-                "quicksight:users": dict(self.quicksight_backend.users),
-            }
-
-            for resource_type, resource_source in quicksight_resource_map.items():
-                if (
-                    not resource_type_filters
-                    or "quicksight" in resource_type_filters
-                    or resource_type in resource_type_filters
-                ):
-                    for resource in resource_source.values():
-                        tags = self.quicksight_backend.tagger.list_tags_for_resource(
-                            resource.arn
-                        )["Tags"]
-
-                        if not tags or not tag_filter(tags):
-                            continue
-
-                        yield {
-                            "ResourceARN": resource.arn,
-                            "Tags": tags,
-                        }
 
         # RedShift Cluster
         # RedShift Hardware security module (HSM) client certificate
@@ -843,12 +808,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.sagemaker_backend.add_tags(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
                 )
-
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:quicksight:"):
-                assert self.quicksight_backend is not None
-                self.quicksight_backend.tag_resource(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
-                )
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
                 self.sesv2_backend.tag_resource(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
@@ -882,10 +841,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 except NotImplementedError:
                     missing_resources.append(arn)
                 continue
-            if arn.startswith(f"arn:{get_partition(self.region_name)}:quicksight:"):
-                assert self.quicksight_backend is not None
-                self.quicksight_backend.untag_resource(arn, tag_keys)
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
+            if arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
                 self.sesv2_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
                 self.swf_backend.tagger.untag_resource_using_names(arn, tag_keys)

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.cloudwatch.models import CloudWatchBackend, cloudwatch_backends
 from moto.comprehend.models import ComprehendBackend, comprehend_backends
 from moto.connectcampaigns.models import (
     ConnectCampaignServiceBackend,
@@ -216,10 +215,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return swf_backends[self.account_id][self.region_name]
 
     @property
-    def cloudwatch_backend(self) -> CloudWatchBackend:
-        return cloudwatch_backends[self.account_id][self.region_name]
-
-    @property
     def connectcampaigns_backend(self) -> ConnectCampaignServiceBackend | None:
         # Connect Campaigns service has limited region availability
         if self.region_name in connectcampaigns_backends[self.account_id].regions:
@@ -396,35 +391,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        if self.cloudwatch_backend:
-            cloudwatch_resource_map: dict[str, dict[str, Any]] = {
-                "cloudwatch:alarm": self.cloudwatch_backend.alarms,
-                "cloudwatch:insight-rule": self.cloudwatch_backend.insight_rules,
-            }
-            for resource_type, resource_source in cloudwatch_resource_map.items():
-                if (
-                    not resource_type_filters
-                    or "cloudwatch" in resource_type_filters
-                    or resource_type in resource_type_filters
-                ):
-                    for resource in resource_source.values():
-                        if resource_type == "cloudwatch:alarm":
-                            end_of_arn = f"alarm:{resource.name}"
-                        elif resource_type == "cloudwatch:insight-rule":
-                            end_of_arn = f"insight-rule/{resource.name}"
-
-                        arn = f"arn:{get_partition(self.region_name)}:cloudwatch:{self.region_name}:{self.account_id}:{end_of_arn}"
-
-                        cw_tags = self.cloudwatch_backend.list_tags_for_resource(arn)
-
-                        tags = format_tags(cw_tags)
-                        if not tags or not tag_filter(tags):
-                            continue
-                        yield {
-                            "ResourceARN": arn,
-                            "Tags": tags,
-                        }
 
         # Connect Campaigns v1
         if self.connectcampaigns_backend:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.athena.models import athena_backends
 from moto.backup.models import BackupBackend, backup_backends
 from moto.clouddirectory import CloudDirectoryBackend, clouddirectory_backends
 from moto.cloudfront.models import CloudFrontBackend, cloudfront_backends
@@ -346,37 +345,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "ResourceARN": resource.arn,
                     "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
                 }
-
-        # Athena
-        if not resource_type_filters or "athena" in resource_type_filters:
-            athena_backend = athena_backends[self.account_id][self.region_name]
-
-            # Capacity Reservations
-            for capacity_reservation in athena_backend.capacity_reservations.values():
-                tags = athena_backend.tagger.list_tags_for_resource(
-                    capacity_reservation.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{capacity_reservation.arn}", "Tags": tags}
-
-            # Workgroups
-            for work_group in athena_backend.work_groups.values():
-                tags = athena_backend.tagger.list_tags_for_resource(work_group.arn)[
-                    "Tags"
-                ]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{work_group.arn}", "Tags": tags}
-
-            # Data Catalogs
-            for data_catalog in athena_backend.data_catalogs.values():
-                tags = athena_backend.tagger.list_tags_for_resource(data_catalog.arn)[
-                    "Tags"
-                ]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{data_catalog.arn}", "Tags": tags}
 
         # Backup
         if not resource_type_filters or "backup" in resource_type_filters:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -42,6 +42,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self,
         tag_filters: list[dict[str, Any]] | None = None,
         resource_type_filters: list[str] | None = None,
+        resource_arn_list: list[str] | None = None,
     ) -> Iterator[TaggedResource]:
         tag_matcher = make_tag_matcher(tag_filters)
         for backend in iter_taggable_backends(self.account_id, self.region_name):
@@ -62,6 +63,8 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 ):
                     continue
                 if not tag_matcher(resource.tags):
+                    continue
+                if resource_arn_list and resource.arn not in resource_arn_list:
                     continue
                 yield resource
 
@@ -84,6 +87,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         tags_per_page: int = 100,
         tag_filters: list[dict[str, Any]] | None = None,
         resource_type_filters: list[str] | None = None,
+        resource_arn_list: list[str] | None = None,
     ) -> tuple[str | None, list[TaggedResource]]:
         # If we have a token, go and find the respective generator, or error
         if pagination_token:
@@ -96,7 +100,9 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             left_over = self._pages[pagination_token]["misc"]
         else:
             generator = self._get_resources_generator(
-                tag_filters=tag_filters, resource_type_filters=resource_type_filters
+                tag_filters=tag_filters,
+                resource_type_filters=resource_type_filters,
+                resource_arn_list=resource_arn_list,
             )
             left_over = None
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,7 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.sqs.models import SQSBackend, sqs_backends
 from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
 from moto.ssm.utils import parameter_arn
 from moto.stepfunctions.models import StepFunctionBackend, stepfunctions_backends
@@ -61,10 +60,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def ssm_backend(self) -> SimpleSystemManagerBackend:
         return ssm_backends[self.account_id][self.region_name]
-
-    @property
-    def sqs_backend(self) -> SQSBackend:
-        return sqs_backends[self.account_id][self.region_name]
 
     @property
     def stepfunctions_backend(self) -> StepFunctionBackend:
@@ -189,21 +184,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # SQS
-        if (
-            not resource_type_filters
-            or "sqs" in resource_type_filters
-            or "sqs:queue" in resource_type_filters
-        ):
-            for queue in self.sqs_backend.queues.values():
-                tags = format_tags(queue.tags)
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {"ResourceARN": f"{queue.queue_arn}", "Tags": tags}
 
         # SSM Documents
         if (

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.elasticbeanstalk.models import EBBackend, eb_backends
 from moto.elb.models import ELBBackend, elb_backends
 from moto.elbv2.models import ELBv2Backend, elbv2_backends
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
@@ -63,10 +62,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def eb_backend(self) -> EBBackend:
-        return eb_backends[self.account_id][self.region_name]
 
     @property
     def elb_backend(self) -> ELBBackend:
@@ -287,23 +282,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         continue
                     yield {
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
-                        "Tags": tags,
-                    }
-
-        # ElasticBeanstalk
-        if (
-            not resource_type_filters
-            or "elasticbeanstalk:environment" in resource_type_filters
-        ):
-            for eb_application in self.eb_backend.applications.values():
-                for eb_environment in eb_application.environments.values():
-                    tags = [
-                        {"Key": k, "Value": v} for k, v in eb_environment.tags.items()
-                    ]
-                    if not tag_filter(tags):
-                        continue
-                    yield {
-                        "ResourceARN": f"{eb_environment.environment_arn}",
                         "Tags": tags,
                     }
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,10 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.connectcampaigns.models import (
-    ConnectCampaignServiceBackend,
-    connectcampaigns_backends,
-)
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.resource_tagging import (
     TaggableResourcesMixin,
@@ -207,13 +203,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return swf_backends[self.account_id][self.region_name]
 
     @property
-    def connectcampaigns_backend(self) -> ConnectCampaignServiceBackend | None:
-        # Connect Campaigns service has limited region availability
-        if self.region_name in connectcampaigns_backends[self.account_id].regions:
-            return connectcampaigns_backends[self.account_id][self.region_name]
-        return None
-
-    @property
     def quicksight_backend(self) -> QuickSightBackend | None:
         if self.region_name in quicksight_backends[self.account_id].regions:
             return quicksight_backends[self.account_id][self.region_name]
@@ -330,20 +319,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # Connect Campaigns v1
-        if self.connectcampaigns_backend:
-            if not resource_type_filters or "connectcampaigns" in resource_type_filters:
-                connectcampaigns_backend: ConnectCampaignServiceBackend = (
-                    connectcampaigns_backends[self.account_id][self.region_name]
-                )
-                for campaign in connectcampaigns_backend.campaigns.values():
-                    tags = connectcampaigns_backend.tagger.list_tags_for_resource(
-                        campaign.arn
-                    )["Tags"]
-                    if not tags or not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{campaign.arn}", "Tags": tags}
 
         # Direct Connect
         if self.directconnect_backend:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.ecs.models import EC2ContainerServiceBackend, ecs_backends
 from moto.efs.models import EFSBackend, efs_backends
 from moto.elasticache.models import ElastiCacheBackend, elasticache_backends
 from moto.elasticbeanstalk.models import EBBackend, eb_backends
@@ -122,10 +121,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def ecs_backend(self) -> EC2ContainerServiceBackend:
-        return ecs_backends[self.account_id][self.region_name]
 
     @property
     def firehose_backend(self) -> FirehoseBackend:
@@ -304,37 +299,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # ECS
-        if not resource_type_filters or "ecs:service" in resource_type_filters:
-            for service in self.ecs_backend.services.values():
-                tags = format_tag_keys(service.tags, ["key", "value"])
-                if not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{service.physical_resource_id}", "Tags": tags}
-
-        if not resource_type_filters or "ecs:cluster" in resource_type_filters:
-            for cluster in self.ecs_backend.clusters.values():
-                tags = format_tag_keys(cluster.tags, ["key", "value"])  # type: ignore[arg-type]
-                if not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{cluster.arn}", "Tags": tags}
-
-        if not resource_type_filters or "ecs:task" in resource_type_filters:
-            for task_dict in self.ecs_backend.tasks.values():
-                for task in task_dict.values():
-                    tags = format_tag_keys(task.tags, ["key", "value"])
-                    if not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{task.task_arn}", "Tags": tags}
-
-        if not resource_type_filters or "ecs:task-definition" in resource_type_filters:
-            for task_definition_dict in self.ecs_backend.task_definitions.values():
-                for task_definition in task_definition_dict.values():
-                    tags = format_tag_keys(task_definition.tags, ["key", "value"])
-                    if not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{task_definition.arn}", "Tags": tags}
 
         # EFS, resource type elasticfilesystem:access-point
         if (

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.clouddirectory import CloudDirectoryBackend, clouddirectory_backends
 from moto.cloudfront.models import CloudFrontBackend, cloudfront_backends
 from moto.cloudwatch.models import CloudWatchBackend, cloudwatch_backends
 from moto.comprehend.models import ComprehendBackend, comprehend_backends
@@ -214,12 +213,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return None
 
     @property
-    def clouddirectory_backend(self) -> CloudDirectoryBackend | None:
-        if self.region_name in clouddirectory_backends[self.account_id].regions:
-            return clouddirectory_backends[self.account_id][self.region_name]
-        return None
-
-    @property
     def cloudfront_backend(self) -> CloudFrontBackend:
         return cloudfront_backends[self.account_id][self.partition]
 
@@ -393,20 +386,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         if not tag_filter(tags):
                             continue
                         yield {"ResourceARN": f"{arn}", "Tags": tags}
-
-        # Cloud Directory
-        if self.clouddirectory_backend:
-            if not resource_type_filters or "clouddirectory" in resource_type_filters:
-                clouddirectory_backend = clouddirectory_backends[self.account_id][
-                    self.region_name
-                ]
-                for directory in clouddirectory_backend.directories.values():
-                    tags = clouddirectory_backend.tagger.list_tags_for_resource(
-                        directory.directory_arn
-                    )["Tags"]
-                    if not tags or not tag_filter(tags):
-                        continue
-                    yield {"ResourceARN": f"{directory.directory_arn}", "Tags": tags}
 
         # Firehose
         if self.firehose_backend:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -9,7 +9,6 @@ from moto.core.resource_tagging import (
     match_resource_type,
 )
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
-from moto.events.models import EventsBackend, events_backends
 from moto.firehose.models import FirehoseBackend, firehose_backends
 from moto.fsx.models import FSxBackend, fsx_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
@@ -60,10 +59,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def events_backend(self) -> EventsBackend:
-        return events_backends[self.account_id][self.region_name]
 
     @property
     def glue_backend(self) -> GlueBackend:
@@ -276,22 +271,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     }
 
         # EMR Cluster
-
-        # Events
-        if (
-            not resource_type_filters
-            or "events" in resource_type_filters
-            or "events:event-bus" in resource_type_filters
-        ):
-            for bus in self.events_backend.event_buses.values():
-                tags = self.events_backend.tagger.list_tags_for_resource(bus.arn)[
-                    "Tags"
-                ]
-                if (
-                    not tag_filter(tags) or len(tags) == 0
-                ):  # Skip if no tags, or invalid filter
-                    continue
-                yield {"ResourceARN": f"{bus.arn}", "Tags": tags}
 
         # FSx
         if not resource_type_filters or "fsx" in resource_type_filters:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.acm.models import AWSCertificateManagerBackend, acm_backends
 from moto.appsync.models import AppSyncBackend, appsync_backends
 from moto.athena.models import athena_backends
 from moto.backup.models import BackupBackend, backup_backends
@@ -157,10 +156,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def firehose_backend(self) -> FirehoseBackend:
         return firehose_backends[self.account_id][self.region_name]
-
-    @property
-    def acm_backend(self) -> AWSCertificateManagerBackend:
-        return acm_backends[self.account_id][self.region_name]
 
     @property
     def secretsmanager_backend(self) -> SecretsManagerBackend:
@@ -356,13 +351,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "ResourceARN": resource.arn,
                     "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
                 }
-        # ACM
-        if not resource_type_filters or "acm" in resource_type_filters:
-            for certificate in self.acm_backend._certificates.values():
-                tags = format_tags(certificate.tags)
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{certificate.arn}", "Tags": tags}
 
         # AppSync
         if not resource_type_filters or "appsync" in resource_type_filters:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,9 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.utilities.tagging_service import TaggingService
-from moto.utilities.utils import get_partition
-from moto.workspacesweb.models import WorkSpacesWebBackend, workspacesweb_backends
 
 # Left: EC2 RDS ELB Lambda EMR Glacier Kinesis Redshift Route53
 # StorageGateway MachineLearning ACM DirectoryService CloudHSM
@@ -50,13 +47,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def workspacesweb_backends(self) -> WorkSpacesWebBackend | None:
-        # WorkspacesWeb service has limited region availability
-        if self.region_name in workspacesweb_backends[self.account_id].regions:
-            return workspacesweb_backends[self.account_id][self.region_name]
-        return None
 
     def _get_backend_for_resource(
         self, resource_arn: str
@@ -155,21 +145,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # Workspaces Web
-        if self.workspacesweb_backends and (
-            not resource_type_filters or "workspaces-web" in resource_type_filters
-        ):
-            for portal in self.workspacesweb_backends.portals.values():
-                tags = self.workspacesweb_backends.tagger.list_tags_for_resource(
-                    portal.arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {
-                    "ResourceARN": f"arn:{get_partition(self.region_name)}:workspaces-web:{self.region_name}:{self.account_id}:portal/{portal.portal_id}",
-                    "Tags": tags,
-                }
 
     def _get_tag_keys_generator(self) -> Iterator[str]:
         # Look at
@@ -376,13 +351,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 except NotImplementedError:
                     missing_resources.append(arn)
                 continue
-            if arn.startswith(f"arn:{get_partition(self.region_name)}:workspaces-web:"):
-                resource_id = arn.split("/")[-1]
-                self.workspacesweb_backends.create_tags(  # type: ignore[union-attr]
-                    resource_id, TaggingService.convert_dict_to_tags_input(tags)
-                )
-            else:
-                missing_resources.append(arn)
         return dict.fromkeys(missing_resources, missing_error)
 
     def untag_resources(

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -9,7 +9,6 @@ from moto.core.resource_tagging import (
     match_resource_type,
 )
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
-from moto.fsx.models import FSxBackend, fsx_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
 from moto.glue.models import GlueBackend, glue_backends
 from moto.kafka.models import KafkaBackend, kafka_backends
@@ -78,10 +77,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def logs_backend(self) -> LogsBackend:
         return logs_backends[self.account_id][self.region_name]
-
-    @property
-    def fsx_backends(self) -> FSxBackend:
-        return fsx_backends[self.account_id][self.region_name]
 
     @property
     def glacier_backend(self) -> GlacierBackend:
@@ -251,26 +246,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 }
 
         # EMR Cluster
-
-        # FSx
-        if not resource_type_filters or "fsx" in resource_type_filters:
-            # File system
-            for file_system in self.fsx_backends.file_systems.values():
-                tags = self.fsx_backends.tagger.list_tags_for_resource(
-                    file_system.resource_arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{file_system.resource_arn}", "Tags": tags}
-
-            # Backup
-            for backup in self.fsx_backends.backups.values():
-                tags = self.fsx_backends.tagger.list_tags_for_resource(
-                    backup.resource_arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{backup.resource_arn}", "Tags": tags}
 
         # Glacier Vault
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.elb.models import ELBBackend, elb_backends
 from moto.elbv2.models import ELBv2Backend, elbv2_backends
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.events.models import EventsBackend, events_backends
@@ -62,10 +61,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def elb_backend(self) -> ELBBackend:
-        return elb_backends[self.account_id][self.region_name]
 
     @property
     def elbv2_backend(self) -> ELBv2Backend:
@@ -284,24 +279,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # ELB (Classic Load Balancers)
-        if (
-            not resource_type_filters
-            or "elb" in resource_type_filters
-            or "elb:loadbalancer" in resource_type_filters
-        ):
-            for elb in self.elb_backend.load_balancers.values():
-                tags = format_tags(elb.tags)
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {
-                    "ResourceARN": f"arn:{get_partition(self.region_name)}:elasticloadbalancing:{self.region_name}:{self.account_id}:loadbalancer/{elb.name}",
-                    "Tags": tags,
-                }
 
         # TODO add these to the keys and values functions / combine functions
         # ELB, resource type elasticloadbalancing:loadbalancer

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -18,7 +18,6 @@ from moto.resourcegroupstaggingapi.exceptions import (
 )
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
-from moto.workspaces.models import WorkSpacesBackend, workspaces_backends
 from moto.workspacesweb.models import WorkSpacesWebBackend, workspacesweb_backends
 
 # Left: EC2 RDS ELB Lambda EMR Glacier Kinesis Redshift Route53
@@ -51,13 +50,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def workspaces_backend(self) -> WorkSpacesBackend | None:
-        # Workspaces service has limited region availability
-        if self.region_name in workspaces_backends[self.account_id].regions:
-            return workspaces_backends[self.account_id][self.region_name]
-        return None
 
     @property
     def workspacesweb_backends(self) -> WorkSpacesWebBackend | None:
@@ -163,54 +155,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # Workspaces
-        if self.workspaces_backend and (
-            not resource_type_filters or "workspaces" in resource_type_filters
-        ):
-            for ws in self.workspaces_backend.workspaces.values():
-                tags = format_tag_keys(ws.tags, ["Key", "Value"])
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {
-                    "ResourceARN": f"arn:{get_partition(self.region_name)}:workspaces:{self.region_name}:{self.account_id}:workspace/{ws.workspace_id}",
-                    "Tags": tags,
-                }
-
-        # Workspace Directories
-        if self.workspaces_backend and (
-            not resource_type_filters or "workspaces-directory" in resource_type_filters
-        ):
-            for wd in self.workspaces_backend.workspace_directories.values():
-                tags = format_tag_keys(wd.tags, ["Key", "Value"])
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {
-                    "ResourceARN": f"arn:{get_partition(self.region_name)}:workspaces:{self.region_name}:{self.account_id}:directory/{wd.directory_id}",
-                    "Tags": tags,
-                }
-
-        # Workspace Images
-        if self.workspaces_backend and (
-            not resource_type_filters or "workspaces-image" in resource_type_filters
-        ):
-            for wi in self.workspaces_backend.workspace_images.values():
-                tags = format_tag_keys(wi.tags, ["Key", "Value"])
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {
-                    "ResourceARN": f"arn:{get_partition(self.region_name)}:workspaces:{self.region_name}:{self.account_id}:workspaceimage/{wi.image_id}",
-                    "Tags": tags,
-                }
 
         # Workspaces Web
         if self.workspacesweb_backends and (
@@ -435,11 +379,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
             if arn.startswith(f"arn:{get_partition(self.region_name)}:workspaces-web:"):
                 resource_id = arn.split("/")[-1]
                 self.workspacesweb_backends.create_tags(  # type: ignore[union-attr]
-                    resource_id, TaggingService.convert_dict_to_tags_input(tags)
-                )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:workspaces:"):
-                resource_id = arn.split("/")[-1]
-                self.workspaces_backend.create_tags(  # type: ignore[union-attr]
                     resource_id, TaggingService.convert_dict_to_tags_input(tags)
                 )
             else:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -9,7 +9,6 @@ from moto.core.resource_tagging import (
     match_resource_type,
 )
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
-from moto.firehose.models import FirehoseBackend, firehose_backends
 from moto.fsx.models import FSxBackend, fsx_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
 from moto.glue.models import GlueBackend, glue_backends
@@ -95,10 +94,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def firehose_backend(self) -> FirehoseBackend:
-        return firehose_backends[self.account_id][self.region_name]
 
     @property
     def secretsmanager_backend(self) -> SecretsManagerBackend:
@@ -254,21 +249,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "ResourceARN": resource.arn,
                     "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
                 }
-
-        # Firehose
-        if self.firehose_backend:
-            if not resource_type_filters or "firehose" in resource_type_filters:
-                firehose_backend = firehose_backends[self.account_id][self.region_name]
-                for delivery_stream in firehose_backend.delivery_streams.values():
-                    tags = firehose_backend.tagger.list_tags_for_resource(
-                        delivery_stream.delivery_stream_arn
-                    )["Tags"]
-                    if not tags or not tag_filter(tags):
-                        continue
-                    yield {
-                        "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
-                        "Tags": tags,
-                    }
 
         # EMR Cluster
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.dynamodb.models import DynamoDBBackend, dynamodb_backends
 from moto.ecs.models import EC2ContainerServiceBackend, ecs_backends
 from moto.efs.models import EFSBackend, efs_backends
 from moto.elasticache.models import ElastiCacheBackend, elasticache_backends
@@ -54,7 +53,7 @@ from moto.workspaces.models import WorkSpacesBackend, workspaces_backends
 from moto.workspacesweb.models import WorkSpacesWebBackend, workspacesweb_backends
 
 # Left: EC2 RDS ELB Lambda EMR Glacier Kinesis Redshift Route53
-# StorageGateway DynamoDB MachineLearning ACM DirectoryService CloudHSM
+# StorageGateway MachineLearning ACM DirectoryService CloudHSM
 # Inspector Elasticsearch
 
 
@@ -155,10 +154,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def stepfunctions_backend(self) -> StepFunctionBackend:
         return stepfunctions_backends[self.account_id][self.region_name]
-
-    @property
-    def dynamodb_backend(self) -> DynamoDBBackend:
-        return dynamodb_backends[self.account_id][self.region_name]
 
     @property
     def workspaces_backend(self) -> WorkSpacesBackend | None:
@@ -981,21 +976,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "Tags": tags,
                 }
 
-        if (
-            not resource_type_filters
-            or "dynamodb" in resource_type_filters
-            or "dynamodb:table" in resource_type_filters
-        ):
-            for table in self.dynamodb_backend.tables.values():
-                tags = table.tags
-
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {
-                    "ResourceARN": table.table_arn,
-                    "Tags": tags,
-                }
-
         # sagemaker cluster, automljob, compilation-job, domain, model-explainability-job-definition, model-quality-job-definition, and hyper-parameter-tuning-job currently supported
         sagemaker_resource_map: dict[str, dict[str, Any]] = {
             "sagemaker:cluster": self.sagemaker_backend.clusters,
@@ -1238,7 +1218,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self, resource_arns: list[str], tags: dict[str, str]
     ) -> dict[str, dict[str, Any]]:
         """
-        Only DynamoDB, EFS, Elasticache, Lambda, Logs, Quicksight, RDS, SageMaker, SES, and SWF resources are currently supported
+        Only EFS, Elasticache, Lambda, Logs, Quicksight, RDS, SageMaker, SES, and SWF resources are currently supported
         """
         missing_resources = []
         missing_error: dict[str, Any] = {
@@ -1267,10 +1247,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 )
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:logs:"):
                 self.logs_backend.tag_resource(arn, tags)
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:dynamodb"):
-                self.dynamodb_backend.tag_resource(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
-                )
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:sagemaker:"):
                 self.sagemaker_backend.add_tags(
                     arn, TaggingService.convert_dict_to_tags_input(tags)

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -10,7 +10,6 @@ from moto.core.resource_tagging import (
 )
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
-from moto.kafka.models import KafkaBackend, kafka_backends
 from moto.kinesis.models import KinesisBackend, kinesis_backends
 from moto.kinesisanalyticsv2.models import (
     KinesisAnalyticsV2Backend,
@@ -122,10 +121,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         if self.region_name in workspacesweb_backends[self.account_id].regions:
             return workspacesweb_backends[self.account_id][self.region_name]
         return None
-
-    @property
-    def kafka_backend(self) -> KafkaBackend:
-        return kafka_backends[self.account_id][self.region_name]
 
     @property
     def sagemaker_backend(self) -> SageMakerModelBackend:
@@ -663,22 +658,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
                 yield {
                     "ResourceARN": f"arn:{get_partition(self.region_name)}:workspaces:{self.region_name}:{self.account_id}:workspaceimage/{wi.image_id}",
-                    "Tags": tags,
-                }
-
-        # Kafka (MSK)
-        if self.kafka_backend and (
-            not resource_type_filters or "kafka" in resource_type_filters
-        ):
-            for msk_cluster in self.kafka_backend.clusters.values():
-                tag_dict = self.kafka_backend.list_tags_for_resource(msk_cluster.arn)
-                tags = [{"Key": key, "Value": value} for key, value in tag_dict.items()]
-
-                if not tags or not tag_filter(tags):
-                    continue
-
-                yield {
-                    "ResourceARN": msk_cluster.arn,
                     "Tags": tags,
                 }
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,7 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.sesv2.models import SESV2Backend, sesv2_backends
 from moto.sns.models import SNSBackend, sns_backends
 from moto.sqs.models import SQSBackend, sqs_backends
 from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
@@ -97,10 +96,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def vpclattice_backend(self) -> VPCLatticeBackend:
         return vpclattice_backends[self.account_id][self.region_name]
-
-    @property
-    def sesv2_backend(self) -> SESV2Backend:
-        return sesv2_backends[self.account_id][self.region_name]
 
     def _get_backend_for_resource(
         self, resource_arn: str
@@ -215,44 +210,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
                 yield {"ResourceARN": f"{queue.queue_arn}", "Tags": tags}
 
-        if self.sesv2_backend:
-            sesv2_resource_map: dict[str, dict[str, Any]] = {
-                "ses:configuration-set": self.sesv2_backend.core_backend.config_sets,
-                "ses:contact-list": self.sesv2_backend.core_backend.contacts_lists,
-                "ses:dedicated-ip-pool": self.sesv2_backend.core_backend.dedicated_ip_pools,
-                "ses:email-identity": self.sesv2_backend.core_backend.email_identities,
-            }
-
-            resource_id_attr_map: dict[str, str] = {
-                "ses:configuration-set": "configuration_set_name",
-                "ses:contact-list": "contact_list_name",
-                "ses:dedicated-ip-pool": "pool_name",
-                "ses:email-identity": "email_identity",
-            }
-
-            for resource_type, resource_source in sesv2_resource_map.items():
-                if (
-                    not resource_type_filters
-                    or "ses" in resource_type_filters
-                    or resource_type in resource_type_filters
-                ):
-                    for resource in resource_source.values():
-                        resource_id_attr = resource_id_attr_map[resource_type]
-                        resource_id = getattr(resource, resource_id_attr)
-
-                        arn = f"arn:{get_partition(self.region_name)}:ses:{self.region_name}:{self.account_id}:{resource_type.split(':')[-1]}/{resource_id}"
-
-                        tags = self.sesv2_backend.core_backend.tagger.list_tags_for_resource(
-                            arn
-                        )["Tags"]
-
-                        if not tags or not tag_filter(tags):
-                            continue
-
-                        yield {
-                            "ResourceARN": arn,
-                            "Tags": tags,
-                        }
         # SNS
         if not resource_type_filters or "sns" in resource_type_filters:
             for topic in self.sns_backend.topics.values():
@@ -706,10 +663,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.workspaces_backend.create_tags(  # type: ignore[union-attr]
                     resource_id, TaggingService.convert_dict_to_tags_input(tags)
                 )
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
-                self.sesv2_backend.tag_resource(
-                    arn, TaggingService.convert_dict_to_tags_input(tags)
-                )
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
                 self.swf_backend.tagger.tag_resource(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
@@ -739,9 +692,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 except NotImplementedError:
                     missing_resources.append(arn)
                 continue
-            if arn.startswith(f"arn:{get_partition(self.region_name)}:ses:"):
-                self.sesv2_backend.untag_resource(arn, tag_keys)
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
+            if arn.startswith(f"arn:{get_partition(self.region_name)}:swf:"):
                 self.swf_backend.tagger.untag_resource_using_names(arn, tag_keys)
             else:
                 missing_resources.append(arn)

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -16,8 +16,6 @@ from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-from moto.ssm.models import SimpleSystemManagerBackend, ssm_backends
-from moto.ssm.utils import parameter_arn
 from moto.stepfunctions.models import StepFunctionBackend, stepfunctions_backends
 from moto.swf.models import SWFBackend, swf_backends
 from moto.utilities.tagging_service import TaggingService
@@ -56,10 +54,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def redshift_backend(self) -> RedshiftBackend:
         return redshift_backends[self.account_id][self.region_name]
-
-    @property
-    def ssm_backend(self) -> SimpleSystemManagerBackend:
-        return ssm_backends[self.account_id][self.region_name]
 
     @property
     def stepfunctions_backend(self) -> StepFunctionBackend:
@@ -184,45 +178,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # RedShift Parameter group
         # RedShift Snapshot
         # RedShift Subnet group
-
-        # SSM Documents
-        if (
-            not resource_type_filters
-            or "ssm" in resource_type_filters
-            or "ssm:document" in resource_type_filters
-        ):
-            for document in self.ssm_backend._documents.values():
-                doc_name = document.describe()["Name"]
-                tags = self.ssm_backend._get_documents_tags(doc_name)
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-                yield {
-                    "ResourceARN": f"arn:{get_partition(self.region_name)}:ssm:{self.region_name}:{self.account_id}:document/{doc_name}",
-                    "Tags": tags,
-                }
-
-        # SSM Parameters
-        if (
-            not resource_type_filters
-            or "ssm" in resource_type_filters
-            or "ssm:parameter" in resource_type_filters
-        ):
-            for param_name in self.ssm_backend._parameters:
-                tags = format_tags(
-                    self.ssm_backend.list_tags_for_resource("Parameter", param_name)
-                )
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-                yield {
-                    "ResourceARN": parameter_arn(
-                        self.account_id, self.region_name, param_name
-                    ),
-                    "Tags": tags,
-                }
 
         # Step Functions
         if not resource_type_filters or "states:stateMachine" in resource_type_filters:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -4,22 +4,15 @@ from typing import Any
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.resource_tagging import (
     TaggableResourcesMixin,
+    TaggedResource,
     iter_taggable_backends,
     make_tag_matcher,
     match_resource_type,
 )
-from moto.emr.models import ElasticMapReduceBackend, emr_backends
-from moto.glacier.models import GlacierBackend, glacier_backends
-from moto.kinesis.models import KinesisBackend, kinesis_backends
 from moto.moto_api._internal import mock_random
-from moto.redshift.models import RedshiftBackend, redshift_backends
 from moto.resourcegroupstaggingapi.exceptions import (
     ResourceGroupsTaggingAPIError as RESTError,
 )
-
-# Left: EC2 RDS ELB Lambda EMR Glacier Kinesis Redshift Route53
-# StorageGateway MachineLearning ACM DirectoryService CloudHSM
-# Inspector Elasticsearch
 
 
 class ResourceGroupsTaggingAPIBackend(BaseBackend):
@@ -31,22 +24,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def kinesis_backend(self) -> KinesisBackend:
-        return kinesis_backends[self.account_id][self.region_name]
-
-    @property
-    def glacier_backend(self) -> GlacierBackend:
-        return glacier_backends[self.account_id][self.region_name]
-
-    @property
-    def emr_backend(self) -> ElasticMapReduceBackend:
-        return emr_backends[self.account_id][self.region_name]
-
-    @property
-    def redshift_backend(self) -> RedshiftBackend:
-        return redshift_backends[self.account_id][self.region_name]
 
     def _get_backend_for_resource(
         self, resource_arn: str
@@ -65,61 +42,19 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         self,
         tag_filters: list[dict[str, Any]] | None = None,
         resource_type_filters: list[str] | None = None,
-    ) -> Iterator[dict[str, Any]]:
-        # Look at
-        # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-
-        # TODO move these to their respective backends
-        filters = []
-        for tag_filter_dict in tag_filters:  # type: ignore
-            values = tag_filter_dict.get("Values", [])
-            if len(values) == 0:
-                # Check key matches
-                filters.append(lambda t, v, key=tag_filter_dict["Key"]: t == key)
-            elif len(values) == 1:
-                # Check it's exactly the same as key, value
-                filters.append(
-                    lambda t, v, key=tag_filter_dict["Key"], value=values[0]: t == key  # type: ignore
-                    and v == value
-                )
-            else:
-                # Check key matches and value is one of the provided values
-                filters.append(
-                    lambda t, v, key=tag_filter_dict["Key"], vl=values: t == key  # type: ignore
-                    and v in vl
-                )
-
-        def tag_filter(tag_list: list[dict[str, Any]]) -> bool:
-            result = []
-            if tag_filters:
-                for f in filters:
-                    temp_result = []
-                    for tag in tag_list:
-                        f_result = f(tag["Key"], tag["Value"])  # type: ignore
-                        temp_result.append(f_result)
-                    result.append(any(temp_result))
-                return all(result)
-            else:
-                return True
-
-        def format_tags(tags: dict[str, Any]) -> list[dict[str, Any]]:
-            result = []
-            for key, value in tags.items():
-                result.append({"Key": key, "Value": value})
-            return result
-
-        def format_tag_keys(
-            tags: list[dict[str, Any]], keys: list[str]
-        ) -> list[dict[str, Any]]:
-            result = []
-            for tag in tags:
-                result.append({"Key": tag[keys[0]], "Value": tag[keys[1]]})
-            return result
-
-        # Services opted in via TaggableResourcesMixin
+    ) -> Iterator[TaggedResource]:
         tag_matcher = make_tag_matcher(tag_filters)
         for backend in iter_taggable_backends(self.account_id, self.region_name):
             for resource in backend.iter_tagged_resources():
+                # https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html
+                # According to the docs, GetResources returns all "tagged or previously tagged" resources.
+                # This means that even though generally resources without tags are not returned, a resource
+                # that had been tagged and then had all of its tags deleted would be returned.
+                # Historically, Moto has not supported this behavior and has been inconsistent across
+                # service backends with respect to returning resources without tags (some do, some don't).
+                # The extra "include_untagged" here allows backends to decide whether resources without
+                # tags should be returned.
+                # TODO: apply consistent behavior for untagged resources that matches real AWS.
                 if not resource.tags and not resource.extra.get("include_untagged"):
                     continue
                 if not match_resource_type(
@@ -128,38 +63,14 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     continue
                 if not tag_matcher(resource.tags):
                     continue
-                yield {
-                    "ResourceARN": resource.arn,
-                    "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
-                }
-
-        # EMR Cluster
-
-        # Glacier Vault
-
-        # Kinesis
-
-        # RedShift Cluster
-        # RedShift Hardware security module (HSM) client certificate
-        # RedShift HSM connection
-        # RedShift Parameter group
-        # RedShift Snapshot
-        # RedShift Subnet group
+                yield resource
 
     def _get_tag_keys_generator(self) -> Iterator[str]:
-        # Look at
-        # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-
-        # Services opted in via TaggableResourcesMixin
         for backend in iter_taggable_backends(self.account_id, self.region_name):
             for resource in backend.iter_tagged_resources():
                 yield from resource.tags.keys()
 
     def _get_tag_values_generator(self, tag_key: str) -> Iterator[str]:
-        # Look at
-        # https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
-
-        # Services opted in via TaggableResourcesMixin
         for backend in iter_taggable_backends(self.account_id, self.region_name):
             for resource in backend.iter_tagged_resources():
                 for key, value in resource.tags.items():
@@ -173,17 +84,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         tags_per_page: int = 100,
         tag_filters: list[dict[str, Any]] | None = None,
         resource_type_filters: list[str] | None = None,
-    ) -> tuple[str | None, list[dict[str, Any]]]:
-        # Simple range checking
-        if 100 >= tags_per_page >= 500:
-            raise RESTError(
-                "InvalidParameterException", "TagsPerPage must be between 100 and 500"
-            )
-        if 1 >= resources_per_page >= 50:
-            raise RESTError(
-                "InvalidParameterException", "ResourcesPerPage must be between 1 and 50"
-            )
-
+    ) -> tuple[str | None, list[TaggedResource]]:
         # If we have a token, go and find the respective generator, or error
         if pagination_token:
             if pagination_token not in self._pages:
@@ -205,13 +106,11 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         if left_over:
             result.append(left_over)
             current_resources += 1
-            current_tags += len(left_over["Tags"])
 
         try:
             while True:
-                # Generator format: [{'ResourceARN': str, 'Tags': [{'Key': str, 'Value': str]}, ...]
                 next_item = next(generator)
-                resource_tags = len(next_item["Tags"])
+                resource_tags = len(next_item.tags)
 
                 if current_resources >= resources_per_page:
                     break
@@ -234,6 +133,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Token used up, might as well bin now, if you call it again you're an idiot
         if pagination_token:
             del self._pages[pagination_token]
+
         return new_token, result
 
     def get_tag_keys(
@@ -333,9 +233,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     def tag_resources(
         self, resource_arns: list[str], tags: dict[str, str]
     ) -> dict[str, dict[str, Any]]:
-        """
-        Only EFS, Elasticache, Lambda, Logs, Quicksight, RDS, SageMaker, SES, and SWF resources are currently supported
-        """
         missing_resources = []
         missing_error: dict[str, Any] = {
             "StatusCode": 404,
@@ -345,20 +242,18 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
         for arn in resource_arns:
             backend_for_arn = self._get_backend_for_resource(arn)
-            if backend_for_arn is not None:
-                try:
-                    backend_for_arn.tag_resource(arn, tags)
-                except NotImplementedError:
-                    missing_resources.append(arn)
+            if backend_for_arn is None:
+                missing_resources.append(arn)
                 continue
+            try:
+                backend_for_arn.tag_resource(arn, tags)
+            except NotImplementedError:
+                missing_resources.append(arn)
         return dict.fromkeys(missing_resources, missing_error)
 
     def untag_resources(
         self, resource_arn_list: list[str], tag_keys: list[str]
     ) -> dict[str, dict[str, Any]]:
-        """
-        Only EFS, Elasticache, Lambda, Quicksight, SES, and SWF resources are currently supported
-        """
         missing_resources = []
         missing_error: dict[str, Any] = {
             "StatusCode": 404,
@@ -368,12 +263,13 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
 
         for arn in resource_arn_list:
             backend_for_arn = self._get_backend_for_resource(arn)
-            if backend_for_arn is not None:
-                try:
-                    backend_for_arn.untag_resource(arn, tag_keys)
-                except NotImplementedError:
-                    missing_resources.append(arn)
+            if backend_for_arn is None:
+                missing_resources.append(arn)
                 continue
+            try:
+                backend_for_arn.untag_resource(arn, tag_keys)
+            except NotImplementedError:
+                missing_resources.append(arn)
 
         return dict.fromkeys(missing_resources, missing_error)
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.elbv2.models import ELBv2Backend, elbv2_backends
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.events.models import EventsBackend, events_backends
 from moto.firehose.models import FirehoseBackend, firehose_backends
@@ -61,10 +60,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def elbv2_backend(self) -> ELBv2Backend:
-        return elbv2_backends[self.account_id][self.region_name]
 
     @property
     def events_backend(self) -> EventsBackend:
@@ -279,37 +274,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # TODO add these to the keys and values functions / combine functions
-        # ELB, resource type elasticloadbalancing:loadbalancer
-        if (
-            not resource_type_filters
-            or "elasticloadbalancing" in resource_type_filters
-            or "elasticloadbalancing:loadbalancer" in resource_type_filters
-        ):
-            for elbv2 in self.elbv2_backend.load_balancers.values():
-                tags = self.elbv2_backend.tagging_service.list_tags_for_resource(
-                    elbv2.arn
-                )["Tags"]
-                if not tag_filter(tags):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {"ResourceARN": f"{elbv2.arn}", "Tags": tags}
-
-        # ELB Target Group, resource type elasticloadbalancing:targetgroup
-        if (
-            not resource_type_filters
-            or "elasticloadbalancing" in resource_type_filters
-            or "elasticloadbalancing:targetgroup" in resource_type_filters
-        ):
-            for target_group in self.elbv2_backend.target_groups.values():
-                tags = self.elbv2_backend.tagging_service.list_tags_for_resource(
-                    target_group.arn
-                )["Tags"]
-                if not tag_filter(tags):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {"ResourceARN": f"{target_group.arn}", "Tags": tags}
 
         # EMR Cluster
 

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -11,10 +11,6 @@ from moto.core.resource_tagging import (
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
 from moto.kinesis.models import KinesisBackend, kinesis_backends
-from moto.kinesisanalyticsv2.models import (
-    KinesisAnalyticsV2Backend,
-    kinesisanalyticsv2_backends,
-)
 from moto.kms.models import KmsBackend, kms_backends
 from moto.lexv2models.models import LexModelsV2Backend, lexv2models_backends
 from moto.logs.models import LogsBackend, logs_backends
@@ -59,10 +55,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def kinesis_backend(self) -> KinesisBackend:
         return kinesis_backends[self.account_id][self.region_name]
-
-    @property
-    def kinesisanalyticsv2_backend(self) -> KinesisAnalyticsV2Backend:
-        return kinesisanalyticsv2_backends[self.account_id][self.region_name]
 
     @property
     def kms_backend(self) -> KmsBackend:
@@ -240,21 +232,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Glacier Vault
 
         # Kinesis
-
-        # KinesisAnalyticsV2
-        if self.kinesisanalyticsv2_backend and (
-            not resource_type_filters or "kinesisanalyticsv2" in resource_type_filters
-        ):
-            for application in self.kinesisanalyticsv2_backend.applications.values():
-                tags = self.kinesisanalyticsv2_backend.tagger.list_tags_for_resource(
-                    application.application_arn
-                )["Tags"]
-                if not tags or not tag_filter(tags):
-                    continue
-                yield {
-                    "ResourceARN": application.application_arn,
-                    "Tags": tags,
-                }
 
         # KMS
         if (

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.comprehend.models import ComprehendBackend, comprehend_backends
 from moto.connectcampaigns.models import (
     ConnectCampaignServiceBackend,
     connectcampaigns_backends,
@@ -190,13 +189,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         return None
 
     @property
-    def comprehend_backend(self) -> ComprehendBackend | None:
-        # aws Comprehend has limited region availability
-        if self.region_name in comprehend_backends[self.account_id].regions:
-            return comprehend_backends[self.account_id][self.region_name]
-        return None
-
-    @property
     def kafka_backend(self) -> KafkaBackend:
         return kafka_backends[self.account_id][self.region_name]
 
@@ -323,59 +315,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "ResourceARN": resource.arn,
                     "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
                 }
-
-        # Comprehend
-        if self.comprehend_backend:
-            comprehend_resource_map: dict[str, dict[str, Any]] = {
-                "comprehend:document-classification-job": dict(
-                    self.comprehend_backend.jobs
-                ),
-                "comprehend:document-classifier": dict(
-                    self.comprehend_backend.classifiers
-                ),
-                "comprehend:dominant-language-detection-job": dict(
-                    self.comprehend_backend.jobs
-                ),
-                "comprehend:entity-recognizer": dict(
-                    self.comprehend_backend.recognizers
-                ),
-                "comprehend:entities-detection-job": dict(self.comprehend_backend.jobs),
-                "comprehend:endpoint": dict(self.comprehend_backend.endpoints),
-                "comprehend:events-detection-job": dict(self.comprehend_backend.jobs),
-                "comprehend:flywheel": dict(self.comprehend_backend.flywheels),
-                "comprehend:key-phrases-detection-job": dict(
-                    self.comprehend_backend.jobs
-                ),
-                "comprehend:pii-entities-detection-job": dict(
-                    self.comprehend_backend.jobs
-                ),
-                "comprehend:sentiment-detection-job": dict(
-                    self.comprehend_backend.jobs
-                ),
-                "comprehend:targeted-sentiment-detection-job": dict(
-                    self.comprehend_backend.jobs
-                ),
-                "comprehend:topic-detection-job": dict(self.comprehend_backend.jobs),
-            }
-            for resource_type, resource_source in comprehend_resource_map.items():
-                if (
-                    not resource_type_filters
-                    or "comprehend" in resource_type_filters
-                    or resource_type in resource_type_filters
-                ):
-                    for resource in resource_source.values():
-                        arn = getattr(resource, "arn", None) or getattr(
-                            resource, "job_arn", None
-                        )
-                        if not arn:
-                            continue
-
-                        tags = self.comprehend_backend.tagger.list_tags_for_resource(
-                            arn
-                        )["Tags"]
-                        if not tag_filter(tags):
-                            continue
-                        yield {"ResourceARN": f"{arn}", "Tags": tags}
 
         # Firehose
         if self.firehose_backend:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterator
 from typing import Any
 
-from moto.appsync.models import AppSyncBackend, appsync_backends
 from moto.athena.models import athena_backends
 from moto.backup.models import BackupBackend, backup_backends
 from moto.clouddirectory import CloudDirectoryBackend, clouddirectory_backends
@@ -80,10 +79,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def appsync_backend(self) -> AppSyncBackend:
-        return appsync_backends[self.account_id][self.region_name]
 
     @property
     def directconnect_backend(self) -> DirectConnectBackend:
@@ -351,19 +346,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                     "ResourceARN": resource.arn,
                     "Tags": [{"Key": k, "Value": v} for k, v in resource.tags.items()],
                 }
-
-        # AppSync
-        if not resource_type_filters or "appsync" in resource_type_filters:
-            for api in self.appsync_backend.graphql_apis.values():
-                tags = self.appsync_backend.tagger.list_tags_for_resource(api.arn)[
-                    "Tags"
-                ]
-                if not tags or not tag_filter(
-                    tags
-                ):  # Skip if no tags, or invalid filter
-                    continue
-
-                yield {"ResourceARN": f"{api.arn}", "Tags": tags}
 
         # Athena
         if not resource_type_filters or "athena" in resource_type_filters:

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -8,7 +8,6 @@ from moto.core.resource_tagging import (
     make_tag_matcher,
     match_resource_type,
 )
-from moto.efs.models import EFSBackend, efs_backends
 from moto.elasticache.models import ElastiCacheBackend, elasticache_backends
 from moto.elasticbeanstalk.models import EBBackend, eb_backends
 from moto.elb.models import ELBBackend, elb_backends
@@ -65,10 +64,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Misc is there for peeking from a generator and it cant
         # fit in the current request. As we only store generators
         # there is really no point cleaning up
-
-    @property
-    def efs_backend(self) -> EFSBackend:
-        return efs_backends[self.account_id][self.region_name]
 
     @property
     def eb_backend(self) -> EBBackend:
@@ -299,30 +294,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                         "ResourceARN": f"{delivery_stream.delivery_stream_arn}",
                         "Tags": tags,
                     }
-
-        # EFS, resource type elasticfilesystem:access-point
-        if (
-            not resource_type_filters
-            or "elasticfilesystem" in resource_type_filters
-            or "elasticfilesystem:access-point" in resource_type_filters
-        ):
-            for ap in self.efs_backend.access_points.values():
-                tags = self.efs_backend.list_tags_for_resource(ap.access_point_id)
-                if not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{ap.access_point_arn}", "Tags": tags}
-
-        # EFS, resource type elasticfilesystem:file-system
-        if (
-            not resource_type_filters
-            or "elasticfilesystem" in resource_type_filters
-            or "elasticfilesystem:file-system" in resource_type_filters
-        ):
-            for fs in self.efs_backend.file_systems_by_id.values():
-                tags = self.efs_backend.list_tags_for_resource(fs.file_system_id)
-                if not tag_filter(tags):
-                    continue
-                yield {"ResourceARN": f"{fs.file_system_arn}", "Tags": tags}
 
         elasticache_resource_map: dict[str, dict[str, Any]] = {
             "elasticache:cache_clusters": dict(self.elasticache_backend.cache_clusters),
@@ -1215,13 +1186,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 self.sagemaker_backend.add_tags(
                     arn, TaggingService.convert_dict_to_tags_input(tags)
                 )
-            elif arn.startswith(
-                f"arn:{get_partition(self.region_name)}:elasticfilesystem:"
-            ):
-                resource_id = arn.split("/")[-1]
-                self.efs_backend.tag_resource(
-                    resource_id, TaggingService.convert_dict_to_tags_input(tags)
-                )
+
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:quicksight:"):
                 assert self.quicksight_backend is not None
                 self.quicksight_backend.tag_resource(
@@ -1264,12 +1229,7 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
                 except NotImplementedError:
                     missing_resources.append(arn)
                 continue
-            if arn.startswith(
-                f"arn:{get_partition(self.region_name)}:elasticfilesystem:"
-            ):
-                resource_id = arn.split("/")[-1]
-                self.efs_backend.untag_resource(resource_id, tag_keys)
-            elif arn.startswith(f"arn:{get_partition(self.region_name)}:quicksight:"):
+            if arn.startswith(f"arn:{get_partition(self.region_name)}:quicksight:"):
                 assert self.quicksight_backend is not None
                 self.quicksight_backend.untag_resource(arn, tag_keys)
             elif arn.startswith(f"arn:{get_partition(self.region_name)}:elasticache:"):

--- a/moto/resourcegroupstaggingapi/models.py
+++ b/moto/resourcegroupstaggingapi/models.py
@@ -11,7 +11,6 @@ from moto.core.resource_tagging import (
 from moto.emr.models import ElasticMapReduceBackend, emr_backends
 from moto.glacier.models import GlacierBackend, glacier_backends
 from moto.kinesis.models import KinesisBackend, kinesis_backends
-from moto.lexv2models.models import LexModelsV2Backend, lexv2models_backends
 from moto.logs.models import LogsBackend, logs_backends
 from moto.moto_api._internal import mock_random
 from moto.quicksight.models import QuickSightBackend, quicksight_backends
@@ -112,12 +111,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
     @property
     def sagemaker_backend(self) -> SageMakerModelBackend:
         return sagemaker_backends[self.account_id][self.region_name]
-
-    @property
-    def lexv2_backend(self) -> LexModelsV2Backend | None:
-        if self.region_name in lexv2models_backends[self.account_id].regions:
-            return lexv2models_backends[self.account_id][self.region_name]
-        return None
 
     @property
     def swf_backend(self) -> SWFBackend:
@@ -227,31 +220,6 @@ class ResourceGroupsTaggingAPIBackend(BaseBackend):
         # Glacier Vault
 
         # Kinesis
-
-        # LexV2
-        if self.lexv2_backend:
-            lex_v2_resource_map: dict[str, dict[str, Any]] = {
-                "lexv2:bot": self.lexv2_backend.bots,
-                "lexv2:bot-alias": self.lexv2_backend.bot_aliases,
-            }
-            for resource_type, resource_source in lex_v2_resource_map.items():
-                if (
-                    not resource_type_filters
-                    or "lexv2" in resource_type_filters
-                    or resource_type in resource_type_filters
-                ):
-                    for resource in resource_source.values():
-                        bot_tags = self.lexv2_backend.list_tags_for_resource(
-                            resource.arn
-                        )
-
-                        tags = format_tags(bot_tags)
-                        if not tags or not tag_filter(tags):
-                            continue
-                        yield {
-                            "ResourceARN": resource.arn,
-                            "Tags": tags,
-                        }
 
         # LOGS
         if (

--- a/moto/resourcegroupstaggingapi/responses.py
+++ b/moto/resourcegroupstaggingapi/responses.py
@@ -1,5 +1,6 @@
 from moto.core.responses import ActionResult, BaseResponse
 
+from .exceptions import ResourceGroupsTaggingAPIError
 from .models import ResourceGroupsTaggingAPIBackend, resourcegroupstaggingapi_backends
 
 
@@ -18,7 +19,16 @@ class ResourceGroupsTaggingAPIResponse(BaseResponse):
         resources_per_page = self._get_int_param("ResourcesPerPage", 50)
         tags_per_page = self._get_int_param("TagsPerPage", 100)
         resource_type_filters = self._get_param("ResourceTypeFilters", [])
-
+        # Simple range checking
+        if tags_per_page not in range(100, 501):
+            raise ResourceGroupsTaggingAPIError(
+                "InvalidParameterException", "TagsPerPage must be between 100 and 500"
+            )
+        if resources_per_page not in range(1, 101):
+            raise ResourceGroupsTaggingAPIError(
+                "InvalidParameterException",
+                "ResourcesPerPage must be between 1 and 50",
+            )
         pagination_token, resource_tag_mapping_list = self.backend.get_resources(
             pagination_token=pagination_token,
             tag_filters=tag_filters,
@@ -29,7 +39,16 @@ class ResourceGroupsTaggingAPIResponse(BaseResponse):
 
         # Format tag response
         response = {
-            "ResourceTagMappingList": resource_tag_mapping_list,
+            "ResourceTagMappingList": [
+                {
+                    "ResourceARN": resource.arn,
+                    "Tags": [
+                        {"Key": key, "Value": value}
+                        for key, value in resource.tags.items()
+                    ],
+                }
+                for resource in resource_tag_mapping_list
+            ],
             "PaginationToken": pagination_token,
         }
         return ActionResult(response)

--- a/moto/resourcegroupstaggingapi/responses.py
+++ b/moto/resourcegroupstaggingapi/responses.py
@@ -19,6 +19,8 @@ class ResourceGroupsTaggingAPIResponse(BaseResponse):
         resources_per_page = self._get_int_param("ResourcesPerPage", 50)
         tags_per_page = self._get_int_param("TagsPerPage", 100)
         resource_type_filters = self._get_param("ResourceTypeFilters", [])
+        resource_arn_list = self._get_param("ResourceARNList", [])
+
         # Simple range checking
         if tags_per_page not in range(100, 501):
             raise ResourceGroupsTaggingAPIError(
@@ -27,7 +29,7 @@ class ResourceGroupsTaggingAPIResponse(BaseResponse):
         if resources_per_page not in range(1, 101):
             raise ResourceGroupsTaggingAPIError(
                 "InvalidParameterException",
-                "ResourcesPerPage must be between 1 and 50",
+                "ResourcesPerPage must be between 1 and 100",
             )
         pagination_token, resource_tag_mapping_list = self.backend.get_resources(
             pagination_token=pagination_token,
@@ -35,6 +37,7 @@ class ResourceGroupsTaggingAPIResponse(BaseResponse):
             resources_per_page=resources_per_page,
             tags_per_page=tags_per_page,
             resource_type_filters=resource_type_filters,
+            resource_arn_list=resource_arn_list,
         )
 
         # Format tag response

--- a/moto/s3/models.py
+++ b/moto/s3/models.py
@@ -3280,7 +3280,7 @@ class S3Backend(BaseBackend, CloudWatchMetricProvider, TaggableResourcesMixin):
         bucket = self.get_bucket(bucket_name)
         return list(bucket.inventory_configs.values())
 
-    # Resource Groups Tagging API
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
     def iter_tagged_resources(self) -> Iterator[TaggedResource]:
         for bucket in self.buckets.values():
             yield TaggedResource(

--- a/moto/sagemaker/models.py
+++ b/moto/sagemaker/models.py
@@ -4,12 +4,13 @@ import random
 import re
 import string
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timezone
 from typing import Any, cast
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import camelcase_to_underscores, utcnow
 from moto.sagemaker import validators
 from moto.utilities.paginator import paginate
@@ -2860,7 +2861,9 @@ class FakeSageMakerNotebookInstanceLifecycleConfig(BaseObject, CloudFormationMod
         backend.delete_notebook_instance_lifecycle_config(config_name)
 
 
-class SageMakerModelBackend(BaseBackend):
+class SageMakerModelBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "sagemaker"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self._models: dict[str, Model] = {}
@@ -5694,6 +5697,51 @@ class SageMakerModelBackend(BaseBackend):
             del self.data_quality_job_definitions[job_definition_name]
         else:
             raise ResourceNotFound(f"Job definition {job_definition_name} not found")
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        sources: dict[str, dict[str, Any]] = {
+            "sagemaker:automl-job": self.auto_ml_jobs,
+            "sagemaker:cluster": self.clusters,
+            "sagemaker:compilation-job": self.compilation_jobs,
+            "sagemaker:data-quality-job-definition": self.data_quality_job_definitions,
+            "sagemaker:domain": self.domains,
+            "sagemaker:endpoint": self.endpoints,
+            "sagemaker:endpoint-config": self.endpoint_configs,
+            "sagemaker:experiment": self.experiments,
+            "sagemaker:feature-group": self.feature_groups,
+            "sagemaker:hyper-parameter-tuning-job": self.hyper_parameter_tuning_jobs,
+            "sagemaker:model": self._models,
+            "sagemaker:model-bias-job-definition": self.model_bias_job_definitions,
+            "sagemaker:model-card": self.model_cards,
+            "sagemaker:model-explainability-job-definition": self.model_explainability_job_definitions,
+            "sagemaker:model-package": self.model_packages,
+            "sagemaker:model-package-group": self.model_package_groups,
+            "sagemaker:model-quality-job-definition": self.model_quality_job_definitions,
+            "sagemaker:notebook-instance": self.notebook_instances,
+            "sagemaker:notebook-instance-lifecycle-config": self.notebook_instance_lifecycle_configurations,
+            "sagemaker:pipeline": self.pipelines,
+            "sagemaker:pipeline-execution": self.pipeline_executions,
+            "sagemaker:processing-job": self.processing_jobs,
+            "sagemaker:training-job": self.training_jobs,
+            "sagemaker:transform-job": self.transform_jobs,
+            "sagemaker:trial": self.trials,
+            "sagemaker:trial-component": self.trial_components,
+        }
+        for resource_type, items in sources.items():
+            for resource in items.values():
+                tags = getattr(resource, "tags", None) or []
+                yield TaggedResource(
+                    arn=resource.arn,
+                    tags={t["Key"]: t["Value"] for t in tags},
+                    resource_type=resource_type,
+                )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.add_tags(arn, [{"Key": k, "Value": v} for k, v in tags.items()])
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.delete_tags(arn, tag_keys)
 
 
 class FakeDataQualityJobDefinition(BaseObject):

--- a/moto/secretsmanager/models.py
+++ b/moto/secretsmanager/models.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import datetime
 import json
 import time
+from collections.abc import Iterator
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcfromtimestamp, utcnow
 from moto.moto_api._internal import mock_random
 
@@ -382,7 +384,9 @@ class SecretsStore(dict[str, FakeSecret | ReplicaSecret]):
         return super().pop(name, None)
 
 
-class SecretsManagerBackend(BaseBackend):
+class SecretsManagerBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "secretsmanager"
+
     DEFAULT_KMS_KEY_ALIAS = "alias/aws/secretsmanager"
 
     def __init__(self, region_name: str, account_id: str):
@@ -1124,34 +1128,6 @@ class SecretsManagerBackend(BaseBackend):
 
         return secret.arn, secret.name
 
-    def tag_resource(self, secret_id: str, tags: list[dict[str, str]]) -> None:
-        if secret_id not in self.secrets:
-            raise SecretNotFoundException()
-
-        secret = self.secrets[secret_id]
-        if isinstance(secret, ReplicaSecret):
-            raise OperationNotPermittedOnReplica
-
-        old_tags = {tag["Key"]: tag for tag in secret.tags or []}
-
-        for tag in tags:
-            old_tags[tag["Key"]] = tag
-
-        secret.tags = list(old_tags.values())
-
-    def untag_resource(self, secret_id: str, tag_keys: list[str]) -> None:
-        if secret_id not in self.secrets:
-            raise SecretNotFoundException()
-
-        secret = self.secrets[secret_id]
-        if isinstance(secret, ReplicaSecret):
-            raise OperationNotPermittedOnReplica
-
-        if secret.tags is None:
-            return
-
-        secret.tags = [tag for tag in secret.tags if tag["Key"] not in tag_keys]
-
     def update_secret_version_stage(
         self,
         secret_id: str,
@@ -1295,6 +1271,46 @@ class SecretsManagerBackend(BaseBackend):
         new_next_token = str(ending_point) if ending_point < len(secret_list) else None
 
         return secret_page, new_next_token
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for secret in self.secrets.values():
+            secret_tags = (
+                secret.source.tags if isinstance(secret, ReplicaSecret) else secret.tags
+            )
+            yield TaggedResource(
+                arn=secret.arn,
+                tags={t["Key"]: t["Value"] for t in (secret_tags or [])},
+                resource_type="secretsmanager:secret",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        if arn not in self.secrets:
+            raise SecretNotFoundException()
+
+        secret = self.secrets[arn]
+        if isinstance(secret, ReplicaSecret):
+            raise OperationNotPermittedOnReplica
+
+        old_tags = {tag["Key"]: tag for tag in secret.tags or []}
+
+        for k, v in tags.items():
+            old_tags[k] = {"Key": k, "Value": v}
+
+        secret.tags = list(old_tags.values())
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        if arn not in self.secrets:
+            raise SecretNotFoundException()
+
+        secret = self.secrets[arn]
+        if isinstance(secret, ReplicaSecret):
+            raise OperationNotPermittedOnReplica
+
+        if secret.tags is None:
+            return
+
+        secret.tags = [tag for tag in secret.tags if tag["Key"] not in tag_keys]
 
 
 secretsmanager_backends = BackendDict(SecretsManagerBackend, "secretsmanager")

--- a/moto/secretsmanager/responses.py
+++ b/moto/secretsmanager/responses.py
@@ -219,14 +219,15 @@ class SecretsManagerResponse(BaseResponse):
 
     def tag_resource(self) -> str:
         secret_id = self._get_param("SecretId")
-        tags = self._get_param("Tags", if_none=[])
+        tags = self._get_param("Tags", if_none=[]) or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
         self.backend.tag_resource(secret_id, tags)
         return "{}"
 
     def untag_resource(self) -> str:
         secret_id = self._get_param("SecretId")
-        tag_keys = self._get_param("TagKeys", if_none=[])
-        self.backend.untag_resource(secret_id=secret_id, tag_keys=tag_keys)
+        tag_keys = self._get_param("TagKeys", if_none=[]) or []
+        self.backend.untag_resource(secret_id, tag_keys)
         return "{}"
 
     def update_secret_version_stage(self) -> str:

--- a/moto/servicecatalog/models.py
+++ b/moto/servicecatalog/models.py
@@ -1,10 +1,12 @@
 """ServiceCatalogBackend class with methods for supported APIs."""
 
 import uuid
+from collections.abc import Iterator
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
@@ -129,8 +131,10 @@ class Product(BaseModel):
         return product_view_summary
 
 
-class ServiceCatalogBackend(BaseBackend):
+class ServiceCatalogBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of ServiceCatalog APIs."""
+
+    SERVICE_NAMESPACE = "catalog"
 
     def __init__(self, region_name: str, account_id: str) -> None:
         super().__init__(region_name, account_id)
@@ -454,6 +458,21 @@ class ServiceCatalogBackend(BaseBackend):
         if self.tagger.has_tags(resource_arn):
             return self.tagger.list_tags_for_resource(resource_arn)["Tags"]
         return []
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for portfolio in self.portfolios.values():
+            yield TaggedResource(
+                arn=portfolio.arn,
+                tags=self.tagger.get_tag_dict_for_resource(portfolio.arn),
+                resource_type="servicecatalog:portfolio",
+            )
+        for product in self.products.values():
+            yield TaggedResource(
+                arn=product.arn,
+                tags=self.tagger.get_tag_dict_for_resource(product.arn),
+                resource_type="servicecatalog:product",
+            )
 
 
 servicecatalog_backends = BackendDict(ServiceCatalogBackend, "servicecatalog")

--- a/moto/sesv2/models.py
+++ b/moto/sesv2/models.py
@@ -1,8 +1,10 @@
 """SESV2Backend class with methods for supported APIs."""
 
+from collections.abc import Iterator
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import iso_8601_datetime_with_milliseconds
 from moto.utilities.paginator import paginate
 
@@ -43,8 +45,10 @@ PAGINATION_MODEL = {
 
 # TODO
 # ListTagsForResource, TagResource, UntagResource to do
-class SESV2Backend(BaseBackend):
+class SESV2Backend(BaseBackend, TaggableResourcesMixin):
     """Implementation of SESV2 APIs, piggy back on v1 SES"""
+
+    SERVICE_NAMESPACE = "ses"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -272,15 +276,49 @@ class SESV2Backend(BaseBackend):
 
         return email_id.policies
 
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.core_backend.tagger.tag_resource(resource_arn, tags)
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.core_backend.tagger.untag_resource_using_names(resource_arn, tag_keys)
-
     def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         tags = self.core_backend.tagger.list_tags_for_resource(resource_arn)
         return tags.get("Tags", [])
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        partition = self.partition
+        sources: list[tuple[str, str, dict[str, Any]]] = [
+            (
+                "ses:configuration-set",
+                "configuration_set_name",
+                self.core_backend.config_sets,
+            ),
+            ("ses:contact-list", "contact_list_name", self.core_backend.contacts_lists),
+            (
+                "ses:dedicated-ip-pool",
+                "pool_name",
+                self.core_backend.dedicated_ip_pools,
+            ),
+            (
+                "ses:email-identity",
+                "email_identity",
+                self.core_backend.email_identities,
+            ),
+        ]
+        for resource_type, id_attr, items in sources:
+            for resource in items.values():
+                resource_id = getattr(resource, id_attr)
+                kind = resource_type.split(":", 1)[1]
+                arn = f"arn:{partition}:ses:{self.region_name}:{self.account_id}:{kind}/{resource_id}"
+                yield TaggedResource(
+                    arn=arn,
+                    tags=self.core_backend.tagger.get_tag_dict_for_resource(arn),
+                    resource_type=resource_type,
+                )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.core_backend.tagger.tag_resource(
+            arn, self.core_backend.tagger.convert_dict_to_tags_input(tags)
+        )
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.core_backend.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 sesv2_backends = BackendDict(SESV2Backend, "sesv2")

--- a/moto/sesv2/responses.py
+++ b/moto/sesv2/responses.py
@@ -283,20 +283,15 @@ class SESV2Response(BaseResponse):
 
     def tag_resource(self) -> str:
         resource_arn = self._get_param("ResourceArn")
-        tags = self._get_param("Tags")
-        self.sesv2_backend.tag_resource(
-            resource_arn=resource_arn,
-            tags=tags,
-        )
+        tags = self._get_param("Tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
+        self.sesv2_backend.tag_resource(resource_arn, tags)
         return json.dumps({})
 
     def untag_resource(self) -> str:
         resource_arn = self._get_param("ResourceArn")
         tag_keys = self.__dict__["data"]["TagKeys"]
-        self.sesv2_backend.untag_resource(
-            resource_arn=resource_arn,
-            tag_keys=tag_keys,
-        )
+        self.sesv2_backend.untag_resource(resource_arn, tag_keys)
         return json.dumps({})
 
     def list_tags_for_resource(self) -> str:

--- a/moto/sns/models.py
+++ b/moto/sns/models.py
@@ -3,7 +3,7 @@ import contextlib
 import json
 import re
 from collections import OrderedDict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import timedelta
 from functools import lru_cache
 from typing import Any, cast
@@ -18,6 +18,7 @@ from cryptography.x509.oid import NameOID
 from moto.core import DEFAULT_ACCOUNT_ID
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import (
     camelcase_to_underscores,
     iso_8601_datetime_with_milliseconds,
@@ -491,7 +492,7 @@ class PlatformEndpoint(BaseModel):
         return message_id
 
 
-class SNSBackend(BaseBackend):
+class SNSBackend(BaseBackend, TaggableResourcesMixin):
     """
     Responsible for mocking calls to SNS. Integration with SQS/HTTP/etc is supported.
 
@@ -508,6 +509,8 @@ class SNSBackend(BaseBackend):
 
     Note that, as this is an internal API, the exact format may differ per versions.
     """
+
+    SERVICE_NAMESPACE = "sns"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -1157,25 +1160,6 @@ class SNSBackend(BaseBackend):
 
         return self.topics[resource_arn]._tags
 
-    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
-        if resource_arn not in self.topics:
-            raise ResourceNotFoundError
-
-        updated_tags = self.topics[resource_arn]._tags.copy()
-        updated_tags.update(tags)
-
-        if len(updated_tags) > 50:
-            raise TagLimitExceededError
-
-        self.topics[resource_arn]._tags = updated_tags
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        if resource_arn not in self.topics:
-            raise ResourceNotFoundError
-
-        for key in tag_keys:
-            self.topics[resource_arn]._tags.pop(key, None)
-
     def publish_batch(
         self, topic_arn: str, publish_batch_request_entries: list[dict[str, Any]]
     ) -> tuple[list[dict[str, str]], list[dict[str, Any]]]:
@@ -1331,6 +1315,34 @@ class SNSBackend(BaseBackend):
 
     def get_topic_attributes(self) -> None:
         pass
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for topic in self.topics.values():
+            yield TaggedResource(
+                arn=topic.arn,
+                tags=dict(topic._tags or {}),
+                resource_type="sns:topic",
+            )
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
+        if resource_arn not in self.topics:
+            raise ResourceNotFoundError
+
+        updated_tags = self.topics[resource_arn]._tags.copy()
+        updated_tags.update(tags)
+
+        if len(updated_tags) > 50:
+            raise TagLimitExceededError
+
+        self.topics[resource_arn]._tags = updated_tags
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        if resource_arn not in self.topics:
+            raise ResourceNotFoundError
+
+        for key in tag_keys:
+            self.topics[resource_arn]._tags.pop(key, None)
 
 
 sns_backends = BackendDict(SNSBackend, "sns")

--- a/moto/sqs/models.py
+++ b/moto/sqs/models.py
@@ -3,6 +3,7 @@ import json
 import re
 import string
 import struct
+from collections.abc import Iterator
 from copy import deepcopy
 from threading import Condition
 from typing import TYPE_CHECKING, Any
@@ -10,6 +11,7 @@ from urllib.parse import ParseResult
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import (
     camelcase_to_underscores,
     tags_from_cloudformation_tags_list,
@@ -684,7 +686,9 @@ def _filter_message_attributes(
     message.message_attributes = filtered_message_attributes
 
 
-class SQSBackend(BaseBackend):
+class SQSBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "sqs"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.queues: dict[str, Queue] = {}
@@ -1262,6 +1266,15 @@ class SQSBackend(BaseBackend):
         if retain_until <= unix_time():
             return False
         return True
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for queue in self.queues.values():
+            yield TaggedResource(
+                arn=queue.queue_arn,
+                tags=dict(queue.tags or {}),
+                resource_type="sqs:queue",
+            )
 
 
 sqs_backends = BackendDict(SQSBackend, "sqs")

--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -15,6 +15,7 @@ import yaml
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel, CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.ec2 import ec2_backends
 from moto.moto_api._internal import mock_random as random
@@ -1266,7 +1267,7 @@ class FakePatchGroup:
         self.default_associations = latest_patch_baselines[self.region_name]
 
 
-class SimpleSystemManagerBackend(BaseBackend):
+class SimpleSystemManagerBackend(BaseBackend, TaggableResourcesMixin):
     """
     Moto supports the following default parameters out of the box:
 
@@ -1277,6 +1278,8 @@ class SimpleSystemManagerBackend(BaseBackend):
 
     Integration with SecretsManager is also supported.
     """
+
+    SERVICE_NAMESPACE = "ssm"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -2711,6 +2714,23 @@ class SimpleSystemManagerBackend(BaseBackend):
             baseline_os = self.baselines[baseline_id].operating_system
             self.patch_groups[patch_group].associations[baseline_os] = baseline_id
         return baseline_id, patch_group
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for document in self._documents.values():
+            doc_name = document.describe()["Name"]
+            tags = {t["Key"]: t["Value"] for t in self._get_documents_tags(doc_name)}
+            yield TaggedResource(
+                arn=f"arn:{self.partition}:ssm:{self.region_name}:{self.account_id}:document/{doc_name}",
+                tags=tags,
+                resource_type="ssm:document",
+            )
+        for param_name in self._parameters:
+            yield TaggedResource(
+                arn=parameter_arn(self.account_id, self.region_name, param_name),
+                tags=dict(self.list_tags_for_resource("Parameter", param_name) or {}),
+                resource_type="ssm:parameter",
+            )
 
 
 ssm_backends = BackendDict(SimpleSystemManagerBackend, "ssm")

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from re import Pattern
 from typing import Any, cast
@@ -9,6 +10,7 @@ from typing import Any, cast
 from moto import settings
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import CloudFormationModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random
 from moto.utilities.paginator import paginate
@@ -329,7 +331,7 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
             state_machine = sf_backend.update_state_machine(
                 original_resource.arn, definition=definition, role_arn=role_arn
             )
-            sf_backend.tag_resource(state_machine.arn, tags)
+            sf_backend.tagger.tag_resource(state_machine.arn, tags)
             return state_machine
 
 
@@ -475,7 +477,7 @@ class Activity:
         self.update_date = self.creation_date
 
 
-class StepFunctionBackend(BaseBackend):
+class StepFunctionBackend(BaseBackend, TaggableResourcesMixin):
     """
     Configure Moto to explicitly parse and execute the StateMachine:
 
@@ -608,6 +610,8 @@ class StepFunctionBackend(BaseBackend):
         + r":states:[-0-9a-zA-Z]+:(?P<account_id>[0-9]{12}):activity:.+"
     )
 
+    SERVICE_NAMESPACE = "states"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.tagger = TaggingService(
@@ -650,7 +654,7 @@ class StepFunctionBackend(BaseBackend):
                 state_machine.publish(description=version_description)
 
             if tags:
-                self.tag_resource(arn, tags)
+                self.tagger.tag_resource(arn, tags)
 
             self.state_machines.append(state_machine)
             return state_machine
@@ -866,12 +870,6 @@ class StepFunctionBackend(BaseBackend):
     def list_tags_for_resource(self, arn: str) -> dict[str, list[dict[str, str]]]:
         return self.tagger.list_tags_for_resource(arn)
 
-    def tag_resource(self, resource_arn: str, tags: list[dict[str, str]]) -> None:
-        self.tagger.tag_resource(resource_arn, tags)
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
-
     def get_tags_list_for_state_machine(self, arn: str) -> list[dict[str, str]]:
         return self.list_tags_for_resource(arn)[self.tagger.tag_name]
 
@@ -996,7 +994,7 @@ class StepFunctionBackend(BaseBackend):
         self.activities[arn] = activity
 
         if tags:
-            self.tag_resource(arn, tags)
+            self.tagger.tag_resource(arn, tags)
 
         return activity
 
@@ -1015,6 +1013,21 @@ class StepFunctionBackend(BaseBackend):
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_activities(self) -> list[Activity]:
         return sorted(self.activities.values(), key=lambda x: x.creation_date)
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for sm in self.state_machines:
+            yield TaggedResource(
+                arn=sm.arn,
+                tags=self.tagger.get_tag_dict_for_resource(sm.arn),
+                resource_type="states:stateMachine",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, [{"key": k, "value": v} for k, v in tags.items()])
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 stepfunctions_backends = BackendDict(StepFunctionBackend, "stepfunctions")

--- a/moto/stepfunctions/responses.py
+++ b/moto/stepfunctions/responses.py
@@ -256,6 +256,7 @@ class StepFunctionResponse(BaseResponse):
     def tag_resource(self) -> ActionResult:
         arn = self._get_param("resourceArn")
         tags = self._get_param("tags", [])
+        tags = {tag["key"]: tag["value"] for tag in tags}
         self.stepfunction_backend.tag_resource(arn, tags)
         return EmptyResult()
 

--- a/moto/swf/models/__init__.py
+++ b/moto/swf/models/__init__.py
@@ -1,7 +1,9 @@
+from collections.abc import Iterator
 from time import sleep
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.tagging_service import TaggingService
 
 from ..exceptions import (
@@ -26,7 +28,9 @@ from .workflow_type import WorkflowType  # noqa
 KNOWN_SWF_TYPES = {"activity": ActivityType, "workflow": WorkflowType}
 
 
-class SWFBackend(BaseBackend):
+class SWFBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "swf"
+
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
         self.domains: list[Domain] = []
@@ -494,6 +498,22 @@ class SWFBackend(BaseBackend):
             workflow_id, run_id=run_id, raise_if_closed=True
         )
         wfe.signal(signal_name, workflow_input)  # type: ignore[union-attr]
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for domain in self.domains:
+            domain_arn = domain.to_short_dict()["arn"]
+            yield TaggedResource(
+                arn=domain_arn,
+                tags=self.tagger.get_tag_dict_for_resource(domain_arn),
+                resource_type="swf:domain",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, [{"Key": k, "Value": v} for k, v in tags.items()])
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 swf_backends = BackendDict(SWFBackend, "swf")

--- a/moto/vpclattice/models.py
+++ b/moto/vpclattice/models.py
@@ -1,10 +1,12 @@
 import random
 import uuid
+from collections.abc import Iterator
 from datetime import datetime, timezone
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.paginator import paginate
 from moto.utilities.tagging_service import TaggingService
 from moto.vpclattice.exceptions import (
@@ -404,7 +406,9 @@ class AuthPolicy:
         self.state = state
 
 
-class VPCLatticeBackend(BaseBackend):
+class VPCLatticeBackend(BaseBackend, TaggableResourcesMixin):
+    SERVICE_NAMESPACE = "vpc-lattice"
+
     PAGINATION_MODEL = {
         "list_services": {
             "input_token": "next_token",
@@ -589,17 +593,8 @@ class VPCLatticeBackend(BaseBackend):
         self.tag_resource(rule.arn, tags or {})
         return rule
 
-    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
-        tags_input = self.tagger.convert_dict_to_tags_input(tags or {})
-        self.tagger.tag_resource(resource_arn, tags_input)
-
     def list_tags_for_resource(self, resource_arn: str) -> dict[str, str]:
         return self.tagger.get_tag_dict_for_resource(resource_arn)
-
-    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
-        if not isinstance(tag_keys, list):
-            tag_keys = [tag_keys]
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
     def create_access_log_subscription(
         self,
@@ -1013,6 +1008,34 @@ class VPCLatticeBackend(BaseBackend):
                 if assoc.service_id == service_identifier
             ]
         return associations
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        sources: dict[str, dict[str, Any]] = {
+            "vpc-lattice:accesslogsubscription": self.access_log_subscriptions,
+            "vpc-lattice:listener": self.listeners,
+            "vpc-lattice:rule": self.rules,
+            "vpc-lattice:service": self.services,
+            "vpc-lattice:servicenetwork": self.service_networks,
+            "vpc-lattice:servicenetworkresourceassociation": self.service_network_resource_associations,
+            "vpc-lattice:servicenetworkserviceassociation": self.service_network_service_associations,
+            "vpc-lattice:servicenetworkvpcassociation": self.service_network_vpc_associations,
+            "vpc-lattice:targetgroup": self.target_groups,
+        }
+        for resource_type, items in sources.items():
+            for item in items.values():
+                yield TaggedResource(
+                    arn=item.arn,
+                    tags=self.tagger.get_tag_dict_for_resource(item.arn),
+                    resource_type=resource_type,
+                )
+
+    def tag_resource(self, resource_arn: str, tags: dict[str, str]) -> None:
+        tags_input = self.tagger.convert_dict_to_tags_input(tags or {})
+        self.tagger.tag_resource(resource_arn, tags_input)
+
+    def untag_resource(self, resource_arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
 
 
 vpclattice_backends: BackendDict[VPCLatticeBackend] = BackendDict(

--- a/moto/vpclattice/responses.py
+++ b/moto/vpclattice/responses.py
@@ -9,6 +9,7 @@ from .models import VPCLatticeBackend, vpclattice_backends
 class VPCLatticeResponse(BaseResponse):
     def __init__(self) -> None:
         super().__init__(service_name="vpc-lattice")
+        self.automated_parameter_parsing = True
 
     @property
     def backend(self) -> VPCLatticeBackend:
@@ -109,7 +110,7 @@ class VPCLatticeResponse(BaseResponse):
 
     def untag_resource(self) -> str:
         resource_arn = unquote(self._get_param("resourceArn"))
-        tag_keys = self._get_param("tagKeys")
+        tag_keys = self._get_param("tagKeys", [])
         self.backend.untag_resource(resource_arn=resource_arn, tag_keys=tag_keys)
         return json.dumps({})
 

--- a/moto/workspaces/models.py
+++ b/moto/workspaces/models.py
@@ -1,11 +1,12 @@
 """WorkSpacesBackend class with methods for supported APIs."""
 
 import re
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.core.utils import unix_time
 from moto.ds import ds_backends
 from moto.ds.models import Directory
@@ -304,8 +305,10 @@ class WorkspaceImage(BaseModel):
         return dct
 
 
-class WorkSpacesBackend(BaseBackend):
+class WorkSpacesBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of WorkSpaces APIs."""
+
+    SERVICE_NAMESPACE = "workspaces"
 
     # The assumption here is that the limits are the same for all regions.
     DIRECTORIES_LIMIT = 50
@@ -639,6 +642,32 @@ class WorkSpacesBackend(BaseBackend):
     ) -> None:
         res = self.workspace_directories[resource_id]
         res.self_service_permissions = selfservice_permissions
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        partition = self.partition
+        for ws in self.workspaces.values():
+            yield TaggedResource(
+                arn=f"arn:{partition}:workspaces:{self.region_name}:{self.account_id}:workspace/{ws.workspace_id}",
+                tags={t["Key"]: t["Value"] for t in (ws.tags or [])},
+                resource_type="workspaces:workspace",
+            )
+        for wd in self.workspace_directories.values():
+            yield TaggedResource(
+                arn=f"arn:{partition}:workspaces:{self.region_name}:{self.account_id}:directory/{wd.directory_id}",
+                tags={t["Key"]: t["Value"] for t in (wd.tags or [])},
+                resource_type="workspaces-directory",
+            )
+        for wi in self.workspace_images.values():
+            yield TaggedResource(
+                arn=f"arn:{partition}:workspaces:{self.region_name}:{self.account_id}:workspaceimage/{wi.image_id}",
+                tags={t["Key"]: t["Value"] for t in (wi.tags or [])},
+                resource_type="workspaces-image",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        resource_id = arn.split("/")[-1]
+        self.create_tags(resource_id, [{"Key": k, "Value": v} for k, v in tags.items()])
 
 
 workspaces_backends = BackendDict(WorkSpacesBackend, "workspaces")

--- a/moto/workspacesweb/models.py
+++ b/moto/workspacesweb/models.py
@@ -2,10 +2,12 @@
 
 import datetime
 import uuid
+from collections.abc import Iterator
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
+from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
 from moto.utilities.utils import get_partition
 
 from ..utilities.tagging_service import TaggingService
@@ -216,8 +218,10 @@ class FakePortal(BaseModel):
         }
 
 
-class WorkSpacesWebBackend(BaseBackend):
+class WorkSpacesWebBackend(BaseBackend, TaggableResourcesMixin):
     """Implementation of WorkSpacesWeb APIs."""
+
+    SERVICE_NAMESPACE = "workspaces-web"
 
     def __init__(self, region_name: str, account_id: str):
         super().__init__(region_name, account_id)
@@ -232,7 +236,7 @@ class WorkSpacesWebBackend(BaseBackend):
         self,
         security_group_ids: list[str],
         subnet_ids: list[str],
-        tags: dict[str, str],
+        tags: list[dict[str, str]] | None,
         vpc_id: str,
     ) -> str:
         network_settings_object = FakeNetworkSettings(
@@ -244,7 +248,7 @@ class WorkSpacesWebBackend(BaseBackend):
         )
         self.network_settings[network_settings_object.arn] = network_settings_object
         if tags:
-            self.tag_resource("TEMP_CLIENT_TOKEN", network_settings_object.arn, tags)
+            self.tagger.tag_resource(network_settings_object.arn, tags)
         return network_settings_object.arn
 
     def list_network_settings(self) -> list[dict[str, str]]:
@@ -277,7 +281,7 @@ class WorkSpacesWebBackend(BaseBackend):
         )
         self.browser_settings[browser_settings_object.arn] = browser_settings_object
         if tags:
-            self.tag_resource(client_token, browser_settings_object.arn, tags)
+            self.tagger.tag_resource(browser_settings_object.arn, tags)
         return browser_settings_object.arn
 
     def list_browser_settings(self) -> list[dict[str, str]]:
@@ -316,7 +320,7 @@ class WorkSpacesWebBackend(BaseBackend):
         )
         self.portals[portal_object.arn] = portal_object
         if tags:
-            self.tag_resource(client_token, portal_object.arn, tags)
+            self.tagger.tag_resource(portal_object.arn, tags)
         return portal_object.arn, portal_object.portal_endpoint
 
     def list_portals(self) -> list[dict[str, Any]]:
@@ -402,7 +406,7 @@ class WorkSpacesWebBackend(BaseBackend):
         )
         self.user_settings[user_settings_object.arn] = user_settings_object
         if tags:
-            self.tag_resource(client_token, user_settings_object.arn, tags)
+            self.tagger.tag_resource(user_settings_object.arn, tags)
         return user_settings_object.arn
 
     def get_user_settings(self, user_settings_arn: str) -> dict[str, Any]:
@@ -421,9 +425,7 @@ class WorkSpacesWebBackend(BaseBackend):
             user_access_logging_settings_object
         )
         if tags:
-            self.tag_resource(
-                client_token, user_access_logging_settings_object.arn, tags
-            )
+            self.tagger.tag_resource(user_access_logging_settings_object.arn, tags)
         return user_access_logging_settings_object.arn
 
     def get_user_access_logging_settings(
@@ -472,18 +474,27 @@ class WorkSpacesWebBackend(BaseBackend):
             for user_access_logging_settings in self.user_access_logging_settings.values()
         ]
 
-    def tag_resource(self, client_token: str, resource_arn: str, tags: Any) -> None:
-        self.tagger.tag_resource(resource_arn, tags)
-
-    def untag_resource(self, resource_arn: str, tag_keys: Any) -> None:
-        self.tagger.untag_resource_using_names(resource_arn, tag_keys)
-
     def list_tags_for_resource(self, resource_arn: str) -> list[dict[str, str]]:
         tags = self.tagger.get_tag_dict_for_resource(resource_arn)
         Tags = []
         for key, value in tags.items():
             Tags.append({"Key": key, "Value": value})
         return Tags
+
+    # Resource Groups Tagging API (TaggableResourcesMixin method overrides)
+    def iter_tagged_resources(self) -> Iterator[TaggedResource]:
+        for portal in self.portals.values():
+            yield TaggedResource(
+                arn=portal.arn,
+                tags=self.tagger.get_tag_dict_for_resource(portal.arn),
+                resource_type="workspaces-web:portal",
+            )
+
+    def tag_resource(self, arn: str, tags: dict[str, str]) -> None:
+        self.tagger.tag_resource(arn, self.tagger.convert_dict_to_tags_input(tags))
+
+    def untag_resource(self, arn: str, tag_keys: list[str]) -> None:
+        self.tagger.untag_resource_using_names(arn, tag_keys)
 
 
 workspacesweb_backends = BackendDict(WorkSpacesWebBackend, "workspaces-web")

--- a/moto/workspacesweb/responses.py
+++ b/moto/workspacesweb/responses.py
@@ -342,23 +342,16 @@ class WorkSpacesWebResponse(BaseResponse):
         return json.dumps({"userAccessLoggingSettings": user_access_logging_settings})
 
     def tag_resource(self) -> str:
-        client_token = self._get_param("clientToken")
         resource_arn = unquote(self._get_param("resourceArn"))
-        tags = self._get_param("tags")
-        self.workspacesweb_backend.tag_resource(
-            client_token=client_token,
-            resource_arn=resource_arn,
-            tags=tags,
-        )
+        tags = self._get_param("tags") or []
+        tags = {tag["Key"]: tag.get("Value") for tag in tags}
+        self.workspacesweb_backend.tag_resource(resource_arn, tags)
         return json.dumps({})
 
     def untag_resource(self) -> str:
         tagKeys = self.__dict__["data"]["tagKeys"]
         resource_arn = unquote(self._get_param("resourceArn"))
-        self.workspacesweb_backend.untag_resource(
-            resource_arn=resource_arn,
-            tag_keys=tagKeys,
-        )
+        self.workspacesweb_backend.untag_resource(resource_arn, tagKeys)
         return json.dumps({})
 
     def list_tags_for_resource(self) -> str:

--- a/tests/test_acm/test_acm_integration.py
+++ b/tests/test_acm/test_acm_integration.py
@@ -1,0 +1,59 @@
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_tag_and_untag_resources_acm():
+    client = boto3.client("acm", region_name="eu-central-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-central-1")
+
+    # Create a tagged certificate
+    cert_arn = client.request_certificate(
+        DomainName="example.com",
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["CertificateArn"]
+
+    # Basic test
+    resp = rtapi.get_resources(ResourceARNList=[cert_arn])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == cert_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(
+        ResourceARNList=[cert_arn],
+        Tags={"Test2": "2"},
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceARNList=[cert_arn])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert {"Key": "Test", "Value": "1"} in tags
+    assert {"Key": "Test2", "Value": "2"} in tags
+
+    # Filtering on the newly-added tag returns the certificate
+    resp = rtapi.get_resources(
+        ResourceARNList=[cert_arn],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == cert_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi.untag_resources(
+        ResourceARNList=[cert_arn],
+        TagKeys=["Test"],
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceARNList=[cert_arn])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert tags == [{"Key": "Test2", "Value": "2"}]
+
+    # The removed tag no longer matches
+    resp = rtapi.get_resources(
+        ResourceARNList=[cert_arn],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 0

--- a/tests/test_athena/test_athena_resourcegroupstagging_integration.py
+++ b/tests/test_athena/test_athena_resourcegroupstagging_integration.py
@@ -28,9 +28,9 @@ def test_athena_capacity_reservation_group_tagging_api(client, resource_groups_c
     metadata = capacity_reservation["ResponseMetadata"]
     assert metadata["HTTPStatusCode"] == 200
     assert metadata["RetryAttempts"] == 0
-
+    resource_arn = f"arn:aws:athena:us-east-1:123456789012:capacity-reservation/{capacity_reservation_name}"
     resource_group_tags = resource_groups_client.get_resources(
-        ResourceARNList=[capacity_reservation_name],
+        ResourceARNList=[resource_arn],
     )["ResourceTagMappingList"]
     assert len(resource_group_tags) == 1
     assert capacity_reservation_name in resource_group_tags[0]["ResourceARN"]
@@ -59,9 +59,9 @@ def test_create_work_group_group_tagging_api(client, resource_groups_client):
     metadata = work_group["ResponseMetadata"]
     assert metadata["HTTPStatusCode"] == 200
     assert metadata["RetryAttempts"] == 0
-
+    resource_arn = f"arn:aws:athena:us-east-1:123456789012:workgroup/{work_group_name}"
     resource_group_tags = resource_groups_client.get_resources(
-        ResourceARNList=[work_group_name],
+        ResourceARNList=[resource_arn],
     )["ResourceTagMappingList"]
     assert len(resource_group_tags) == 1
     assert work_group_name in resource_group_tags[0]["ResourceARN"]
@@ -83,9 +83,11 @@ def test_create_data_catalog_group_tagging_api(client, resource_groups_client):
     metadata = data_catalog["ResponseMetadata"]
     assert metadata["HTTPStatusCode"] == 200
     assert metadata["RetryAttempts"] == 0
-
+    resource_arn = (
+        f"arn:aws:athena:us-east-1:123456789012:datacatalog/{data_catalog_name}"
+    )
     resource_group_tags = resource_groups_client.get_resources(
-        ResourceARNList=[data_catalog_name],
+        ResourceARNList=[resource_arn],
     )["ResourceTagMappingList"]
     assert len(resource_group_tags) == 1
     assert data_catalog_name in resource_group_tags[0]["ResourceARN"]

--- a/tests/test_comprehend/test_comprehend_integration.py
+++ b/tests/test_comprehend/test_comprehend_integration.py
@@ -4,7 +4,10 @@ from moto import mock_aws
 from moto.comprehend.models import comprehend_backends
 from tests.test_comprehend.test_comprehend import (
     DOCUMENT_CLASSIFIER_INPUT_DATA_CONFIG,
+    INPUT_DATA_CONFIG,
 )
+
+REGION = "ap-southeast-1"
 
 
 @mock_aws
@@ -76,3 +79,88 @@ def test_tags_from_resourcegroupsapi_no_arn():
     )["ResourceTagMappingList"]
 
     assert result == []
+
+
+def _assert_rgtapi_tag_untag(arn, resource_type):
+    """Exercise get_resources + tag_resources + untag_resources for a single ARN."""
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name=REGION)
+
+    # GetResources returns the resource
+    resp = rtapi.get_resources(ResourceTypeFilters=[resource_type])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(ResourceARNList=[arn], Tags={"Test2": "2"})
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=[resource_type],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi.untag_resources(ResourceARNList=[arn], TagKeys=["Test"])
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=[resource_type])
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test2", "Value": "2"}]
+
+
+@mock_aws
+def test_rgtapi_entity_recognizer():
+    client = boto3.client("comprehend", region_name=REGION)
+    arn = client.create_entity_recognizer(
+        RecognizerName="test-recognizer",
+        VersionName="v1",
+        DataAccessRoleArn="iam_role_with_20_chars",
+        InputDataConfig=INPUT_DATA_CONFIG,
+        LanguageCode="en",
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["EntityRecognizerArn"]
+
+    _assert_rgtapi_tag_untag(arn, "comprehend:entity-recognizer")
+
+
+@mock_aws
+def test_rgtapi_endpoint():
+    client = boto3.client("comprehend", region_name=REGION)
+    model_arn = (
+        f"arn:aws:comprehend:{REGION}:123456789012:document-classifier/test-classifier"
+    )
+    arn = client.create_endpoint(
+        EndpointName="test-endpoint",
+        ModelArn=model_arn,
+        DesiredInferenceUnits=1,
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["EndpointArn"]
+
+    _assert_rgtapi_tag_untag(arn, "comprehend:endpoint")
+
+
+@mock_aws
+def test_rgtapi_flywheel():
+    client = boto3.client("comprehend", region_name=REGION)
+    model_arn = (
+        f"arn:aws:comprehend:{REGION}:123456789012:document-classifier/test-classifier"
+    )
+    arn = client.create_flywheel(
+        FlywheelName="test-flywheel",
+        ActiveModelArn=model_arn,
+        DataAccessRoleArn="iam_role_with_20_chars",
+        TaskConfig={
+            "LanguageCode": "en",
+            "DocumentClassificationConfig": {
+                "Mode": "MULTI_CLASS",
+                "Labels": ["Label1", "Label2"],
+            },
+        },
+        ModelType="DOCUMENT_CLASSIFIER",
+        DataLakeS3Uri=f"s3://{REGION}-bucket/documents.txt",
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["FlywheelArn"]
+
+    _assert_rgtapi_tag_untag(arn, "comprehend:flywheel")

--- a/tests/test_dms/test_dms_integration.py
+++ b/tests/test_dms/test_dms_integration.py
@@ -71,3 +71,61 @@ def test_create_replication_task_with_tags(client, resource_groups_client):
         {"Key": "Test-tag", "Value": "Test Task"},
         {"Key": "Test-tag2", "Value": "Test Task"},
     ]
+
+
+@mock_aws
+def test_tag_and_untag_replication_task(client, resource_groups_client):
+    task_arn = client.create_replication_task(
+        ReplicationTaskIdentifier="test",
+        SourceEndpointArn="source-endpoint-arn",
+        TargetEndpointArn="target-endpoint-arn",
+        ReplicationInstanceArn="replication-instance-arn",
+        MigrationType="full-load",
+        TableMappings='{"rules":[]}',
+        ReplicationTaskSettings='{"Logging":{} }',
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["ReplicationTask"]["ReplicationTaskArn"]
+
+    # Basic test
+    resp = resource_groups_client.get_resources(ResourceTypeFilters=["dms:task"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == task_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = resource_groups_client.tag_resources(
+        ResourceARNList=[task_arn],
+        Tags={"Test2": "2"},
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = resource_groups_client.get_resources(ResourceTypeFilters=["dms:task"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert {"Key": "Test", "Value": "1"} in tags
+    assert {"Key": "Test2", "Value": "2"} in tags
+
+    # Filtering on the newly-added tag returns the task
+    resp = resource_groups_client.get_resources(
+        ResourceTypeFilters=["dms:task"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == task_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = resource_groups_client.untag_resources(
+        ResourceARNList=[task_arn],
+        TagKeys=["Test"],
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = resource_groups_client.get_resources(ResourceTypeFilters=["dms:task"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert tags == [{"Key": "Test2", "Value": "2"}]
+
+    # The removed tag no longer matches
+    resp = resource_groups_client.get_resources(
+        ResourceTypeFilters=["dms:task"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 0

--- a/tests/test_firehose/test_firehose_integration.py
+++ b/tests/test_firehose/test_firehose_integration.py
@@ -1,0 +1,63 @@
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_get_tag_and_untag_resources_firehose():
+    client = boto3.client("firehose", region_name="us-east-2")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-2")
+
+    # Create a tagged delivery stream
+    stream_arn = client.create_delivery_stream(
+        DeliveryStreamName="my-stream",
+        S3DestinationConfiguration={
+            "RoleARN": "arn:aws:iam::123456789012:role/my-role",
+            "BucketARN": "arn:aws:s3:::my-bucket",
+        },
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["DeliveryStreamARN"]
+
+    # Basic test
+    resp = rtapi.get_resources(ResourceTypeFilters=["firehose"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == stream_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(
+        ResourceARNList=[stream_arn],
+        Tags={"Test2": "2"},
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["firehose"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert {"Key": "Test", "Value": "1"} in tags
+    assert {"Key": "Test2", "Value": "2"} in tags
+
+    # Filtering on the newly-added tag returns the stream
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["firehose"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == stream_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi.untag_resources(
+        ResourceARNList=[stream_arn],
+        TagKeys=["Test"],
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["firehose"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert tags == [{"Key": "Test2", "Value": "2"}]
+
+    # The removed tag no longer matches
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["firehose"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 0

--- a/tests/test_kafka/test_kafka_integration.py
+++ b/tests/test_kafka/test_kafka_integration.py
@@ -1,0 +1,45 @@
+import boto3
+
+from moto import mock_aws
+
+
+@mock_aws
+def test_get_resources_kafka():
+    client = boto3.client("kafka", region_name="ap-southeast-1")
+
+    # Create a tagged cluster
+    cluster_arn = client.create_cluster_v2(
+        ClusterName="TestCluster",
+        Serverless={
+            "VpcConfigs": [
+                {
+                    "SubnetIds": ["subnet-0123456789abcdef0"],
+                    "SecurityGroupIds": ["sg-0123456789abcdef0"],
+                }
+            ]
+        },
+        Tags={"Test": "1"},
+    )["ClusterArn"]
+
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="ap-southeast-1")
+
+    # Basic test
+    resp = rtapi.get_resources(ResourceTypeFilters=["kafka"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == cluster_arn
+    assert {"Key": "Test", "Value": "1"} in resp["ResourceTagMappingList"][0]["Tags"]
+
+    # Test tag filtering
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["kafka"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == cluster_arn
+
+    # Non-matching tag filter returns nothing
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["kafka"],
+        TagFilters=[{"Key": "Test", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 0

--- a/tests/test_kinesisanalyticsv2/test_kinesisanalyticsv2_integration.py
+++ b/tests/test_kinesisanalyticsv2/test_kinesisanalyticsv2_integration.py
@@ -25,3 +25,61 @@ def test_resource_groups_tagging_api():
     assert len(resp["ResourceTagMappingList"]) == 1
     assert resp["ResourceTagMappingList"][0]["ResourceARN"] == app_arn
     assert resp["ResourceTagMappingList"][0]["Tags"] == FAKE_TAGS
+
+
+@mock_aws
+def test_tag_and_untag_resources():
+    region = "us-east-2"
+    client = boto3.client("kinesisanalyticsv2", region_name=region)
+    rtapi_client = boto3.client("resourcegroupstaggingapi", region_name=region)
+
+    app_arn = client.create_application(
+        ApplicationName="test_application",
+        RuntimeEnvironment="FLINK-1_20",
+        ServiceExecutionRole=f"arn:aws:iam::{ACCOUNT_ID}:role/application_role",
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["ApplicationDetail"]["ApplicationARN"]
+
+    # Basic test
+    resp = rtapi_client.get_resources(ResourceTypeFilters=["kinesisanalyticsv2"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == app_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi_client.tag_resources(
+        ResourceARNList=[app_arn],
+        Tags={"Test2": "2"},
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi_client.get_resources(ResourceTypeFilters=["kinesisanalyticsv2"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert {"Key": "Test", "Value": "1"} in tags
+    assert {"Key": "Test2", "Value": "2"} in tags
+
+    # Filtering on the newly-added tag returns the application
+    resp = rtapi_client.get_resources(
+        ResourceTypeFilters=["kinesisanalyticsv2"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == app_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi_client.untag_resources(
+        ResourceARNList=[app_arn],
+        TagKeys=["Test"],
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi_client.get_resources(ResourceTypeFilters=["kinesisanalyticsv2"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert tags == [{"Key": "Test2", "Value": "2"}]
+
+    # The removed tag no longer matches
+    resp = rtapi_client.get_resources(
+        ResourceTypeFilters=["kinesisanalyticsv2"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 0

--- a/tests/test_quicksight/test_quicksight_integration.py
+++ b/tests/test_quicksight/test_quicksight_integration.py
@@ -1,0 +1,131 @@
+import boto3
+
+from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
+
+
+@mock_aws
+def test_get_tag_and_untag_resources_quicksight_data_sources():
+    client = boto3.client("quicksight", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    source_arn = client.create_data_source(
+        AwsAccountId=ACCOUNT_ID,
+        DataSourceId="ds1",
+        Name="TestDataSource",
+        Type="ATHENA",
+        DataSourceParameters={"AthenaParameters": {"WorkGroup": "primary"}},
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["Arn"]
+
+    # GetResources returns the data source
+    resp = rtapi.get_resources(ResourceTypeFilters=["quicksight:data_sources"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == source_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(ResourceARNList=[source_arn], Tags={"Test2": "2"})
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["quicksight:data_sources"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == source_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi.untag_resources(ResourceARNList=[source_arn], TagKeys=["Test"])
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["quicksight:data_sources"])
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test2", "Value": "2"}]
+
+
+@mock_aws
+def test_get_tag_and_untag_resources_quicksight_dashboards():
+    client = boto3.client("quicksight", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    dash_arn = client.create_dashboard(
+        AwsAccountId=ACCOUNT_ID,
+        DashboardId="dash1",
+        Name="TestDashboard",
+        SourceEntity={
+            "SourceTemplate": {
+                "DataSetReferences": [
+                    {
+                        "DataSetPlaceholder": "placeholder",
+                        "DataSetArn": f"arn:aws:quicksight:us-east-1:{ACCOUNT_ID}:dataset/ds1",
+                    }
+                ],
+                "Arn": f"arn:aws:quicksight:us-east-1:{ACCOUNT_ID}:template/template1",
+            }
+        },
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["Arn"]
+
+    # GetResources returns the dashboard
+    resp = rtapi.get_resources(ResourceTypeFilters=["quicksight:dashboards"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == dash_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(ResourceARNList=[dash_arn], Tags={"Test2": "2"})
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["quicksight:dashboards"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == dash_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi.untag_resources(ResourceARNList=[dash_arn], TagKeys=["Test"])
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["quicksight:dashboards"])
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test2", "Value": "2"}]
+
+
+@mock_aws
+def test_get_tag_and_untag_resources_quicksight_users():
+    client = boto3.client("quicksight", region_name="us-east-1")
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+
+    user_arn = client.register_user(
+        AwsAccountId=ACCOUNT_ID,
+        Namespace="default",
+        Email="user@example.com",
+        IdentityType="QUICKSIGHT",
+        UserName="testuser",
+        UserRole="READER",
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["User"]["Arn"]
+
+    # GetResources returns the user
+    resp = rtapi.get_resources(ResourceTypeFilters=["quicksight:users"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == user_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(ResourceARNList=[user_arn], Tags={"Test2": "2"})
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["quicksight:users"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == user_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi.untag_resources(ResourceARNList=[user_arn], TagKeys=["Test"])
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["quicksight:users"])
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test2", "Value": "2"}]

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -2065,3 +2065,27 @@ def test_untag_resources_elasticache():
 
     resp = elc.list_tags_for_resource(ResourceName=cluster["ARN"])
     assert len(resp["TagList"]) == 0
+
+
+@mock_aws
+def test_get_resources_param_validation():
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    dummy_arn = "arn:aws:s3:::bucket-name"
+    # Too high
+    with pytest.raises(ClientError) as exc_info:
+        rtapi.get_resources(ResourceARNList=[dummy_arn], TagsPerPage=1000)
+    error = exc_info.value.response["Error"]
+    assert error["Code"] == "InvalidParameterException"
+    with pytest.raises(ClientError) as exc_info:
+        rtapi.get_resources(ResourceARNList=[dummy_arn], ResourcesPerPage=1000)
+    error = exc_info.value.response["Error"]
+    assert error["Code"] == "InvalidParameterException"
+    # Too low
+    with pytest.raises(ClientError) as exc_info:
+        rtapi.get_resources(ResourceARNList=[dummy_arn], TagsPerPage=10)
+    error = exc_info.value.response["Error"]
+    assert error["Code"] == "InvalidParameterException"
+    with pytest.raises(ClientError) as exc_info:
+        rtapi.get_resources(ResourceARNList=[dummy_arn], ResourcesPerPage=0)
+    error = exc_info.value.response["Error"]
+    assert error["Code"] == "InvalidParameterException"

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi.py
@@ -2089,3 +2089,37 @@ def test_get_resources_param_validation():
         rtapi.get_resources(ResourceARNList=[dummy_arn], ResourcesPerPage=0)
     error = exc_info.value.response["Error"]
     assert error["Code"] == "InvalidParameterException"
+
+
+@mock_aws
+def test_get_resources_by_resource_arn_list():
+    client = boto3.client("s3", region_name="us-east-1")
+    for i in range(3):
+        bucket_name = f"arn-list-bucket-{i}"
+        client.create_bucket(Bucket=bucket_name)
+        client.put_bucket_tagging(
+            Bucket=bucket_name,
+            Tagging={"TagSet": [{"Key": "env", "Value": bucket_name}]},
+        )
+
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="us-east-1")
+    resp = rtapi.get_resources(
+        ResourceARNList=[
+            "arn:aws:s3:::arn-list-bucket-0",
+            "arn:aws:s3:::arn-list-bucket-2",
+            "arn:aws:s3:::arn-list-bucket-does-not-exist",
+        ]
+    )
+
+    # Only the requested, existing buckets are returned. The non-existent ARN is
+    # silently omitted, and the un-requested arn-list-bucket-1 is excluded.
+    mappings = {
+        r["ResourceARN"]: {t["Key"]: t["Value"] for t in r["Tags"]}
+        for r in resp["ResourceTagMappingList"]
+    }
+    assert mappings == {
+        "arn:aws:s3:::arn-list-bucket-0": {"env": "arn-list-bucket-0"},
+        "arn:aws:s3:::arn-list-bucket-2": {"env": "arn-list-bucket-2"},
+    }
+    # ARN-list requests are not paginated
+    assert resp.get("PaginationToken", "") == ""

--- a/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi_workspaces.py
+++ b/tests/test_resourcegroupstaggingapi/test_resourcegroupstaggingapi_workspaces.py
@@ -55,6 +55,53 @@ def test_get_resources_workspaces():
 
 
 @mock_aws
+def test_tag_resources_workspaces():
+    workspaces = boto3.client("workspaces", region_name="eu-central-1")
+
+    # Create a tagged Workspace
+    directory_id = create_directory()
+    workspaces.register_workspace_directory(DirectoryId=directory_id)
+    resp = workspaces.create_workspaces(
+        Workspaces=[
+            {
+                "DirectoryId": directory_id,
+                "UserName": "Administrator",
+                "BundleId": "wsb-bh8rsxt14",
+                "Tags": [{"Key": "Test", "Value": "1"}],
+            },
+        ]
+    )
+    workspace_id = resp["PendingRequests"][0]["WorkspaceId"]
+
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name="eu-central-1")
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["workspaces"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    workspace_arn = resp["ResourceTagMappingList"][0]["ResourceARN"]
+    assert workspace_arn.endswith(f"workspace/{workspace_id}")
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(
+        ResourceARNList=[workspace_arn],
+        Tags={"Test2": "2"},
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["workspaces"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert {"Key": "Test", "Value": "1"} in tags
+    assert {"Key": "Test2", "Value": "2"} in tags
+
+    # Filtering on the newly-added tag returns the Workspace
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["workspaces"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == workspace_arn
+
+
+@mock_aws
 def test_get_resources_workspace_directories():
     workspaces = boto3.client("workspaces", region_name="eu-central-1")
 

--- a/tests/test_sagemaker/test_sagemaker_integration.py
+++ b/tests/test_sagemaker/test_sagemaker_integration.py
@@ -1,0 +1,63 @@
+import boto3
+
+from moto import mock_aws
+
+TEST_REGION_NAME = "us-east-1"
+TEST_ROLE_ARN = "arn:aws:iam::123456789012:role/FooRole"
+
+
+@mock_aws
+def test_tag_and_untag_resources_sagemaker():
+    client = boto3.client("sagemaker", region_name=TEST_REGION_NAME)
+    rtapi = boto3.client("resourcegroupstaggingapi", region_name=TEST_REGION_NAME)
+
+    # Create a tagged model
+    model_arn = client.create_model(
+        ModelName="my-model",
+        ExecutionRoleArn=TEST_ROLE_ARN,
+        Tags=[{"Key": "Test", "Value": "1"}],
+    )["ModelArn"]
+
+    # Basic test
+    resp = rtapi.get_resources(ResourceTypeFilters=["sagemaker:model"])
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == model_arn
+    assert resp["ResourceTagMappingList"][0]["Tags"] == [{"Key": "Test", "Value": "1"}]
+
+    # Add a tag through the Resource Groups Tagging API
+    failed = rtapi.tag_resources(
+        ResourceARNList=[model_arn],
+        Tags={"Test2": "2"},
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["sagemaker:model"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert {"Key": "Test", "Value": "1"} in tags
+    assert {"Key": "Test2", "Value": "2"} in tags
+
+    # Filtering on the newly-added tag returns the model
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["sagemaker:model"],
+        TagFilters=[{"Key": "Test2", "Values": ["2"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 1
+    assert resp["ResourceTagMappingList"][0]["ResourceARN"] == model_arn
+
+    # Remove the original tag through the Resource Groups Tagging API
+    failed = rtapi.untag_resources(
+        ResourceARNList=[model_arn],
+        TagKeys=["Test"],
+    )
+    assert failed["FailedResourcesMap"] == {}
+
+    resp = rtapi.get_resources(ResourceTypeFilters=["sagemaker:model"])
+    tags = resp["ResourceTagMappingList"][0]["Tags"]
+    assert tags == [{"Key": "Test2", "Value": "2"}]
+
+    # The removed tag no longer matches
+    resp = rtapi.get_resources(
+        ResourceTypeFilters=["sagemaker:model"],
+        TagFilters=[{"Key": "Test", "Values": ["1"]}],
+    )
+    assert len(resp["ResourceTagMappingList"]) == 0


### PR DESCRIPTION
This changeset completes the major refactor of the **Resource Groups Tagging API** backend (initiated in #10038) to dramatically simplify `moto/resourcegroupstaggingapi/models.py` by migrating tagging support to individual service backends via the new `TaggableResourcesMixin` pattern--replacing hundreds of lines of imperative, service-specific code with a clean, extensible abstraction.

> [!NOTE]
> It's possible that the `tag_resource` method on `TaggableResourcesMixin` may clash with an existing `tag_resource` method already defined on a service backend class.
>
>When this happens we:
> - use the method signature from `TaggableResourcesMixin` as the canonical interface
> - translate/adapt any `tag_resource` method signature differences in `responses.py`
>
> This allows the mixin's tagging interface to be consistent across all services while still accommodating tagging requests made with an individual service's native client API.