### PR TITLE
AppSync: migrate to new request parsing/response serialization

### DIFF
--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -179,7 +179,7 @@ class GraphqlAPI(BaseModel):
         authentication_type: str,
         additional_authentication_providers: list[str] | None,
         log_config: str,
-        xray_enabled: str,
+        xray_enabled: bool,
         user_pool_config: str,
         open_id_connect_config: str,
         lambda_authorizer_config: str,
@@ -215,7 +215,7 @@ class GraphqlAPI(BaseModel):
         log_config: str,
         open_id_connect_config: str,
         user_pool_config: str,
-        xray_enabled: str,
+        xray_enabled: bool,
     ) -> None:
         if name:
             self.name = name
@@ -427,7 +427,7 @@ class AppSyncBackend(BaseBackend, TaggableResourcesMixin):
         user_pool_config: str,
         open_id_connect_config: str,
         additional_authentication_providers: list[str] | None,
-        xray_enabled: str,
+        xray_enabled: bool,
         lambda_authorizer_config: str,
         tags: dict[str, str],
         visibility: str,
@@ -461,7 +461,7 @@ class AppSyncBackend(BaseBackend, TaggableResourcesMixin):
         user_pool_config: str,
         open_id_connect_config: str,
         additional_authentication_providers: list[str] | None,
-        xray_enabled: str,
+        xray_enabled: bool,
         lambda_authorizer_config: str,
     ) -> GraphqlAPI:
         graphql_api = self.graphql_apis[api_id]

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -8,7 +8,6 @@ from typing import Any
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
-from moto.core.utils import unix_time
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
@@ -150,7 +149,7 @@ class GraphqlSchema(BaseModel):
 
 
 class GraphqlAPIKey(BaseModel):
-    def __init__(self, description: str, expires: int | None):
+    def __init__(self, description: str, expires: datetime | None):
         self.key_id = str(mock_random.uuid4())[0:6]
         self.description = description
         if not expires:
@@ -159,11 +158,11 @@ class GraphqlAPIKey(BaseModel):
                 minute=0, second=0, microsecond=0, tzinfo=None
             )
             default_expiry = default_expiry + timedelta(days=7)
-            self.expires = unix_time(default_expiry)
+            self.expires = default_expiry
         else:
             self.expires = expires
 
-    def update(self, description: str | None, expires: int | None) -> None:
+    def update(self, description: str | None, expires: datetime | None) -> None:
         if description:
             self.description = description
         if expires:
@@ -236,7 +235,9 @@ class GraphqlAPI(BaseModel):
         if xray_enabled is not None:
             self.xray_enabled = xray_enabled
 
-    def create_api_key(self, description: str, expires: int | None) -> GraphqlAPIKey:
+    def create_api_key(
+        self, description: str, expires: datetime | None
+    ) -> GraphqlAPIKey:
         api_key = GraphqlAPIKey(description, expires)
         self.api_keys[api_key.key_id] = api_key
         return api_key
@@ -248,7 +249,7 @@ class GraphqlAPI(BaseModel):
         self.api_keys.pop(api_key_id)
 
     def update_api_key(
-        self, api_key_id: str, description: str, expires: int | None
+        self, api_key_id: str, description: str, expires: datetime | None
     ) -> GraphqlAPIKey:
         api_key = self.api_keys[api_key_id]
         api_key.update(description, expires)
@@ -305,7 +306,7 @@ class GraphqlAPI(BaseModel):
 
 # region: EventsAPI
 class EventsAPIKey(BaseModel):
-    def __init__(self, description: str, expires: int | None):
+    def __init__(self, description: str, expires: datetime | None):
         self.key_id = str(mock_random.uuid4())[0:6]
         self.description = description
         if not expires:
@@ -314,11 +315,11 @@ class EventsAPIKey(BaseModel):
                 minute=0, second=0, microsecond=0, tzinfo=None
             )
             default_expiry = default_expiry + timedelta(days=7)
-            self.expires = unix_time(default_expiry)
+            self.expires = default_expiry
         else:
             self.expires = expires
 
-    def update(self, description: str | None, expires: int | None) -> None:
+    def update(self, description: str | None, expires: datetime | None) -> None:
         if description:
             self.description = description
         if expires:
@@ -347,7 +348,7 @@ class ChannelNamespace(BaseModel):
 
         self.channel_namespace_arn = f"arn:{get_partition(region)}:appsync:{region}:{account_id}:apis/{api_id}/channelNamespace/{name}"
 
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(timezone.utc)
         self.created = now
         self.last_modified = now
 
@@ -381,11 +382,13 @@ class EventsAPI(BaseModel):
             "HTTP": f"{dns_prefix}.appsync-api.{self.region}.amazonaws.com",
         }
 
-        self.created = datetime.now(timezone.utc).isoformat()
+        self.created = datetime.now(timezone.utc)
 
         self.backend = backend
 
-    def create_api_key(self, description: str, expires: int | None) -> EventsAPIKey:
+    def create_api_key(
+        self, description: str, expires: datetime | None
+    ) -> EventsAPIKey:
         api_key = EventsAPIKey(description, expires)
         self.api_keys[api_key.key_id] = api_key
         return api_key
@@ -397,7 +400,7 @@ class EventsAPI(BaseModel):
         self.api_keys.pop(api_key_id)
 
     def update_api_key(
-        self, api_key_id: str, description: str, expires: int | None
+        self, api_key_id: str, description: str, expires: datetime | None
     ) -> EventsAPIKey:
         api_key = self.api_keys[api_key_id]
         api_key.update(description, expires)
@@ -501,7 +504,7 @@ class AppSyncBackend(BaseBackend, TaggableResourcesMixin):
         return self.graphql_apis.values()
 
     def create_api_key(
-        self, api_id: str, description: str, expires: int | None
+        self, api_id: str, description: str, expires: datetime | None
     ) -> GraphqlAPIKey | EventsAPIKey:
         if api_id in self.graphql_apis:
             return self.graphql_apis[api_id].create_api_key(description, expires)
@@ -530,7 +533,7 @@ class AppSyncBackend(BaseBackend, TaggableResourcesMixin):
         api_id: str,
         api_key_id: str,
         description: str,
