### PR TITLE
EC2: Add snapshot tiering support (ModifySnapshotTier, DescribeSnapshotTierStatus, RestoreSnapshotTier)

### DIFF
--- a/docs/docs/services/ec2.rst
+++ b/docs/docs/services/ec2.rst
@@ -437,7 +437,7 @@ The Filters-parameter is not yet implemented
 - [X] describe_security_groups
 - [ ] describe_service_link_virtual_interfaces
 - [ ] describe_snapshot_attribute
-- [ ] describe_snapshot_tier_status
+- [X] describe_snapshot_tier_status
 - [X] describe_snapshots
 - [ ] describe_spot_datafeed_subscription
 - [X] describe_spot_fleet_instances
@@ -709,7 +709,7 @@ The DryRun parameter is ignored.
 - [ ] modify_route_server
 - [X] modify_security_group_rules
 - [ ] modify_snapshot_attribute
-- [ ] modify_snapshot_tier
+- [X] modify_snapshot_tier
 - [X] modify_spot_fleet_request
 - [X] modify_subnet_attribute
 - [ ] modify_traffic_mirror_filter_network_services
@@ -797,7 +797,7 @@ The following parameters are not yet implemented: RemovePrivateDnsName
 - [ ] restore_image_from_recycle_bin
 - [ ] restore_managed_prefix_list_version
 - [ ] restore_snapshot_from_recycle_bin
-- [ ] restore_snapshot_tier
+- [X] restore_snapshot_tier
 - [ ] restore_volume_from_recycle_bin
 - [ ] revoke_client_vpn_ingress
 - [X] revoke_security_group_egress

--- a/moto/ec2/models/elastic_block_store.py
+++ b/moto/ec2/models/elastic_block_store.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from datetime import datetime, timedelta
 from typing import Any
 
 from moto.core.common_models import CloudFormationModel
@@ -330,6 +331,15 @@ class Snapshot(TaggedEC2Resource):
         self.owner_id = owner_id or ec2_backend.account_id
         self.from_ami = from_ami
         self.kms_key_id = kms_key_id
+        # Storage tiering (standard | archive)
+        self.storage_tier = "standard"
+        self.last_tiering_start_time: datetime | None = None
+        self.last_tiering_progress: int | None = None
+        self.last_tiering_operation_status: str | None = None
+        self.last_tiering_operation_status_detail: str | None = None
+        self.archival_complete_time: datetime | None = None
+        self.restore_expiry_time: datetime | None = None
+        self.restore_start_time: datetime | None = None
 
     @property
     def snapshot_id(self) -> str:
@@ -366,6 +376,8 @@ class Snapshot(TaggedEC2Resource):
             return self.status
         elif filter_name == "owner-id":
             return self.owner_id
+        elif filter_name == "storage-tier":
+            return self.storage_tier
         else:
             return super().get_filter_value(filter_name, "DescribeSnapshots")
 
@@ -628,6 +640,49 @@ class EBSBackend:
         if not snapshot:
             raise InvalidSnapshotIdError()
         return snapshot
+
+    def modify_snapshot_tier(self, snapshot_id: str, storage_tier: str) -> Snapshot:
+        snapshot = self.get_snapshot(snapshot_id)
+        # ModifySnapshotTier only supports moving a snapshot to the archive tier.
+        if storage_tier != "archive":
+            raise InvalidParameterValueError(str(storage_tier))
+        now = utcnow()
+        snapshot.storage_tier = "archive"
+        snapshot.last_tiering_start_time = now
+        snapshot.last_tiering_progress = 100
+        snapshot.last_tiering_operation_status = "archival-completed"
+        snapshot.last_tiering_operation_status_detail = (
+            "Archival completed successfully"
+        )
+        snapshot.archival_complete_time = now
+        snapshot.restore_expiry_time = None
+        return snapshot
+
+    def restore_snapshot_tier(
+        self,
+        snapshot_id: str,
+        temporary_restore_days: int | None = None,
+        permanent_restore: bool = False,
+    ) -> Snapshot:
+        snapshot = self.get_snapshot(snapshot_id)
+        now = utcnow()
+        snapshot.restore_start_time = now
+        if permanent_restore:
+            snapshot.storage_tier = "standard"
+            snapshot.last_tiering_operation_status = "permanent-restore-completed"
+            snapshot.restore_expiry_time = None
+        else:
+            snapshot.last_tiering_operation_status = "temporary-restore-completed"
+            snapshot.restore_expiry_time = now + timedelta(
+                days=temporary_restore_days or 1
+            )
+        return snapshot
+
+    def describe_snapshot_tier_status(self, filters: Any = None) -> list[Snapshot]:
+        snapshots = list(self.snapshots.values())
+        if filters:
+            snapshots = generic_filter(filters, snapshots)
+        return snapshots
 
     def delete_snapshot(self, snapshot_id: str) -> Snapshot:
         if snapshot_id in self.snapshots:

--- a/moto/ec2/responses/elastic_block_store.py
+++ b/moto/ec2/responses/elastic_block_store.py
@@ -148,6 +148,63 @@ class ElasticBlockStore(EC2BaseResponse):
         )
         return ActionResult({"Snapshots": snapshots})
 
+    def modify_snapshot_tier(self) -> ActionResult:
+        snapshot_id = self._get_param("SnapshotId")
+        storage_tier = self._get_param("StorageTier")
+
+        self.error_on_dryrun()
+
+        snapshot = self.ec2_backend.modify_snapshot_tier(snapshot_id, storage_tier)
+        return ActionResult(
+            {
+                "SnapshotId": snapshot.id,
+                "TieringStartTime": snapshot.last_tiering_start_time,
+            }
+        )
+
+    def describe_snapshot_tier_status(self) -> ActionResult:
+        filters = self._filters_from_querystring()
+        snapshots = self.ec2_backend.describe_snapshot_tier_status(filters=filters)
+        statuses = [
+            {
+                "SnapshotId": snapshot.id,
+                "VolumeId": snapshot.volume_id,
+                "Status": snapshot.status,
+                "OwnerId": snapshot.owner_id,
+                "Tags": snapshot.tag_set,
+                "StorageTier": snapshot.storage_tier,
+                "LastTieringStartTime": snapshot.last_tiering_start_time,
+                "LastTieringProgress": snapshot.last_tiering_progress,
+                "LastTieringOperationStatus": snapshot.last_tiering_operation_status,
+                "LastTieringOperationStatusDetail": snapshot.last_tiering_operation_status_detail,
+                "ArchivalCompleteTime": snapshot.archival_complete_time,
+                "RestoreExpiryTime": snapshot.restore_expiry_time,
+            }
+            for snapshot in snapshots
+        ]
+        return ActionResult({"SnapshotTierStatuses": statuses})
+
+    def restore_snapshot_tier(self) -> ActionResult:
+        snapshot_id = self._get_param("SnapshotId")
+        temporary_restore_days = self._get_param("TemporaryRestoreDays")
+        permanent_restore = self._get_param("PermanentRestore", False)
+
+        self.error_on_dryrun()
+
+        snapshot = self.ec2_backend.restore_snapshot_tier(
+            snapshot_id,
+            temporary_restore_days=temporary_restore_days,
+            permanent_restore=permanent_restore,
+        )
+        result = {
+            "SnapshotId": snapshot.id,
+            "RestoreStartTime": snapshot.restore_start_time,
+            "IsPermanentRestore": bool(permanent_restore),
+        }
+        if not permanent_restore and temporary_restore_days is not None:
+            result["RestoreDuration"] = temporary_restore_days
+        return ActionResult(result)
+
     def describe_volumes(self) -> ActionResult:
         filters = self._filters_from_querystring()
         volume_ids = self._get_param("VolumeIds", [])

--- a/tests/test_ec2/test_elastic_block_store.py
+++ b/tests/test_ec2/test_elastic_block_store.py
@@ -1257,3 +1257,96 @@ def test_create_volume_without_size():
         ex.value.response["Error"]["Message"]
         == "The request must contain the parameter size/snapshot"
     )