-        expires: int | None,
+        expires: datetime | None,
     ) -> GraphqlAPIKey | EventsAPIKey:
         if api_id in self.graphql_apis:
             return self.graphql_apis[api_id].update_api_key(

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterable, Iterator
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 
 from moto.core.base_backend import BackendDict, BaseBackend
 from moto.core.common_models import BaseModel
 from moto.core.resource_tagging import TaggableResourcesMixin, TaggedResource
+from moto.core.utils import utcnow
 from moto.moto_api._internal import mock_random
 from moto.utilities.tagging_service import TaggingService
 from moto.utilities.utils import get_partition
@@ -153,7 +154,7 @@ class GraphqlAPIKey(BaseModel):
         self.key_id = str(mock_random.uuid4())[0:6]
         self.description = description
         if not expires:
-            default_expiry = datetime.now(timezone.utc)
+            default_expiry = utcnow()
             default_expiry = default_expiry.replace(
                 minute=0, second=0, microsecond=0, tzinfo=None
             )
@@ -310,7 +311,7 @@ class EventsAPIKey(BaseModel):
         self.key_id = str(mock_random.uuid4())[0:6]
         self.description = description
         if not expires:
-            default_expiry = datetime.now(timezone.utc)
+            default_expiry = utcnow()
             default_expiry = default_expiry.replace(
                 minute=0, second=0, microsecond=0, tzinfo=None
             )
@@ -348,7 +349,7 @@ class ChannelNamespace(BaseModel):
 
         self.channel_namespace_arn = f"arn:{get_partition(region)}:appsync:{region}:{account_id}:apis/{api_id}/channelNamespace/{name}"
 
-        now = datetime.now(timezone.utc)
+        now = utcnow()
         self.created = now
         self.last_modified = now
 
@@ -382,7 +383,7 @@ class EventsAPI(BaseModel):
             "HTTP": f"{dns_prefix}.appsync-api.{self.region}.amazonaws.com",
         }
 
-        self.created = datetime.now(timezone.utc)
+        self.created = utcnow()
 
         self.backend = backend
 

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -81,17 +81,6 @@ class APICache(BaseModel):
         if health_metrics_config is not None:
             self.health_metrics_config = health_metrics_config
 
-    def to_json(self) -> dict[str, Any]:
-        return {
-            "ttl": self.ttl,
-            "transitEncryptionEnabled": self.transit_encryption_enabled,
-            "atRestEncryptionEnabled": self.at_rest_encryption_enabled,
-            "apiCachingBehavior": self.api_caching_behavior,
-            "type": self.type,
-            "healthMetricsConfig": self.health_metrics_config,
-            "status": self.status,
-        }
-
 
 # endregion
 
@@ -179,14 +168,6 @@ class GraphqlAPIKey(BaseModel):
             self.description = description
         if expires:
             self.expires = expires
-
-    def to_json(self) -> dict[str, Any]:
-        return {
-            "id": self.key_id,
-            "description": self.description,
-            "expires": self.expires,
-            "deletes": self.expires,
-        }
 
 
 class GraphqlAPI(BaseModel):
@@ -318,23 +299,6 @@ class GraphqlAPI(BaseModel):
     def delete_api_cache(self) -> None:
         self.api_cache = None
 
-    def to_json(self) -> dict[str, Any]:
-        return {
-            "name": self.name,
-            "apiId": self.api_id,
-            "authenticationType": self.authentication_type,
-            "arn": self.arn,
-            "uris": {"GRAPHQL": "http://graphql.uri"},
-            "additionalAuthenticationProviders": self.additional_authentication_providers,
-            "lambdaAuthorizerConfig": self.lambda_authorizer_config,
-            "logConfig": self.log_config,
-            "openIDConnectConfig": self.open_id_connect_config,
-            "userPoolConfig": self.user_pool_config,
-            "xrayEnabled": self.xray_enabled,
-            "visibility": self.visibility,
-            "tags": self.backend.list_tags_for_resource(self.arn),
-        }
-
 
 # endregion
 
@@ -359,14 +323,6 @@ class EventsAPIKey(BaseModel):
             self.description = description
         if expires:
             self.expires = expires
-
-    def to_json(self) -> dict[str, Any]:
-        return {
-            "id": self.key_id,
-            "description": self.description,
-            "expires": self.expires,
-            "deletes": self.expires,
-        }
 
 
 class ChannelNamespace(BaseModel):
@@ -396,28 +352,6 @@ class ChannelNamespace(BaseModel):
         self.last_modified = now
 
         self.backend = backend
-
-    def to_json(self) -> dict[str, Any]:
-        response = {
-            "apiId": self.api_id,
-            "name": self.name,
-            "subscribeAuthModes": self.subscribe_auth_modes,
-            "publishAuthModes": self.publish_auth_modes,
-            "channelNamespaceArn": self.channel_namespace_arn,
-            "created": self.created,
-            "lastModified": self.last_modified,
-            "handlerConfigs": self.handler_configs,
-        }
-
-        if self.code_handlers:
-            response["codeHandlers"] = self.code_handlers
-
-        if self.backend:
-            response["tags"] = self.backend.list_tags_for_resource(
-                self.channel_namespace_arn
-            )
-
-        return response
 
 
 class EventsAPI(BaseModel):
@@ -450,22 +384,6 @@ class EventsAPI(BaseModel):
         self.created = datetime.now(timezone.utc).isoformat()
 
         self.backend = backend
-
-    def to_json(self) -> dict[str, Any]:
-        response = {
-            "apiId": self.api_id,
-            "name": self.name,
-            "tags": self.backend.list_tags_for_resource(self.api_arn),
-            "dns": self.dns,
-            "apiArn": self.api_arn,
-            "created": self.created,
-            "eventConfig": self.event_config or {},  # Default to empty dict if None
-        }
-
-        if self.owner_contact:
-            response["ownerContact"] = self.owner_contact
-
-        return response
 
     def create_api_key(self, description: str, expires: int | None) -> EventsAPIKey:
         api_key = EventsAPIKey(description, expires)

--- a/moto/appsync/models.py
+++ b/moto/appsync/models.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import json
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta, timezone
@@ -274,8 +273,8 @@ class GraphqlAPI(BaseModel):
         api_key.update(description, expires)
         return api_key
 
-    def start_schema_creation(self, definition: str) -> None:
-        graphql_definition = base64.b64decode(definition).decode("utf-8")
+    def start_schema_creation(self, definition: bytes) -> None:
+        graphql_definition = definition.decode("utf-8")
 
         self.graphql_schema = GraphqlSchema(graphql_definition, region_name=self.region)
 
@@ -624,7 +623,7 @@ class AppSyncBackend(BaseBackend, TaggableResourcesMixin):
                 api_key_id, description, expires
             )
 
-    def start_schema_creation(self, api_id: str, definition: str) -> str:
+    def start_schema_creation(self, api_id: str, definition: bytes) -> str:
         self.graphql_apis[api_id].start_schema_creation(definition)
         return "PROCESSING"
 

--- a/moto/appsync/responses.py
+++ b/moto/appsync/responses.py
@@ -3,7 +3,6 @@
 import json
 import re
 from typing import Any
-from urllib.parse import unquote
 from uuid import uuid4
 
 from moto.core.common_types import TYPE_RESPONSE
@@ -19,9 +18,10 @@ class AppSyncResponse(BaseResponse):
 
     def __init__(self) -> None:
         super().__init__(service_name="appsync")
+        self.automated_parameter_parsing = True
 
     @staticmethod
-    def dns_event_response(request: Any, url: str, headers: Any) -> TYPE_RESPONSE:  # type: ignore[misc]
+    def dns_event_response(request: Any, url: str, headers: Any) -> TYPE_RESPONSE:
         data = json.loads(request.data.decode("utf-8"))
 
         response: dict[str, list[Any]] = {"failed": [], "successful": []}
@@ -36,19 +36,18 @@ class AppSyncResponse(BaseResponse):
         return appsync_backends[self.current_account][self.region]
 
     def create_graphql_api(self) -> str:
-        params = json.loads(self.body)
-        name = params.get("name")
-        log_config = params.get("logConfig")
-        authentication_type = params.get("authenticationType")
-        user_pool_config = params.get("userPoolConfig")
-        open_id_connect_config = params.get("openIDConnectConfig")
-        tags = params.get("tags")
-        additional_authentication_providers = params.get(
+        name = self._get_param("name")
+        log_config = self._get_param("logConfig")
+        authentication_type = self._get_param("authenticationType")
+        user_pool_config = self._get_param("userPoolConfig")
+        open_id_connect_config = self._get_param("openIDConnectConfig")
+        tags = self._get_param("tags")
+        additional_authentication_providers = self._get_param(
             "additionalAuthenticationProviders"
         )
-        xray_enabled = params.get("xrayEnabled", False)
-        lambda_authorizer_config = params.get("lambdaAuthorizerConfig")
-        visibility = params.get("visibility")
+        xray_enabled = self._get_param("xrayEnabled", False)
+        lambda_authorizer_config = self._get_param("lambdaAuthorizerConfig")
+        visibility = self._get_param("visibility")
         graphql_api = self.appsync_backend.create_graphql_api(
             name=name,
             log_config=log_config,
@@ -66,7 +65,7 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"graphqlApi": response})
 
     def get_graphql_api(self) -> str:
-        api_id = self.path.split("/")[-1]
+        api_id = self._get_param("apiId")
 
         graphql_api = self.appsync_backend.get_graphql_api(api_id=api_id)
         response = graphql_api.to_json()
@@ -74,24 +73,23 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"graphqlApi": response})
 
     def delete_graphql_api(self) -> str:
-        api_id = self.path.split("/")[-1]
+        api_id = self._get_param("apiId")
         self.appsync_backend.delete_graphql_api(api_id=api_id)
         return "{}"
 
     def update_graphql_api(self) -> str:
-        api_id = self.path.split("/")[-1]
+        api_id = self._get_param("apiId")
 
-        params = json.loads(self.body)
-        name = params.get("name")
-        log_config = params.get("logConfig")
-        authentication_type = params.get("authenticationType")
-        user_pool_config = params.get("userPoolConfig")
-        open_id_connect_config = params.get("openIDConnectConfig")
-        additional_authentication_providers = params.get(
+        name = self._get_param("name")
+        log_config = self._get_param("logConfig")
+        authentication_type = self._get_param("authenticationType")
+        user_pool_config = self._get_param("userPoolConfig")
+        open_id_connect_config = self._get_param("openIDConnectConfig")
+        additional_authentication_providers = self._get_param(
             "additionalAuthenticationProviders"
         )
-        xray_enabled = params.get("xrayEnabled", False)
-        lambda_authorizer_config = params.get("lambdaAuthorizerConfig")
+        xray_enabled = self._get_param("xrayEnabled", False)
+        lambda_authorizer_config = self._get_param("lambdaAuthorizerConfig")
 
         api = self.appsync_backend.update_graphql_api(
             api_id=api_id,
@@ -111,11 +109,9 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"graphqlApis": [api.to_json() for api in graphql_apis]})
 
     def create_api_key(self) -> str:
-        params = json.loads(self.body)
-        # /v1/apis/[api_id]/apikeys
-        api_id = self.path.split("/")[-2]
-        description = params.get("description")
-        expires = params.get("expires")
+        api_id = self._get_param("apiId")
+        description = self._get_param("description")
+        expires = self._get_param("expires")
 
         if expires:
             current_time = int(unix_time())
@@ -131,23 +127,21 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"apiKey": api_key.to_json()})
 
     def delete_api_key(self) -> str:
-        api_id = self.path.split("/")[-3]
-        api_key_id = self.path.split("/")[-1]
+        api_id = self._get_param("apiId")
+        api_key_id = self._get_param("id")
         self.appsync_backend.delete_api_key(api_id=api_id, api_key_id=api_key_id)
         return "{}"
 
     def list_api_keys(self) -> str:
-        # /v1/apis/[api_id]/apikeys
-        api_id = self.path.split("/")[-2]
+        api_id = self._get_param("apiId")
         api_keys = self.appsync_backend.list_api_keys(api_id=api_id)
         return json.dumps({"apiKeys": [key.to_json() for key in api_keys]})
 
     def update_api_key(self) -> str:
-        api_id = self.path.split("/")[-3]
-        api_key_id = self.path.split("/")[-1]
-        params = json.loads(self.body)
-        description = params.get("description")
-        expires = params.get("expires")
+        api_id = self._get_param("apiId")
+        api_key_id = self._get_param("id")
+        description = self._get_param("description")
+        expires = self._get_param("expires")
 
         # Validate that API key expires at least 1 day from now
         if expires:
@@ -167,62 +161,50 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"apiKey": api_key.to_json()})
 
     def start_schema_creation(self) -> str:
-        params = json.loads(self.body)
-        api_id = self.path.split("/")[-2]
-        definition = params.get("definition")
+        api_id = self._get_param("apiId")
+        definition = self._get_param("definition")
         status = self.appsync_backend.start_schema_creation(
             api_id=api_id, definition=definition
         )
         return json.dumps({"status": status})
 
     def get_schema_creation_status(self) -> str:
-        api_id = self.path.split("/")[-2]
+        api_id = self._get_param("apiId")
         status, details = self.appsync_backend.get_schema_creation_status(api_id=api_id)
         return json.dumps({"status": status, "details": details})
 
     def tag_resource(self) -> str:
-        resource_arn = self._extract_arn_from_path()
-        params = json.loads(self.body)
-        tags = params.get("tags")
+        resource_arn = self._get_param("resourceArn")
+        tags = self._get_param("tags")
         self.appsync_backend.tag_resource(resource_arn=resource_arn, tags=tags)
         return "{}"
 
     def untag_resource(self) -> str:
-        resource_arn = self._extract_arn_from_path()
-        tag_keys = self.querystring.get("tagKeys", [])
+        resource_arn = self._get_param("resourceArn")
+        tag_keys = self._get_param("tagKeys", [])
         self.appsync_backend.untag_resource(
             resource_arn=resource_arn, tag_keys=tag_keys
         )
         return "{}"
 
     def list_tags_for_resource(self) -> str:
-        resource_arn = self._extract_arn_from_path()
+        resource_arn = self._get_param("resourceArn")
         tags = self.appsync_backend.list_tags_for_resource(resource_arn=resource_arn)
         return json.dumps({"tags": tags})
 
-    def _extract_arn_from_path(self) -> str:
-        # /v1/tags/arn_that_may_contain_a_slash
-        path = unquote(self.path)
-        return "/".join(path.split("/")[3:])
-
     def get_type(self) -> str:
-        api_id = unquote(self.path.split("/")[-3])
-        type_name = self.path.split("/")[-1]
-        type_format = self.querystring.get("format")[0]  # type: ignore[index]
+        api_id = self._get_param("apiId")
+        type_name = self._get_param("typeName")
+        type_format = self._get_param("format")
         graphql_type = self.appsync_backend.get_type(
             api_id=api_id, type_name=type_name, type_format=type_format
         )
         return json.dumps({"type": graphql_type})
 
     def get_introspection_schema(self) -> str:
-        api_id = self.path.split("/")[-2]
-        format_ = self.querystring.get("format")[0]  # type: ignore[index]
-        if self.querystring.get("includeDirectives"):
-            include_directives = (
-                self.querystring.get("includeDirectives")[0].lower() == "true"  # type: ignore[index]
-            )
-        else:
-            include_directives = True
+        api_id = self._get_param("apiId")
+        format_ = self._get_param("format")
+        include_directives = self._get_bool_param("includeDirectives", True)
         graphql_schema = self.appsync_backend.get_graphql_schema(api_id=api_id)
 
         schema = graphql_schema.get_introspection_schema(
@@ -231,28 +213,27 @@ class AppSyncResponse(BaseResponse):
         return schema
 
     def get_api_cache(self) -> str:
-        api_id = self.path.split("/")[-2]
+        api_id = self._get_param("apiId")
         api_cache = self.appsync_backend.get_api_cache(
             api_id=api_id,
         )
         return json.dumps({"apiCache": api_cache.to_json()})
 
     def delete_api_cache(self) -> str:
-        api_id = self.path.split("/")[-2]
+        api_id = self._get_param("apiId")
         self.appsync_backend.delete_api_cache(
             api_id=api_id,
         )
         return "{}"
 
     def create_api_cache(self) -> str:
-        params = json.loads(self.body)
-        api_id = self.path.split("/")[-2]
-        ttl = params.get("ttl")
-        transit_encryption_enabled = params.get("transitEncryptionEnabled")
-        at_rest_encryption_enabled = params.get("atRestEncryptionEnabled")
-        api_caching_behavior = params.get("apiCachingBehavior")
-        type = params.get("type")
-        health_metrics_config = params.get("healthMetricsConfig")
+        api_id = self._get_param("apiId")
+        ttl = self._get_param("ttl")
+        transit_encryption_enabled = self._get_param("transitEncryptionEnabled")
+        at_rest_encryption_enabled = self._get_param("atRestEncryptionEnabled")
+        api_caching_behavior = self._get_param("apiCachingBehavior")
+        type = self._get_param("type")
+        health_metrics_config = self._get_param("healthMetricsConfig")
         api_cache = self.appsync_backend.create_api_cache(
             api_id=api_id,
             ttl=ttl,
@@ -265,12 +246,11 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"apiCache": api_cache.to_json()})
 
     def update_api_cache(self) -> str:
-        api_id = self.path.split("/")[-3]
-        params = json.loads(self.body)
-        ttl = params.get("ttl")
-        api_caching_behavior = params.get("apiCachingBehavior")
-        type = params.get("type")
-        health_metrics_config = params.get("healthMetricsConfig")
+        api_id = self._get_param("apiId")
+        ttl = self._get_param("ttl")
+        api_caching_behavior = self._get_param("apiCachingBehavior")
+        type = self._get_param("type")
+        health_metrics_config = self._get_param("healthMetricsConfig")
         api_cache = self.appsync_backend.update_api_cache(
             api_id=api_id,
             ttl=ttl,
@@ -281,15 +261,14 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"apiCache": api_cache.to_json()})
 
     def flush_api_cache(self) -> str:
-        api_id = self.path.split("/")[-2]
+        api_id = self._get_param("apiId")
         self.appsync_backend.flush_api_cache(
             api_id=api_id,
         )
         return "{}"
 
     def create_api(self) -> str:
-        params = json.loads(self.body)
-        name = params.get("name")
+        name = self._get_param("name")
 
         if name:
             pattern = r"^[A-Za-z0-9_\-\ ]+$"
@@ -301,9 +280,9 @@ class AppSyncResponse(BaseResponse):
                     "[A-Za-z0-9_\\-\\ ]+"
                 )
 
-        owner_contact = params.get("ownerContact")
-        tags = params.get("tags", {})
-        event_config = params.get("eventConfig")
+        owner_contact = self._get_param("ownerContact")
+        tags = self._get_param("tags", {})
+        event_config = self._get_param("eventConfig")
 
         api = self.appsync_backend.create_api(
             name=name,
@@ -320,14 +299,13 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"apis": [api.to_json() for api in apis]})
 
     def delete_api(self) -> str:
-        api_id = self.path.split("/")[-1]
+        api_id = self._get_param("apiId")
         self.appsync_backend.delete_api(api_id=api_id)
         return "{}"
 
     def create_channel_namespace(self) -> str:
-        params = json.loads(self.body)
-        api_id = self.path.split("/")[-2]
-        name = params.get("name")
+        api_id = self._get_param("apiId")
+        name = self._get_param("name")
 
         if name:
             pattern = r"^[A-Za-z0-9](?:[A-Za-z0-9\-]{0,48}[A-Za-z0-9])?$"
@@ -339,11 +317,11 @@ class AppSyncResponse(BaseResponse):
                     "([A-Za-z0-9](?:[A-Za-z0-9\\-]{0,48}[A-Za-z0-9])?)"
                 )
 