+
+
+def _create_snapshot(client):
+    volume = client.create_volume(Size=80, AvailabilityZone="us-east-1a")
+    return client.create_snapshot(VolumeId=volume["VolumeId"])["SnapshotId"]
+
+
+@mock_aws
+def test_modify_snapshot_tier():
+    client = boto3.client("ec2", region_name="us-east-1")
+    snapshot_id = _create_snapshot(client)
+
+    resp = client.modify_snapshot_tier(SnapshotId=snapshot_id, StorageTier="archive")
+    assert resp["SnapshotId"] == snapshot_id
+    assert "TieringStartTime" in resp
+
+    status = next(
+        s
+        for s in client.describe_snapshot_tier_status()["SnapshotTierStatuses"]
+        if s["SnapshotId"] == snapshot_id
+    )
+    assert status["StorageTier"] == "archive"
+    assert status["LastTieringOperationStatus"] == "archival-completed"
+    assert status["LastTieringProgress"] == 100
+
+    archived = client.describe_snapshots(
+        Filters=[{"Name": "storage-tier", "Values": ["archive"]}]
+    )["Snapshots"]
+    assert snapshot_id in [s["SnapshotId"] for s in archived]
+
+
+@mock_aws
+def test_modify_snapshot_tier_invalid_storage_tier():
+    client = boto3.client("ec2", region_name="us-east-1")
+    snapshot_id = _create_snapshot(client)
+
+    with pytest.raises(ClientError) as exc:
+        client.modify_snapshot_tier(SnapshotId=snapshot_id, StorageTier="standard")
+    assert exc.value.response["Error"]["Code"] == "InvalidParameterValue"
+
+
+@mock_aws
+def test_describe_snapshot_tier_status_defaults_to_standard():
+    client = boto3.client("ec2", region_name="us-east-1")
+    snapshot_id = _create_snapshot(client)
+
+    status = next(
+        s
+        for s in client.describe_snapshot_tier_status()["SnapshotTierStatuses"]
+        if s["SnapshotId"] == snapshot_id
+    )
+    assert status["StorageTier"] == "standard"
+
+
+@mock_aws
+def test_restore_snapshot_tier_temporary():
+    client = boto3.client("ec2", region_name="us-east-1")
+    snapshot_id = _create_snapshot(client)
+    client.modify_snapshot_tier(SnapshotId=snapshot_id, StorageTier="archive")
+
+    resp = client.restore_snapshot_tier(SnapshotId=snapshot_id, TemporaryRestoreDays=10)
+    assert resp["SnapshotId"] == snapshot_id
+    assert resp["IsPermanentRestore"] is False
+    assert resp["RestoreDuration"] == 10
+    assert "RestoreStartTime" in resp
+
+    status = next(
+        s
+        for s in client.describe_snapshot_tier_status()["SnapshotTierStatuses"]
+        if s["SnapshotId"] == snapshot_id
+    )
+    # A temporary restore keeps the snapshot in the archive tier.
+    assert status["StorageTier"] == "archive"
+    assert "RestoreExpiryTime" in status
+
+
+@mock_aws
+def test_restore_snapshot_tier_permanent():
+    client = boto3.client("ec2", region_name="us-east-1")
+    snapshot_id = _create_snapshot(client)
+    client.modify_snapshot_tier(SnapshotId=snapshot_id, StorageTier="archive")
+
+    resp = client.restore_snapshot_tier(SnapshotId=snapshot_id, PermanentRestore=True)
+    assert resp["IsPermanentRestore"] is True
+    assert "RestoreDuration" not in resp
+
+    status = next(
+        s
+        for s in client.describe_snapshot_tier_status()["SnapshotTierStatuses"]
+        if s["SnapshotId"] == snapshot_id
+    )
+    assert status["StorageTier"] == "standard"
+    assert status["LastTieringOperationStatus"] == "permanent-restore-completed"


### PR DESCRIPTION
This implements EC2 snapshot tiering, as requested in #10061:

- `ModifySnapshotTier` — archive a snapshot (`StorageTier=archive`)
- `DescribeSnapshotTierStatus` — report tiering status for snapshots
- `RestoreSnapshotTier` — restore an archived snapshot (temporary via
  `TemporaryRestoreDays`, or `PermanentRestore`)
- `storage-tier` filter support for `DescribeSnapshots`

New snapshots default to the `standard` tier. Archival and restore are modeled
as immediate, deterministic state transitions (no async polling).

Validation:
- Added tests in `tests/test_ec2/test_elastic_block_store.py` covering modify /
  describe-status / restore-temporary / restore-permanent / invalid-tier /
  default-standard / storage-tier filter
- `pytest tests/test_ec2/test_elastic_block_store.py` — 48 passed (5 new)
- `ruff check` + `ruff format --check` — clean

related: #10061