-        subscribe_auth_modes = params.get("subscribeAuthModes")
-        publish_auth_modes = params.get("publishAuthModes")
-        code_handlers = params.get("codeHandlers")
-        tags = params.get("tags", {})
-        handler_configs = params.get("handlerConfigs", {})
+        subscribe_auth_modes = self._get_param("subscribeAuthModes")
+        publish_auth_modes = self._get_param("publishAuthModes")
+        code_handlers = self._get_param("codeHandlers")
+        tags = self._get_param("tags", {})
+        handler_configs = self._get_param("handlerConfigs", {})
 
         channel_namespace = self.appsync_backend.create_channel_namespace(
             api_id=api_id,
@@ -358,7 +336,7 @@ class AppSyncResponse(BaseResponse):
         return json.dumps({"channelNamespace": channel_namespace.to_json()})
 
     def list_channel_namespaces(self) -> str:
-        api_id = self.path.split("/")[-2]
+        api_id = self._get_param("apiId")
         channel_namespaces = self.appsync_backend.list_channel_namespaces(api_id=api_id)
         return json.dumps(
             {
@@ -370,9 +348,8 @@ class AppSyncResponse(BaseResponse):
         )
 
     def delete_channel_namespace(self) -> str:
-        path_parts = self.path.split("/")
-        api_id = path_parts[-3]
-        name = path_parts[-1]
+        api_id = self._get_param("apiId")
+        name = self._get_param("name")
 
         self.appsync_backend.delete_channel_namespace(
             api_id=api_id,
@@ -381,7 +358,7 @@ class AppSyncResponse(BaseResponse):
         return "{}"
 
     def get_api(self) -> str:
-        api_id = self.path.split("/")[-1]
+        api_id = self._get_param("apiId")
 
         api = self.appsync_backend.get_api(api_id=api_id)
         response = api.to_json()

--- a/moto/appsync/responses.py
+++ b/moto/appsync/responses.py
@@ -6,7 +6,7 @@ from typing import Any
 from uuid import uuid4
 
 from moto.core.common_types import TYPE_RESPONSE
-from moto.core.responses import BaseResponse
+from moto.core.responses import ActionResult, BaseResponse, EmptyResult
 from moto.core.utils import unix_time
 
 from .exceptions import ApiKeyValidityOutOfBoundsException, AWSValidationException
@@ -35,7 +35,7 @@ class AppSyncResponse(BaseResponse):
         """Return backend instance specific for this region."""
         return appsync_backends[self.current_account][self.region]
 
-    def create_graphql_api(self) -> str:
+    def create_graphql_api(self) -> ActionResult:
         name = self._get_param("name")
         log_config = self._get_param("logConfig")
         authentication_type = self._get_param("authenticationType")
@@ -60,24 +60,53 @@ class AppSyncResponse(BaseResponse):
             tags=tags,
             visibility=visibility,
         )
-        response = graphql_api.to_json()
-        response["tags"] = self.appsync_backend.list_tags_for_resource(graphql_api.arn)
-        return json.dumps({"graphqlApi": response})
+        result = {
+            "graphqlApi": {
+                "name": graphql_api.name,
+                "apiId": graphql_api.api_id,
+                "authenticationType": graphql_api.authentication_type,
+                "arn": graphql_api.arn,
+                "uris": {"GRAPHQL": "http://graphql.uri"},
+                "additionalAuthenticationProviders": graphql_api.additional_authentication_providers,
+                "lambdaAuthorizerConfig": graphql_api.lambda_authorizer_config,
+                "logConfig": graphql_api.log_config,
+                "openIDConnectConfig": graphql_api.open_id_connect_config,
+                "userPoolConfig": graphql_api.user_pool_config,
+                "xrayEnabled": graphql_api.xray_enabled,
+                "visibility": graphql_api.visibility,
+                "tags": self.appsync_backend.list_tags_for_resource(graphql_api.arn),
+            }
+        }
+        return ActionResult(result)
 
-    def get_graphql_api(self) -> str:
+    def get_graphql_api(self) -> ActionResult:
         api_id = self._get_param("apiId")
-
         graphql_api = self.appsync_backend.get_graphql_api(api_id=api_id)
-        response = graphql_api.to_json()
-        response["tags"] = self.appsync_backend.list_tags_for_resource(graphql_api.arn)
-        return json.dumps({"graphqlApi": response})
+        result = {
+            "graphqlApi": {
+                "name": graphql_api.name,
+                "apiId": graphql_api.api_id,
+                "authenticationType": graphql_api.authentication_type,
+                "arn": graphql_api.arn,
+                "uris": {"GRAPHQL": "http://graphql.uri"},
+                "additionalAuthenticationProviders": graphql_api.additional_authentication_providers,
+                "lambdaAuthorizerConfig": graphql_api.lambda_authorizer_config,
+                "logConfig": graphql_api.log_config,
+                "openIDConnectConfig": graphql_api.open_id_connect_config,
+                "userPoolConfig": graphql_api.user_pool_config,
+                "xrayEnabled": graphql_api.xray_enabled,
+                "visibility": graphql_api.visibility,
+                "tags": self.appsync_backend.list_tags_for_resource(graphql_api.arn),
+            }
+        }
+        return ActionResult(result)
 
-    def delete_graphql_api(self) -> str:
+    def delete_graphql_api(self) -> ActionResult:
         api_id = self._get_param("apiId")
         self.appsync_backend.delete_graphql_api(api_id=api_id)
-        return "{}"
+        return EmptyResult()
 
-    def update_graphql_api(self) -> str:
+    def update_graphql_api(self) -> ActionResult:
         api_id = self._get_param("apiId")
 
         name = self._get_param("name")
@@ -91,7 +120,7 @@ class AppSyncResponse(BaseResponse):
         xray_enabled = self._get_param("xrayEnabled", False)
         lambda_authorizer_config = self._get_param("lambdaAuthorizerConfig")
 
-        api = self.appsync_backend.update_graphql_api(
+        graphql_api = self.appsync_backend.update_graphql_api(
             api_id=api_id,
             name=name,
             log_config=log_config,
@@ -102,13 +131,52 @@ class AppSyncResponse(BaseResponse):
             xray_enabled=xray_enabled,
             lambda_authorizer_config=lambda_authorizer_config,
         )
-        return json.dumps({"graphqlApi": api.to_json()})
+        result = {
+            "graphqlApi": {
+                "name": graphql_api.name,
+                "apiId": graphql_api.api_id,
+                "authenticationType": graphql_api.authentication_type,
+                "arn": graphql_api.arn,
+                "uris": {"GRAPHQL": "http://graphql.uri"},
+                "additionalAuthenticationProviders": graphql_api.additional_authentication_providers,
+                "lambdaAuthorizerConfig": graphql_api.lambda_authorizer_config,
+                "logConfig": graphql_api.log_config,
+                "openIDConnectConfig": graphql_api.open_id_connect_config,
+                "userPoolConfig": graphql_api.user_pool_config,
+                "xrayEnabled": graphql_api.xray_enabled,
+                "visibility": graphql_api.visibility,
+                "tags": self.appsync_backend.list_tags_for_resource(graphql_api.arn),
+            }
+        }
+        return ActionResult(result)
 
-    def list_graphql_apis(self) -> str:
+    def list_graphql_apis(self) -> ActionResult:
         graphql_apis = self.appsync_backend.list_graphql_apis()
-        return json.dumps({"graphqlApis": [api.to_json() for api in graphql_apis]})
+        result = {
+            "graphqlApis": [
+                {
+                    "name": graphql_api.name,
+                    "apiId": graphql_api.api_id,
+                    "authenticationType": graphql_api.authentication_type,
+                    "arn": graphql_api.arn,
+                    "uris": {"GRAPHQL": "http://graphql.uri"},
+                    "additionalAuthenticationProviders": graphql_api.additional_authentication_providers,
+                    "lambdaAuthorizerConfig": graphql_api.lambda_authorizer_config,
+                    "logConfig": graphql_api.log_config,
+                    "openIDConnectConfig": graphql_api.open_id_connect_config,
+                    "userPoolConfig": graphql_api.user_pool_config,
+                    "xrayEnabled": graphql_api.xray_enabled,
+                    "visibility": graphql_api.visibility,
+                    "tags": self.appsync_backend.list_tags_for_resource(
+                        graphql_api.arn
+                    ),
+                }
+                for graphql_api in graphql_apis
+            ]
+        }
+        return ActionResult(result)
 
-    def create_api_key(self) -> str:
+    def create_api_key(self) -> ActionResult:
         api_id = self._get_param("apiId")
         description = self._get_param("description")
         expires = self._get_param("expires")
@@ -124,20 +192,39 @@ class AppSyncResponse(BaseResponse):
         api_key = self.appsync_backend.create_api_key(
             api_id=api_id, description=description, expires=expires
         )
-        return json.dumps({"apiKey": api_key.to_json()})
+        result = {
+            "apiKey": {
+                "id": api_key.key_id,
+                "description": api_key.description,
+                "expires": api_key.expires,
+                "deletes": api_key.expires,
+            }
+        }
+        return ActionResult(result)
 
-    def delete_api_key(self) -> str:
+    def delete_api_key(self) -> ActionResult:
         api_id = self._get_param("apiId")
         api_key_id = self._get_param("id")
         self.appsync_backend.delete_api_key(api_id=api_id, api_key_id=api_key_id)
-        return "{}"
+        return EmptyResult()
 
-    def list_api_keys(self) -> str:
+    def list_api_keys(self) -> ActionResult:
         api_id = self._get_param("apiId")
         api_keys = self.appsync_backend.list_api_keys(api_id=api_id)
-        return json.dumps({"apiKeys": [key.to_json() for key in api_keys]})
+        result = {
+            "apiKeys": [
+                {
+                    "id": api_key.key_id,
+                    "description": api_key.description,
+                    "expires": api_key.expires,
+                    "deletes": api_key.expires,
+                }
+                for api_key in api_keys
+            ]
+        }
+        return ActionResult(result)
 
-    def update_api_key(self) -> str:
+    def update_api_key(self) -> ActionResult:
         api_id = self._get_param("apiId")
         api_key_id = self._get_param("id")
         description = self._get_param("description")
@@ -158,75 +245,101 @@ class AppSyncResponse(BaseResponse):
             description=description,
             expires=expires,
         )
-        return json.dumps({"apiKey": api_key.to_json()})
+        result = {
+            "apiKey": {
+                "id": api_key.key_id,
+                "description": api_key.description,
+                "expires": api_key.expires,
+                "deletes": api_key.expires,
+            }
+        }
+        return ActionResult(result)
 
-    def start_schema_creation(self) -> str:
+    def start_schema_creation(self) -> ActionResult:
         api_id = self._get_param("apiId")
         definition = self._get_param("definition")
         status = self.appsync_backend.start_schema_creation(
             api_id=api_id, definition=definition
         )
-        return json.dumps({"status": status})
+        result = {"status": status}
+        return ActionResult(result)
 
-    def get_schema_creation_status(self) -> str:
+    def get_schema_creation_status(self) -> ActionResult:
         api_id = self._get_param("apiId")
         status, details = self.appsync_backend.get_schema_creation_status(api_id=api_id)
-        return json.dumps({"status": status, "details": details})
+        result = {"status": status, "details": details}
+        return ActionResult(result)
 
-    def tag_resource(self) -> str:
+    def tag_resource(self) -> ActionResult:
         resource_arn = self._get_param("resourceArn")
         tags = self._get_param("tags")
         self.appsync_backend.tag_resource(resource_arn=resource_arn, tags=tags)
-        return "{}"
+        return EmptyResult()
 
-    def untag_resource(self) -> str:
+    def untag_resource(self) -> ActionResult:
         resource_arn = self._get_param("resourceArn")
         tag_keys = self._get_param("tagKeys", [])
         self.appsync_backend.untag_resource(
             resource_arn=resource_arn, tag_keys=tag_keys
         )
-        return "{}"
+        return EmptyResult()
 
-    def list_tags_for_resource(self) -> str:
+    def list_tags_for_resource(self) -> ActionResult:
         resource_arn = self._get_param("resourceArn")
         tags = self.appsync_backend.list_tags_for_resource(resource_arn=resource_arn)
-        return json.dumps({"tags": tags})
+        result = {"tags": tags}
+        return ActionResult(result)
 
-    def get_type(self) -> str:
+    def get_type(self) -> ActionResult:
         api_id = self._get_param("apiId")
         type_name = self._get_param("typeName")
         type_format = self._get_param("format")
         graphql_type = self.appsync_backend.get_type(
             api_id=api_id, type_name=type_name, type_format=type_format
         )
-        return json.dumps({"type": graphql_type})
+        result = {"type": graphql_type}
+        return ActionResult(result)
 
-    def get_introspection_schema(self) -> str:
+    def get_introspection_schema(self) -> ActionResult:
         api_id = self._get_param("apiId")
         format_ = self._get_param("format")
-        include_directives = self._get_bool_param("includeDirectives", True)
+        include_directives = self._get_param("includeDirectives")
+        if include_directives is None:
+            include_directives = True
         graphql_schema = self.appsync_backend.get_graphql_schema(api_id=api_id)
 
         schema = graphql_schema.get_introspection_schema(
             format_=format_, include_directives=include_directives
         )
-        return schema
+        result = {"schema": schema}
+        return ActionResult(result)
 
-    def get_api_cache(self) -> str:
+    def get_api_cache(self) -> ActionResult:
         api_id = self._get_param("apiId")
         api_cache = self.appsync_backend.get_api_cache(
             api_id=api_id,
         )
-        return json.dumps({"apiCache": api_cache.to_json()})
+        result = {
+            "apiCache": {
+                "ttl": api_cache.ttl,
+                "transitEncryptionEnabled": api_cache.transit_encryption_enabled,
+                "atRestEncryptionEnabled": api_cache.at_rest_encryption_enabled,
+                "apiCachingBehavior": api_cache.api_caching_behavior,
+                "type": api_cache.type,
+                "healthMetricsConfig": api_cache.health_metrics_config,
+                "status": api_cache.status,
+            }
+        }
+        return ActionResult(result)
 
-    def delete_api_cache(self) -> str:
+    def delete_api_cache(self) -> ActionResult:
         api_id = self._get_param("apiId")
         self.appsync_backend.delete_api_cache(
             api_id=api_id,
         )
-        return "{}"
+        return EmptyResult()
 
-    def create_api_cache(self) -> str:
+    def create_api_cache(self) -> ActionResult:
         api_id = self._get_param("apiId")
         ttl = self._get_param("ttl")
         transit_encryption_enabled = self._get_param("transitEncryptionEnabled")
@@ -243,9 +356,20 @@ class AppSyncResponse(BaseResponse):
             type=type,
             health_metrics_config=health_metrics_config,
         )
-        return json.dumps({"apiCache": api_cache.to_json()})
+        result = {
+            "apiCache": {
+                "ttl": api_cache.ttl,
+                "transitEncryptionEnabled": api_cache.transit_encryption_enabled,
+                "atRestEncryptionEnabled": api_cache.at_rest_encryption_enabled,
+                "apiCachingBehavior": api_cache.api_caching_behavior,
+                "type": api_cache.type,
+                "healthMetricsConfig": api_cache.health_metrics_config,
+                "status": api_cache.status,
+            }
+        }
+        return ActionResult(result)
 
-    def update_api_cache(self) -> str:
+    def update_api_cache(self) -> ActionResult:
         api_id = self._get_param("apiId")
         ttl = self._get_param("ttl")
         api_caching_behavior = self._get_param("apiCachingBehavior")
@@ -258,16 +382,27 @@ class AppSyncResponse(BaseResponse):
             type=type,
             health_metrics_config=health_metrics_config,
         )
-        return json.dumps({"apiCache": api_cache.to_json()})
+        result = {
+            "apiCache": {
+                "ttl": api_cache.ttl,
+                "transitEncryptionEnabled": api_cache.transit_encryption_enabled,
+                "atRestEncryptionEnabled": api_cache.at_rest_encryption_enabled,
+                "apiCachingBehavior": api_cache.api_caching_behavior,
+                "type": api_cache.type,
+                "healthMetricsConfig": api_cache.health_metrics_config,
+                "status": api_cache.status,
+            }
+        }
+        return ActionResult(result)
 
-    def flush_api_cache(self) -> str:
+    def flush_api_cache(self) -> ActionResult:
         api_id = self._get_param("apiId")
         self.appsync_backend.flush_api_cache(
             api_id=api_id,
         )
-        return "{}"
+        return EmptyResult()
 
-    def create_api(self) -> str:
+    def create_api(self) -> ActionResult:
         name = self._get_param("name")
 
         if name:
@@ -290,20 +425,45 @@ class AppSyncResponse(BaseResponse):
             tags=tags,
             event_config=event_config,
         )
+        api_dict: dict[str, Any] = {
+            "apiId": api.api_id,
+            "name": api.name,
+            "tags": self.appsync_backend.list_tags_for_resource(api.api_arn),
+            "dns": api.dns,
+            "apiArn": api.api_arn,
+            "created": api.created,
+            "eventConfig": api.event_config or {},  # Default to empty dict if None
+        }
+        if api.owner_contact:
+            api_dict["ownerContact"] = api.owner_contact
+        result = {"api": api_dict}
+        return ActionResult(result)
 
-        response = api.to_json()
-        return json.dumps({"api": response})
-
-    def list_apis(self) -> str:
+    def list_apis(self) -> ActionResult:
         apis = self.appsync_backend.list_apis()
-        return json.dumps({"apis": [api.to_json() for api in apis]})
+        api_list = []
+        for api in apis:
+            api_dict: dict[str, Any] = {
+                "apiId": api.api_id,
+                "name": api.name,
+                "tags": self.appsync_backend.list_tags_for_resource(api.api_arn),
+                "dns": api.dns,
+                "apiArn": api.api_arn,
+                "created": api.created,
+                "eventConfig": api.event_config or {},  # Default to empty dict if None
+            }
+            if api.owner_contact:
+                api_dict["ownerContact"] = api.owner_contact
+            api_list.append(api_dict)
+        result = {"apis": api_list}
+        return ActionResult(result)
 
-    def delete_api(self) -> str:
+    def delete_api(self) -> ActionResult:
         api_id = self._get_param("apiId")
         self.appsync_backend.delete_api(api_id=api_id)
-        return "{}"
+        return EmptyResult()
 
-    def create_channel_namespace(self) -> str:
+    def create_channel_namespace(self) -> ActionResult:
         api_id = self._get_param("apiId")
         name = self._get_param("name")
 
@@ -332,22 +492,51 @@ class AppSyncResponse(BaseResponse):
             tags=tags,
             handler_configs=handler_configs,
         )
+        channel_namespace_dict: dict[str, Any] = {
+            "apiId": channel_namespace.api_id,
+            "name": channel_namespace.name,
+            "subscribeAuthModes": channel_namespace.subscribe_auth_modes,
+            "publishAuthModes": channel_namespace.publish_auth_modes,
+            "channelNamespaceArn": channel_namespace.channel_namespace_arn,
+            "created": channel_namespace.created,
+            "lastModified": channel_namespace.last_modified,
+            "handlerConfigs": channel_namespace.handler_configs,
+        }
+        if channel_namespace.code_handlers:
+            channel_namespace_dict["codeHandlers"] = channel_namespace.code_handlers
+        channel_namespace_dict["tags"] = self.appsync_backend.list_tags_for_resource(
+            channel_namespace.channel_namespace_arn
+        )
+        result = {"channelNamespace": channel_namespace_dict}
+        return ActionResult(result)
 
-        return json.dumps({"channelNamespace": channel_namespace.to_json()})
-
-    def list_channel_namespaces(self) -> str:
+    def list_channel_namespaces(self) -> ActionResult:
         api_id = self._get_param("apiId")
         channel_namespaces = self.appsync_backend.list_channel_namespaces(api_id=api_id)
-        return json.dumps(
-            {
-                "channelNamespaces": [
-                    channel_namespace.to_json()
-                    for channel_namespace in channel_namespaces
-                ]
+        channel_namespace_list = []
+        for channel_namespace in channel_namespaces:
+            channel_namespace_dict: dict[str, Any] = {
+                "apiId": channel_namespace.api_id,
+                "name": channel_namespace.name,
+                "subscribeAuthModes": channel_namespace.subscribe_auth_modes,
+                "publishAuthModes": channel_namespace.publish_auth_modes,
+                "channelNamespaceArn": channel_namespace.channel_namespace_arn,
+                "created": channel_namespace.created,
+                "lastModified": channel_namespace.last_modified,
+                "handlerConfigs": channel_namespace.handler_configs,
             }
-        )
+            if channel_namespace.code_handlers:
+                channel_namespace_dict["codeHandlers"] = channel_namespace.code_handlers
+            channel_namespace_dict["tags"] = (
+                self.appsync_backend.list_tags_for_resource(
+                    channel_namespace.channel_namespace_arn
+                )
+            )
+            channel_namespace_list.append(channel_namespace_dict)
+        result = {"channelNamespaces": channel_namespace_list}
+        return ActionResult(result)
 
-    def delete_channel_namespace(self) -> str:
+    def delete_channel_namespace(self) -> ActionResult:
         api_id = self._get_param("apiId")
         name = self._get_param("name")
 
@@ -355,12 +544,21 @@ class AppSyncResponse(BaseResponse):
             api_id=api_id,
             name=name,
         )
-        return "{}"
+        return EmptyResult()
 
-    def get_api(self) -> str:
+    def get_api(self) -> ActionResult:
         api_id = self._get_param("apiId")
-
         api = self.appsync_backend.get_api(api_id=api_id)
-        response = api.to_json()
-        response["tags"] = self.appsync_backend.list_tags_for_resource(api.api_arn)
-        return json.dumps({"api": response})
+        api_dict: dict[str, Any] = {
+            "apiId": api.api_id,
+            "name": api.name,
+            "tags": self.appsync_backend.list_tags_for_resource(api.api_arn),
+            "dns": api.dns,
+            "apiArn": api.api_arn,
+            "created": api.created,
+            "eventConfig": api.event_config or {},  # Default to empty dict if None
+        }
+        if api.owner_contact:
+            api_dict["ownerContact"] = api.owner_contact
+        result = {"api": api_dict}
+        return ActionResult(result)

--- a/moto/appsync/responses.py
+++ b/moto/appsync/responses.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 from moto.core.common_types import TYPE_RESPONSE
 from moto.core.responses import ActionResult, BaseResponse, EmptyResult
-from moto.core.utils import unix_time
+from moto.core.utils import unix_time, utcfromtimestamp
 
 from .exceptions import ApiKeyValidityOutOfBoundsException, AWSValidationException
 from .models import AppSyncBackend, appsync_backends
@@ -190,14 +190,16 @@ class AppSyncResponse(BaseResponse):
                 )
 
         api_key = self.appsync_backend.create_api_key(
-            api_id=api_id, description=description, expires=expires
+            api_id=api_id,
+            description=description,
+            expires=utcfromtimestamp(expires) if expires else None,
         )
         result = {
             "apiKey": {
                 "id": api_key.key_id,
                 "description": api_key.description,
-                "expires": api_key.expires,
-                "deletes": api_key.expires,
+                "expires": int(unix_time(api_key.expires)),
+                "deletes": int(unix_time(api_key.expires)),
             }
         }
         return ActionResult(result)
@@ -216,8 +218,8 @@ class AppSyncResponse(BaseResponse):
                 {
                     "id": api_key.key_id,
                     "description": api_key.description,
-                    "expires": api_key.expires,
-                    "deletes": api_key.expires,
+                    "expires": int(unix_time(api_key.expires)),
+                    "deletes": int(unix_time(api_key.expires)),
                 }
                 for api_key in api_keys
             ]
@@ -243,14 +245,14 @@ class AppSyncResponse(BaseResponse):
             api_id=api_id,
             api_key_id=api_key_id,
             description=description,
-            expires=expires,
+            expires=utcfromtimestamp(expires) if expires else None,
         )
         result = {
             "apiKey": {
                 "id": api_key.key_id,
                 "description": api_key.description,
-                "expires": api_key.expires,
-                "deletes": api_key.expires,
+                "expires": int(unix_time(api_key.expires)),
+                "deletes": int(unix_time(api_key.expires)),
             }
         }
         return ActionResult(result)

--- a/moto/appsync/responses.py
+++ b/moto/appsync/responses.py
@@ -45,7 +45,7 @@ class AppSyncResponse(BaseResponse):
         additional_authentication_providers = self._get_param(
             "additionalAuthenticationProviders"
         )
-        xray_enabled = self._get_param("xrayEnabled", False)
+        xray_enabled = self._get_bool_param("xrayEnabled", False)
         lambda_authorizer_config = self._get_param("lambdaAuthorizerConfig")
         visibility = self._get_param("visibility")
         graphql_api = self.appsync_backend.create_graphql_api(
@@ -117,7 +117,7 @@ class AppSyncResponse(BaseResponse):
         additional_authentication_providers = self._get_param(
             "additionalAuthenticationProviders"
         )
-        xray_enabled = self._get_param("xrayEnabled", False)
+        xray_enabled = self._get_bool_param("xrayEnabled", False)
         lambda_authorizer_config = self._get_param("lambdaAuthorizerConfig")
 
         graphql_api = self.appsync_backend.update_graphql_api(
@@ -303,9 +303,7 @@ class AppSyncResponse(BaseResponse):
     def get_introspection_schema(self) -> ActionResult:
         api_id = self._get_param("apiId")
         format_ = self._get_param("format")
-        include_directives = self._get_param("includeDirectives")
-        if include_directives is None:
-            include_directives = True
+        include_directives = self._get_bool_param("includeDirectives", True)
         graphql_schema = self.appsync_backend.get_graphql_schema(api_id=api_id)
 
         schema = graphql_schema.get_introspection_schema(
@@ -342,8 +340,8 @@ class AppSyncResponse(BaseResponse):
     def create_api_cache(self) -> ActionResult:
         api_id = self._get_param("apiId")
         ttl = self._get_param("ttl")
-        transit_encryption_enabled = self._get_param("transitEncryptionEnabled")
-        at_rest_encryption_enabled = self._get_param("atRestEncryptionEnabled")
+        transit_encryption_enabled = self._get_bool_param("transitEncryptionEnabled")
+        at_rest_encryption_enabled = self._get_bool_param("atRestEncryptionEnabled")
         api_caching_behavior = self._get_param("apiCachingBehavior")
         type = self._get_param("type")
         health_metrics_config = self._get_param("healthMetricsConfig")


### PR DESCRIPTION
I wanted this migration to serve as an example of how things should look when the boundary between `responses.py` and `models.py` is strictly enforced.  Everything on the models side is native Python types, e.g. `bool` and `datetime` instead of `str`.  Any necessary conversions, like translating epoch timestamp inputs to native `datetime` objects, is handled in `responses.py`.

In previous migrations, I have simply deleted the `to_json()` methods in `models.py` because the serializer does a lot of work to "find" the response attributes it's looking for from the raw model objects; but this time I decided to make things a bit more explicit, essentially moving the `to_json()` stuff onto the other (proper) side of the `responses.py`/`models.py` divide. Although more verbose, this is probably the Right Thing to Do going forward, as it is explicitly clear which response fields Moto supports and exactly where the values are sourced.