### PR TITLE
AppMesh: Add VirtualGateway and GatewayRoute support

### DIFF
--- a/IMPLEMENTATION_COVERAGE.md
+++ b/IMPLEMENTATION_COVERAGE.md
@@ -445,41 +445,41 @@
 <details>
 <summary>57% implemented</summary>
 
-- [ ] create_gateway_route
+- [X] create_gateway_route
 - [X] create_mesh
 - [X] create_route
-- [ ] create_virtual_gateway
+- [X] create_virtual_gateway
 - [X] create_virtual_node
 - [X] create_virtual_router
 - [ ] create_virtual_service
-- [ ] delete_gateway_route
+- [X] delete_gateway_route
 - [X] delete_mesh
 - [X] delete_route
-- [ ] delete_virtual_gateway
+- [X] delete_virtual_gateway
 - [X] delete_virtual_node
 - [X] delete_virtual_router
 - [ ] delete_virtual_service
-- [ ] describe_gateway_route
+- [X] describe_gateway_route
 - [X] describe_mesh
 - [X] describe_route
-- [ ] describe_virtual_gateway
+- [X] describe_virtual_gateway
 - [X] describe_virtual_node
 - [X] describe_virtual_router
 - [ ] describe_virtual_service
-- [ ] list_gateway_routes
+- [X] list_gateway_routes
 - [X] list_meshes
 - [X] list_routes
 - [X] list_tags_for_resource
-- [ ] list_virtual_gateways
+- [X] list_virtual_gateways
 - [X] list_virtual_nodes
 - [X] list_virtual_routers
 - [ ] list_virtual_services
 - [X] tag_resource
 - [ ] untag_resource
-- [ ] update_gateway_route
+- [X] update_gateway_route
 - [X] update_mesh
 - [X] update_route
-- [ ] update_virtual_gateway
+- [X] update_virtual_gateway
 - [X] update_virtual_node
 - [X] update_virtual_router
 - [ ] update_virtual_service

--- a/docs/docs/services/appmesh.rst
+++ b/docs/docs/services/appmesh.rst
@@ -16,41 +16,41 @@ appmesh
 
 |start-h3| Implemented features for this service |end-h3|
 
-- [ ] create_gateway_route
+- [X] create_gateway_route
 - [X] create_mesh
 - [X] create_route
-- [ ] create_virtual_gateway
+- [X] create_virtual_gateway
 - [X] create_virtual_node
 - [X] create_virtual_router
 - [ ] create_virtual_service
-- [ ] delete_gateway_route
+- [X] delete_gateway_route
 - [X] delete_mesh
 - [X] delete_route
-- [ ] delete_virtual_gateway
+- [X] delete_virtual_gateway
 - [X] delete_virtual_node
 - [X] delete_virtual_router
 - [ ] delete_virtual_service
-- [ ] describe_gateway_route
+- [X] describe_gateway_route
 - [X] describe_mesh
 - [X] describe_route
-- [ ] describe_virtual_gateway
+- [X] describe_virtual_gateway
 - [X] describe_virtual_node
 - [X] describe_virtual_router
 - [ ] describe_virtual_service
-- [ ] list_gateway_routes
+- [X] list_gateway_routes
 - [X] list_meshes
 - [X] list_routes
 - [X] list_tags_for_resource
-- [ ] list_virtual_gateways
+- [X] list_virtual_gateways
 - [X] list_virtual_nodes
 - [X] list_virtual_routers
 - [ ] list_virtual_services
 - [X] tag_resource
 - [ ] untag_resource
-- [ ] update_gateway_route
+- [X] update_gateway_route
 - [X] update_mesh
 - [X] update_route
-- [ ] update_virtual_gateway
+- [X] update_virtual_gateway
 - [X] update_virtual_node
 - [X] update_virtual_router
 - [ ] update_virtual_service

--- a/moto/appmesh/dataclasses/gateway_route.py
+++ b/moto/appmesh/dataclasses/gateway_route.py
@@ -1,0 +1,267 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from moto.appmesh.dataclasses.route import (
+    GrpcMetadatum,
+    RouteMatchPath,
+    RouteMatchQueryParameter,
+)
+from moto.appmesh.dataclasses.shared import Metadata, MissingField, Status
+from moto.appmesh.utils.common import clean_dict
+
+
+@dataclass
+class GatewayRouteVirtualService:
+    virtual_service_name: str
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return {"virtualServiceName": self.virtual_service_name}
+
+
+@dataclass
+class GatewayRouteTarget:
+    virtual_service: GatewayRouteVirtualService
+    port: int | None = field(default=None)
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "port": self.port,
+                "virtualService": self.virtual_service.to_dict(),
+            }
+        )
+
+
+@dataclass
+class GatewayRouteHostnameRewrite:
+    default_target_hostname: str
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return {"defaultTargetHostname": self.default_target_hostname}
+
+
+@dataclass
+class HttpGatewayRoutePathRewrite:
+    exact: str
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return {"exact": self.exact}
+
+
+@dataclass
+class HttpGatewayRoutePrefixRewrite:
+    default_prefix: str | None
+    value: str | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict({"defaultPrefix": self.default_prefix, "value": self.value})
+
+
+@dataclass
+class HttpGatewayRouteRewrite:
+    hostname: GatewayRouteHostnameRewrite | None
+    path: HttpGatewayRoutePathRewrite | None
+    prefix: HttpGatewayRoutePrefixRewrite | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "hostname": (self.hostname or MissingField()).to_dict(),
+                "path": (self.path or MissingField()).to_dict(),
+                "prefix": (self.prefix or MissingField()).to_dict(),
+            }
+        )
+
+
+@dataclass
+class GrpcGatewayRouteRewrite:
+    hostname: GatewayRouteHostnameRewrite | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict({"hostname": (self.hostname or MissingField()).to_dict()})
+
+
+@dataclass
+class HttpGatewayRouteAction:
+    target: GatewayRouteTarget
+    rewrite: HttpGatewayRouteRewrite | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "rewrite": (self.rewrite or MissingField()).to_dict(),
+                "target": self.target.to_dict(),
+            }
+        )
+
+
+@dataclass
+class GrpcGatewayRouteAction:
+    target: GatewayRouteTarget
+    rewrite: GrpcGatewayRouteRewrite | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "rewrite": (self.rewrite or MissingField()).to_dict(),
+                "target": self.target.to_dict(),
+            }
+        )
+
+
+@dataclass
+class GatewayRouteHostnameMatch:
+    exact: str | None
+    suffix: str | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict({"exact": self.exact, "suffix": self.suffix})
+
+
+@dataclass
+class HttpGatewayRouteMatch:
+    headers: list[GrpcMetadatum] | None
+    hostname: GatewayRouteHostnameMatch | None
+    method: str | None
+    path: RouteMatchPath | None
+    port: int | None
+    prefix: str | None
+    query_parameters: list[RouteMatchQueryParameter] | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "headers": [header.to_dict() for header in self.headers or []],
+                "hostname": (self.hostname or MissingField()).to_dict(),
+                "method": self.method,
+                "path": (self.path or MissingField()).to_dict(),
+                "port": self.port,
+                "prefix": self.prefix,
+                "queryParameters": [
+                    param.to_dict() for param in self.query_parameters or []
+                ],
+            }
+        )
+
+
+@dataclass
+class GrpcGatewayRouteMatch:
+    hostname: GatewayRouteHostnameMatch | None
+    metadata: list[GrpcMetadatum] | None
+    port: int | None
+    service_name: str | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "hostname": (self.hostname or MissingField()).to_dict(),
+                "metadata": [meta.to_dict() for meta in self.metadata or []],
+                "port": self.port,
+                "serviceName": self.service_name,
+            }
+        )
+
+
+@dataclass
+class HttpGatewayRoute:
+    action: HttpGatewayRouteAction
+    match: HttpGatewayRouteMatch
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {"action": self.action.to_dict(), "match": self.match.to_dict()}
+        )
+
+
+@dataclass
+class GrpcGatewayRoute:
+    action: GrpcGatewayRouteAction
+    match: GrpcGatewayRouteMatch
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {"action": self.action.to_dict(), "match": self.match.to_dict()}
+        )
+
+
+@dataclass
+class GatewayRouteSpec:
+    priority: int | None
+    grpc_route: GrpcGatewayRoute | None = field(default=None)
+    http_route: HttpGatewayRoute | None = field(default=None)
+    http2_route: HttpGatewayRoute | None = field(default=None)
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "grpcRoute": (self.grpc_route or MissingField()).to_dict(),
+                "httpRoute": (self.http_route or MissingField()).to_dict(),
+                "http2Route": (self.http2_route or MissingField()).to_dict(),
+                "priority": self.priority,
+            }
+        )
+
+
+@dataclass
+class GatewayRouteMetadata(Metadata):
+    mesh_name: str = field(default="")
+    gateway_route_name: str = field(default="")
+    virtual_gateway_name: str = field(default="")
+
+    def __post_init__(self) -> None:
+        if self.mesh_name == "":
+            raise TypeError("__init__ missing 1 required argument: 'mesh_name'")
+        if self.mesh_owner == "":
+            raise TypeError("__init__ missing 1 required argument: 'mesh_owner'")
+        if self.virtual_gateway_name == "":
+            raise TypeError(
+                "__init__ missing 1 required argument: 'virtual_gateway_name'"
+            )
+
+    def formatted_for_list_api(self) -> dict[str, Any]:  # type: ignore
+        return {
+            "arn": self.arn,
+            "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "lastUpdatedAt": self.last_updated_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "gatewayRouteName": self.gateway_route_name,
+            "meshName": self.mesh_name,
+            "meshOwner": self.mesh_owner,
+            "resourceOwner": self.resource_owner,
+            "version": self.version,
+            "virtualGatewayName": self.virtual_gateway_name,
+        }
+
+    def formatted_for_crud_apis(self) -> dict[str, Any]:  # type: ignore
+        return {
+            "arn": self.arn,
+            "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "lastUpdatedAt": self.last_updated_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "meshOwner": self.mesh_owner,
+            "resourceOwner": self.resource_owner,
+            "uid": self.uid,
+            "version": self.version,
+        }
+
+
+@dataclass
+class GatewayRoute:
+    gateway_route_name: str
+    mesh_name: str
+    mesh_owner: str
+    metadata: GatewayRouteMetadata
+    spec: GatewayRouteSpec
+    virtual_gateway_name: str
+    status: Status = field(default_factory=lambda: {"status": "ACTIVE"})
+    tags: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "gatewayRouteName": self.gateway_route_name,
+                "meshName": self.mesh_name,
+                "metadata": self.metadata.formatted_for_crud_apis(),
+                "spec": self.spec.to_dict(),
+                "status": self.status,
+                "virtualGatewayName": self.virtual_gateway_name,
+            }
+        )

--- a/moto/appmesh/dataclasses/mesh.py
+++ b/moto/appmesh/dataclasses/mesh.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 from moto.appmesh.dataclasses.shared import Metadata, Status
+from moto.appmesh.dataclasses.virtual_gateway import VirtualGateway
 from moto.appmesh.dataclasses.virtual_node import VirtualNode
 from moto.appmesh.dataclasses.virtual_router import VirtualRouter
 
@@ -18,6 +19,7 @@ class Mesh:
     metadata: Metadata
     spec: MeshSpec
     status: Status
+    virtual_gateways: dict[str, VirtualGateway] = field(default_factory=dict)
     virtual_nodes: dict[str, VirtualNode] = field(default_factory=dict)
     virtual_routers: dict[str, VirtualRouter] = field(default_factory=dict)
     tags: list[dict[str, str]] = field(default_factory=list)

--- a/moto/appmesh/dataclasses/virtual_gateway.py
+++ b/moto/appmesh/dataclasses/virtual_gateway.py
@@ -1,0 +1,110 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+from moto.appmesh.dataclasses.gateway_route import GatewayRoute
+from moto.appmesh.dataclasses.shared import Metadata, MissingField, Status
+from moto.appmesh.dataclasses.virtual_node import (
+    BackendDefaults,
+    ConnectionPool,
+    HealthCheck,
+    ListenerTLS,
+    Logging,
+    PortMapping,
+)
+from moto.appmesh.utils.common import clean_dict
+
+
+@dataclass
+class VirtualGatewayListener:
+    connection_pool: ConnectionPool | None
+    health_check: HealthCheck | None
+    port_mapping: PortMapping
+    tls: ListenerTLS | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "connectionPool": (self.connection_pool or MissingField()).to_dict(),
+                "healthCheck": (self.health_check or MissingField()).to_dict(),
+                "portMapping": self.port_mapping.to_dict(),
+                "tls": (self.tls or MissingField()).to_dict(),
+            }
+        )
+
+
+@dataclass
+class VirtualGatewaySpec:
+    backend_defaults: BackendDefaults | None
+    listeners: list[VirtualGatewayListener] | None
+    logging: Logging | None
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "backendDefaults": (self.backend_defaults or MissingField()).to_dict(),
+                "listeners": [listener.to_dict() for listener in self.listeners or []],
+                "logging": (self.logging or MissingField()).to_dict(),
+            }
+        )
+
+
+@dataclass
+class VirtualGatewayMetadata(Metadata):
+    mesh_name: str = field(default="")
+    virtual_gateway_name: str = field(default="")
+
+    def __post_init__(self) -> None:
+        if self.mesh_name == "":
+            raise TypeError("__init__ missing 1 required argument: 'mesh_name'")
+        if self.mesh_owner == "":
+            raise TypeError("__init__ missing 1 required argument: 'mesh_owner'")
+        if self.virtual_gateway_name == "":
+            raise TypeError(
+                "__init__ missing 1 required argument: 'virtual_gateway_name'"
+            )
+
+    def formatted_for_list_api(self) -> dict[str, Any]:  # type: ignore
+        return {
+            "arn": self.arn,
+            "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "lastUpdatedAt": self.last_updated_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "meshName": self.mesh_name,
+            "meshOwner": self.mesh_owner,
+            "resourceOwner": self.resource_owner,
+            "version": self.version,
+            "virtualGatewayName": self.virtual_gateway_name,
+        }
+
+    def formatted_for_crud_apis(self) -> dict[str, Any]:  # type: ignore
+        return {
+            "arn": self.arn,
+            "createdAt": self.created_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "lastUpdatedAt": self.last_updated_at.strftime("%d/%m/%Y, %H:%M:%S"),
+            "meshOwner": self.mesh_owner,
+            "resourceOwner": self.resource_owner,
+            "uid": self.uid,
+            "version": self.version,
+        }
+
+
+@dataclass
+class VirtualGateway:
+    mesh_name: str
+    mesh_owner: str
+    metadata: VirtualGatewayMetadata
+    spec: VirtualGatewaySpec
+    virtual_gateway_name: str
+    gateway_routes: dict[str, GatewayRoute] = field(default_factory=dict)
+    status: Status = field(default_factory=lambda: {"status": "ACTIVE"})
+    tags: list[dict[str, str]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:  # type: ignore[misc]
+        return clean_dict(
+            {
+                "meshName": self.mesh_name,
+                "metadata": self.metadata.formatted_for_crud_apis(),
+                "spec": self.spec.to_dict(),
+                "status": self.status,
+                "virtualGatewayName": self.virtual_gateway_name,
+            }
+        )

--- a/moto/appmesh/exceptions.py
+++ b/moto/appmesh/exceptions.py
@@ -89,3 +89,39 @@ class VirtualNodeNameAlreadyTakenError(MeshError):
             "VirtualNodeNameAlreadyTaken",
             f"There is already a virtual node named {virtual_node_name} associated with mesh {mesh_name}",
         )
+
+
+class VirtualGatewayNotFoundError(MeshError):
+    def __init__(self, mesh_name: str, virtual_gateway_name: str) -> None:
+        super().__init__(
+            "VirtualGatewayNotFound",
+            f"{virtual_gateway_name} is not a virtual gateway associated with mesh {mesh_name}",
+        )
+
+
+class VirtualGatewayNameAlreadyTakenError(MeshError):
+    def __init__(self, mesh_name: str, virtual_gateway_name: str) -> None:
+        super().__init__(
+            "VirtualGatewayNameAlreadyTaken",
+            f"There is already a virtual gateway named {virtual_gateway_name} associated with mesh {mesh_name}",
+        )
+
+
+class GatewayRouteNotFoundError(MeshError):
+    def __init__(
+        self, mesh_name: str, virtual_gateway_name: str, gateway_route_name: str
+    ) -> None:
+        super().__init__(
+            "GatewayRouteNotFound",
+            f"There is no gateway route named {gateway_route_name} associated with gateway {virtual_gateway_name} in mesh {mesh_name}.",
+        )
+
+
+class GatewayRouteNameAlreadyTakenError(MeshError):
+    def __init__(
+        self, mesh_name: str, virtual_gateway_name: str, gateway_route_name: str
+    ) -> None:
+        super().__init__(
+            "GatewayRouteNameAlreadyTaken",
+            f"There is already a gateway route named {gateway_route_name} associated with gateway {virtual_gateway_name} in mesh {mesh_name}.",
+        )

--- a/moto/appmesh/models.py
+++ b/moto/appmesh/models.py
@@ -2,12 +2,22 @@
 
 from typing import Literal
 
+from moto.appmesh.dataclasses.gateway_route import (
+    GatewayRoute,
+    GatewayRouteMetadata,
+    GatewayRouteSpec,
+)
 from moto.appmesh.dataclasses.mesh import (
     Mesh,
     MeshSpec,
 )
 from moto.appmesh.dataclasses.route import Route, RouteMetadata, RouteSpec
 from moto.appmesh.dataclasses.shared import Metadata
+from moto.appmesh.dataclasses.virtual_gateway import (
+    VirtualGateway,
+    VirtualGatewayMetadata,
+    VirtualGatewaySpec,
+)
 from moto.appmesh.dataclasses.virtual_node import (
     VirtualNode,
     VirtualNodeMetadata,
@@ -19,11 +29,15 @@ from moto.appmesh.dataclasses.virtual_router import (
     VirtualRouterSpec,
 )
 from moto.appmesh.exceptions import (
+    GatewayRouteNameAlreadyTakenError,
+    GatewayRouteNotFoundError,
     MeshNotFoundError,
     MeshOwnerDoesNotMatchError,
     ResourceNotFoundError,
     RouteNameAlreadyTakenError,
     RouteNotFoundError,
+    VirtualGatewayNameAlreadyTakenError,
+    VirtualGatewayNotFoundError,
     VirtualNodeNameAlreadyTakenError,
     VirtualNodeNotFoundError,
     VirtualRouterNameAlreadyTakenError,
@@ -62,6 +76,18 @@ PAGINATION_MODEL = {
         "limit_key": "limit",
         "limit_default": 100,
         "unique_attribute": "virtual_node_name",
+    },
+    "list_virtual_gateways": {
+        "input_token": "next_token",
+        "limit_key": "limit",
+        "limit_default": 100,
+        "unique_attribute": "virtual_gateway_name",
+    },
+    "list_gateway_routes": {
+        "input_token": "next_token",
+        "limit_key": "limit",
+        "limit_default": 100,
+        "unique_attribute": "gateway_route_name",
     },
 }
 
@@ -103,6 +129,80 @@ class AppMeshBackend(BaseBackend):
         if virtual_node_name in self.meshes[mesh_name].virtual_nodes:
             raise VirtualNodeNameAlreadyTakenError(
                 mesh_name=mesh_name, virtual_node_name=virtual_node_name
+            )
+        return
+
+    def _check_virtual_gateway_validity(
+        self,
+        mesh_name: str,
+        mesh_owner: str | None,
+        virtual_gateway_name: str,
+    ) -> None:
+        self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
+        if virtual_gateway_name not in self.meshes[mesh_name].virtual_gateways:
+            raise VirtualGatewayNotFoundError(mesh_name, virtual_gateway_name)
+        return
+
+    def _check_virtual_gateway_availability(
+        self,
+        mesh_name: str,
+        mesh_owner: str | None,
+        virtual_gateway_name: str,
+    ) -> None:
+        self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
+        if virtual_gateway_name in self.meshes[mesh_name].virtual_gateways:
+            raise VirtualGatewayNameAlreadyTakenError(
+                mesh_name=mesh_name, virtual_gateway_name=virtual_gateway_name
+            )
+        return
+
+    def _check_gateway_route_validity(
+        self,
+        mesh_name: str,
+        mesh_owner: str | None,
+        virtual_gateway_name: str,
+        gateway_route_name: str,
+    ) -> None:
+        self._check_virtual_gateway_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        if (
+            gateway_route_name
+            not in self.meshes[mesh_name]
+            .virtual_gateways[virtual_gateway_name]
+            .gateway_routes
+        ):
+            raise GatewayRouteNotFoundError(
+                mesh_name=mesh_name,
+                virtual_gateway_name=virtual_gateway_name,
+                gateway_route_name=gateway_route_name,
+            )
+        return
+
+    def _check_gateway_route_availability(
+        self,
+        mesh_name: str,
+        mesh_owner: str | None,
+        virtual_gateway_name: str,
+        gateway_route_name: str,
+    ) -> None:
+        self._check_virtual_gateway_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        if (
+            gateway_route_name
+            in self.meshes[mesh_name]
+            .virtual_gateways[virtual_gateway_name]
+            .gateway_routes
+        ):
+            raise GatewayRouteNameAlreadyTakenError(
+                mesh_name=mesh_name,
+                virtual_gateway_name=virtual_gateway_name,
+                gateway_route_name=gateway_route_name,
             )
         return
 
@@ -268,7 +368,7 @@ class AppMeshBackend(BaseBackend):
 
     def _get_resource_with_arn(
         self, resource_arn: str
-    ) -> Mesh | VirtualRouter | Route | VirtualNode:
+    ) -> Mesh | VirtualRouter | Route | VirtualNode | VirtualGateway | GatewayRoute:
         for mesh in self.meshes.values():
             if mesh.metadata.arn == resource_arn:
                 return mesh
@@ -281,6 +381,12 @@ class AppMeshBackend(BaseBackend):
             for virtual_node in mesh.virtual_nodes.values():
                 if virtual_node.metadata.arn == resource_arn:
                     return virtual_node
+            for virtual_gateway in mesh.virtual_gateways.values():
+                if virtual_gateway.metadata.arn == resource_arn:
+                    return virtual_gateway
+                for gateway_route in virtual_gateway.gateway_routes.values():
+                    if gateway_route.metadata.arn == resource_arn:
+                        return gateway_route
         raise ResourceNotFoundError(resource_arn)
 
     @paginate(pagination_model=PAGINATION_MODEL)  # type: ignore
@@ -606,6 +712,220 @@ class AppMeshBackend(BaseBackend):
         self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
         virtual_nodes = self.meshes[mesh_name].virtual_nodes
         return [virtual_node.metadata for virtual_node in virtual_nodes.values()]
+
+    def create_virtual_gateway(
+        self,
+        client_token: str | None,
+        mesh_name: str,
+        mesh_owner: str | None,
+        spec: VirtualGatewaySpec,
+        tags: list[dict[str, str]] | None,
+        virtual_gateway_name: str,
+    ) -> VirtualGateway:
+        self._check_virtual_gateway_availability(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        owner = mesh_owner or self.meshes[mesh_name].metadata.mesh_owner
+        metadata = VirtualGatewayMetadata(
+            arn=f"arn:aws:appmesh:{self.region_name}:{self.account_id}:mesh/{mesh_name}/virtualGateway/{virtual_gateway_name}",
+            mesh_name=mesh_name,
+            mesh_owner=owner,
+            resource_owner=owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        virtual_gateway = VirtualGateway(
+            mesh_name=mesh_name,
+            mesh_owner=owner,
+            metadata=metadata,
+            spec=spec,
+            tags=tags or [],
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        self.meshes[mesh_name].virtual_gateways[virtual_gateway_name] = virtual_gateway
+        return virtual_gateway
+
+    def describe_virtual_gateway(
+        self, mesh_name: str, mesh_owner: str | None, virtual_gateway_name: str
+    ) -> VirtualGateway:
+        self._check_virtual_gateway_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return self.meshes[mesh_name].virtual_gateways[virtual_gateway_name]
+
+    def update_virtual_gateway(
+        self,
+        client_token: str | None,
+        mesh_name: str,
+        mesh_owner: str | None,
+        spec: VirtualGatewaySpec,
+        virtual_gateway_name: str,
+    ) -> VirtualGateway:
+        self._check_virtual_gateway_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        virtual_gateway = self.meshes[mesh_name].virtual_gateways[virtual_gateway_name]
+        virtual_gateway.spec = spec
+        virtual_gateway.metadata.version += 1
+        virtual_gateway.metadata.update_timestamp()
+        return virtual_gateway
+
+    def delete_virtual_gateway(
+        self, mesh_name: str, mesh_owner: str | None, virtual_gateway_name: str
+    ) -> VirtualGateway:
+        self._check_virtual_gateway_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        virtual_gateway = self.meshes[mesh_name].virtual_gateways[virtual_gateway_name]
+        virtual_gateway.status["status"] = "DELETED"
+        del self.meshes[mesh_name].virtual_gateways[virtual_gateway_name]
+        return virtual_gateway
+
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_virtual_gateways(
+        self,
+        mesh_name: str,
+        mesh_owner: str | None,
+    ) -> list[VirtualGatewayMetadata]:
+        self._validate_mesh(mesh_name=mesh_name, mesh_owner=mesh_owner)
+        virtual_gateways = self.meshes[mesh_name].virtual_gateways
+        return [
+            virtual_gateway.metadata for virtual_gateway in virtual_gateways.values()
+        ]
+
+    def create_gateway_route(
+        self,
+        client_token: str | None,
+        gateway_route_name: str,
+        mesh_name: str,
+        mesh_owner: str | None,
+        spec: GatewayRouteSpec,
+        tags: list[dict[str, str]] | None,
+        virtual_gateway_name: str,
+    ) -> GatewayRoute:
+        self._check_gateway_route_availability(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+            gateway_route_name=gateway_route_name,
+        )
+        owner = mesh_owner or self.meshes[mesh_name].metadata.mesh_owner
+        metadata = GatewayRouteMetadata(
+            arn=f"arn:aws:appmesh:{self.region_name}:{self.account_id}:mesh/{mesh_name}/virtualGateway/{virtual_gateway_name}/gatewayRoute/{gateway_route_name}",
+            gateway_route_name=gateway_route_name,
+            mesh_name=mesh_name,
+            mesh_owner=owner,
+            resource_owner=owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        gateway_route = GatewayRoute(
+            gateway_route_name=gateway_route_name,
+            mesh_name=mesh_name,
+            mesh_owner=owner,
+            metadata=metadata,
+            spec=spec,
+            tags=tags or [],
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        self.meshes[mesh_name].virtual_gateways[virtual_gateway_name].gateway_routes[
+            gateway_route_name
+        ] = gateway_route
+        return gateway_route
+
+    def describe_gateway_route(
+        self,
+        gateway_route_name: str,
+        mesh_name: str,
+        mesh_owner: str | None,
+        virtual_gateway_name: str,
+    ) -> GatewayRoute:
+        self._check_gateway_route_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+            gateway_route_name=gateway_route_name,
+        )
+        return (
+            self.meshes[mesh_name]
+            .virtual_gateways[virtual_gateway_name]
+            .gateway_routes[gateway_route_name]
+        )
+
+    def update_gateway_route(
+        self,
+        client_token: str | None,
+        gateway_route_name: str,
+        mesh_name: str,
+        mesh_owner: str | None,
+        spec: GatewayRouteSpec,
+        virtual_gateway_name: str,
+    ) -> GatewayRoute:
+        self._check_gateway_route_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+            gateway_route_name=gateway_route_name,
+        )
+        gateway_route = (
+            self.meshes[mesh_name]
+            .virtual_gateways[virtual_gateway_name]
+            .gateway_routes[gateway_route_name]
+        )
+        gateway_route.spec = spec
+        gateway_route.metadata.version += 1
+        gateway_route.metadata.update_timestamp()
+        return gateway_route
+
+    def delete_gateway_route(
+        self,
+        gateway_route_name: str,
+        mesh_name: str,
+        mesh_owner: str | None,
+        virtual_gateway_name: str,
+    ) -> GatewayRoute:
+        self._check_gateway_route_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+            gateway_route_name=gateway_route_name,
+        )
+        gateway_route = (
+            self.meshes[mesh_name]
+            .virtual_gateways[virtual_gateway_name]
+            .gateway_routes[gateway_route_name]
+        )
+        gateway_route.status["status"] = "DELETED"
+        del (
+            self.meshes[mesh_name]
+            .virtual_gateways[virtual_gateway_name]
+            .gateway_routes[gateway_route_name]
+        )
+        return gateway_route
+
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_gateway_routes(
+        self,
+        mesh_name: str,
+        mesh_owner: str | None,
+        virtual_gateway_name: str,
+    ) -> list[GatewayRouteMetadata]:
+        self._check_virtual_gateway_validity(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        virtual_gateway = self.meshes[mesh_name].virtual_gateways[virtual_gateway_name]
+        return [
+            gateway_route.metadata
+            for gateway_route in virtual_gateway.gateway_routes.values()
+        ]
 
 
 appmesh_backends = BackendDict(AppMeshBackend, "appmesh")

--- a/moto/appmesh/responses.py
+++ b/moto/appmesh/responses.py
@@ -3,7 +3,9 @@
 import json
 
 from moto.appmesh.utils.spec_parsing import (
+    build_gateway_route_spec,
     build_route_spec,
+    build_virtual_gateway_spec,
     build_virtual_node_spec,
     port_mappings_from_router_spec,
 )
@@ -325,5 +327,165 @@ class AppMeshResponse(BaseResponse):
             {
                 "nextToken": next_token,
                 "virtualNodes": [n.formatted_for_list_api() for n in virtual_nodes],
+            }
+        )
+
+    def describe_virtual_gateway(self) -> str:
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        virtual_gateway = self.appmesh_backend.describe_virtual_gateway(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(virtual_gateway.to_dict())
+
+    def create_virtual_gateway(self) -> str:
+        params = json.loads(self.body)
+        client_token = params.get("clientToken")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        spec = build_virtual_gateway_spec(params.get("spec") or {})
+        tags = params.get("tags")
+        virtual_gateway_name = params.get("virtualGatewayName")
+        virtual_gateway = self.appmesh_backend.create_virtual_gateway(
+            client_token=client_token,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            spec=spec,
+            tags=tags,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(virtual_gateway.to_dict())
+
+    def update_virtual_gateway(self) -> str:
+        params = json.loads(self.body)
+        client_token = params.get("clientToken")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        spec = build_virtual_gateway_spec(params.get("spec") or {})
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        virtual_gateway = self.appmesh_backend.update_virtual_gateway(
+            client_token=client_token,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            spec=spec,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(virtual_gateway.to_dict())
+
+    def delete_virtual_gateway(self) -> str:
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        virtual_gateway = self.appmesh_backend.delete_virtual_gateway(
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(virtual_gateway.to_dict())
+
+    def list_virtual_gateways(self) -> str:
+        limit = self._get_int_param("limit")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        next_token = self._get_param("nextToken")
+        virtual_gateways, next_token = self.appmesh_backend.list_virtual_gateways(
+            limit=limit,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            next_token=next_token,
+        )
+        return json.dumps(
+            {
+                "nextToken": next_token,
+                "virtualGateways": [
+                    g.formatted_for_list_api() for g in virtual_gateways
+                ],
+            }
+        )
+
+    def create_gateway_route(self) -> str:
+        params = json.loads(self.body)
+        client_token = params.get("clientToken")
+        gateway_route_name = self._get_param("gatewayRouteName")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        spec = build_gateway_route_spec(params.get("spec") or {})
+        tags = params.get("tags")
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        gateway_route = self.appmesh_backend.create_gateway_route(
+            client_token=client_token,
+            gateway_route_name=gateway_route_name,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            spec=spec,
+            tags=tags,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(gateway_route.to_dict())
+
+    def describe_gateway_route(self) -> str:
+        gateway_route_name = self._get_param("gatewayRouteName")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        gateway_route = self.appmesh_backend.describe_gateway_route(
+            gateway_route_name=gateway_route_name,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(gateway_route.to_dict())
+
+    def update_gateway_route(self) -> str:
+        params = json.loads(self.body)
+        client_token = params.get("clientToken")
+        gateway_route_name = self._get_param("gatewayRouteName")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        spec = build_gateway_route_spec(params.get("spec") or {})
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        gateway_route = self.appmesh_backend.update_gateway_route(
+            client_token=client_token,
+            gateway_route_name=gateway_route_name,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            spec=spec,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(gateway_route.to_dict())
+
+    def delete_gateway_route(self) -> str:
+        gateway_route_name = self._get_param("gatewayRouteName")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        gateway_route = self.appmesh_backend.delete_gateway_route(
+            gateway_route_name=gateway_route_name,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(gateway_route.to_dict())
+
+    def list_gateway_routes(self) -> str:
+        limit = self._get_int_param("limit")
+        mesh_name = self._get_param("meshName")
+        mesh_owner = self._get_param("meshOwner")
+        next_token = self._get_param("nextToken")
+        virtual_gateway_name = self._get_param("virtualGatewayName")
+        gateway_routes, next_token = self.appmesh_backend.list_gateway_routes(
+            limit=limit,
+            mesh_name=mesh_name,
+            mesh_owner=mesh_owner,
+            next_token=next_token,
+            virtual_gateway_name=virtual_gateway_name,
+        )
+        return json.dumps(
+            {
+                "nextToken": next_token,
+                "gatewayRoutes": [r.formatted_for_list_api() for r in gateway_routes],
             }
         )

--- a/moto/appmesh/urls.py
+++ b/moto/appmesh/urls.py
@@ -17,4 +17,8 @@ url_paths = {
     "{0}/v20190125/meshes/(?P<meshName>.*)/virtualRouter/(?P<virtualRouterName>.*)/routes/(?P<routeName>[^/]+)$": AppMeshResponse.dispatch,
     "{0}/v20190125/meshes/(?P<meshName>.*)/virtualNodes/(?P<virtualNodeName>[^/]+)$": AppMeshResponse.dispatch,
     "{0}/v20190125/meshes/(?P<meshName>.*)/virtualNodes$": AppMeshResponse.dispatch,
+    "{0}/v20190125/meshes/(?P<meshName>.*)/virtualGateways/(?P<virtualGatewayName>[^/]+)$": AppMeshResponse.dispatch,
+    "{0}/v20190125/meshes/(?P<meshName>.*)/virtualGateways$": AppMeshResponse.dispatch,
+    "{0}/v20190125/meshes/(?P<meshName>.*)/virtualGateway/(?P<virtualGatewayName>.*)/gatewayRoutes$": AppMeshResponse.dispatch,
+    "{0}/v20190125/meshes/(?P<meshName>.*)/virtualGateway/(?P<virtualGatewayName>.*)/gatewayRoutes/(?P<gatewayRouteName>[^/]+)$": AppMeshResponse.dispatch,
 }

--- a/moto/appmesh/utils/spec_parsing.py
+++ b/moto/appmesh/utils/spec_parsing.py
@@ -1,5 +1,22 @@
 from typing import Any
 
+from moto.appmesh.dataclasses.gateway_route import (
+    GatewayRouteHostnameMatch,
+    GatewayRouteHostnameRewrite,
+    GatewayRouteSpec,
+    GatewayRouteTarget,
+    GatewayRouteVirtualService,
+    GrpcGatewayRoute,
+    GrpcGatewayRouteAction,
+    GrpcGatewayRouteMatch,
+    GrpcGatewayRouteRewrite,
+    HttpGatewayRoute,
+    HttpGatewayRouteAction,
+    HttpGatewayRouteMatch,
+    HttpGatewayRoutePathRewrite,
+    HttpGatewayRoutePrefixRewrite,
+    HttpGatewayRouteRewrite,
+)
 from moto.appmesh.dataclasses.route import (
     GrcpRouteRetryPolicy,
     GrpcMetadatum,
@@ -20,6 +37,10 @@ from moto.appmesh.dataclasses.route import (
     TCPRouteMatch,
 )
 from moto.appmesh.dataclasses.shared import Duration, Timeout
+from moto.appmesh.dataclasses.virtual_gateway import (
+    VirtualGatewayListener,
+    VirtualGatewaySpec,
+)
 from moto.appmesh.dataclasses.virtual_node import (
     ACM,
     DNS,
@@ -672,4 +693,278 @@ def build_virtual_node_spec(spec: dict[str, Any]) -> VirtualNodeSpec:  # type: i
         listeners=listeners,
         logging=logging,
         service_discovery=service_discovery,
+    )
+
+
+def get_listener_tls(spec: Any) -> ListenerTLS:  # type: ignore[misc]
+    _certificate = spec.get("certificate")
+    _validation = spec.get("validation")
+    validation = None
+    if _certificate is None:
+        raise MissingRequiredFieldError("certificate")
+    _file = _certificate.get("file")
+    _sds = _certificate.get("sds")
+    _acm = _certificate.get("acm")
+    file, sds, acm = None, None, None
+    if _file is not None:
+        file = CertificateFileWithPrivateKey(
+            certificate_chain=_file.get("certificateChain"),
+            private_key=_file.get("privateKey"),
+        )
+    if _sds is not None:
+        sds = SDS(secret_name=_sds.get("secretName"))
+    if _acm is not None:
+        acm = ListenerCertificateACM(certificate_arn=_acm.get("certificateArn"))
+    certificate = TLSListenerCertificate(file=file, sds=sds, acm=acm)
+
+    if _validation is not None:
+        _subject_alternative_names = _validation.get("subjectAlternativeNames")
+        _trust = _validation.get("trust")
+        subject_alternative_names = None
+        if _subject_alternative_names is not None:
+            match = VirtualNodeMatch(
+                exact=_subject_alternative_names.get("match").get("exact")
+            )
+            subject_alternative_names = SubjectAlternativeNames(match=match)
+        if _trust is None:
+            raise MissingRequiredFieldError("trust")
+        _trust_file = _trust.get("file")
+        _trust_sds = _trust.get("sds")
+        trust_file, trust_sds = None, None
+        if _trust_file is not None:
+            trust_file = CertificateFile(
+                certificate_chain=_trust_file.get("certificateChain")
+            )
+        if _trust_sds is not None:
+            trust_sds = SDS(secret_name=_trust_sds.get("secretName"))
+        validation = TLSListenerValidation(
+            subject_alternative_names=subject_alternative_names,
+            trust=Trust(file=trust_file, sds=trust_sds),
+        )
+    return ListenerTLS(
+        certificate=certificate, mode=spec.get("mode"), validation=validation
+    )
+
+
+def build_virtual_gateway_spec(spec: dict[str, Any]) -> VirtualGatewaySpec:  # type: ignore[misc]
+    _backend_defaults = spec.get("backendDefaults")
+    _listeners = spec.get("listeners")
+    _logging = spec.get("logging")
+    backend_defaults, listeners, logging = None, None, None
+
+    if _backend_defaults is not None:
+        _client_policy = _backend_defaults.get("clientPolicy")
+        client_policy = None
+        if _client_policy is not None:
+            _tls = _client_policy.get("tls")
+            tls = get_tls_for_client_policy(_tls) if _tls is not None else None
+            client_policy = ClientPolicy(tls=tls)
+        backend_defaults = BackendDefaults(client_policy=client_policy)
+
+    if _listeners is not None:
+        listeners = []
+        for _listener in _listeners:
+            _connection_pool = _listener.get("connectionPool")
+            _health_check = _listener.get("healthCheck")
+            _port_mapping = _listener.get("portMapping")
+            _tls = _listener.get("tls")
+            connection_pool, health_check, listener_tls = None, None, None
+
+            if _connection_pool is not None:
+                _grpc = _connection_pool.get("grpc")
+                _http = _connection_pool.get("http")
+                _http2 = _connection_pool.get("http2")
+                grpc, http, http2 = None, None, None
+                if _grpc is not None:
+                    grpc = GRPCOrHTTP2Connection(max_requests=_grpc.get("maxRequests"))
+                if _http is not None:
+                    http = HTTPConnection(
+                        max_connections=_http.get("maxConnections"),
+                        max_pending_requests=_http.get("maxPendingRequests"),
+                    )
+                if _http2 is not None:
+                    http2 = GRPCOrHTTP2Connection(
+                        max_requests=_http2.get("maxRequests")
+                    )
+                connection_pool = ConnectionPool(
+                    grpc=grpc, http=http, http2=http2, tcp=None
+                )
+
+            if _health_check is not None:
+                health_check = HealthCheck(
+                    healthy_threshold=_health_check.get("healthyThreshold"),
+                    interval_millis=_health_check.get("intervalMillis"),
+                    path=_health_check.get("path"),
+                    port=_health_check.get("port"),
+                    protocol=_health_check.get("protocol"),
+                    timeout_millis=_health_check.get("timeoutMillis"),
+                    unhealthy_threshold=_health_check.get("unhealthyThreshold"),
+                )
+
+            if _port_mapping is None:
+                raise MissingRequiredFieldError("portMapping")
+            port_mapping = PortMapping(
+                port=_port_mapping.get("port"), protocol=_port_mapping.get("protocol")
+            )
+
+            if _tls is not None:
+                listener_tls = get_listener_tls(_tls)
+
+            listeners.append(
+                VirtualGatewayListener(
+                    connection_pool=connection_pool,
+                    health_check=health_check,
+                    port_mapping=port_mapping,
+                    tls=listener_tls,
+                )
+            )
+
+    if _logging is not None:
+        _access_log = _logging.get("accessLog")
+        access_log = None
+        if _access_log is not None:
+            _file = _access_log.get("file")
+            file = None
+            if _file is not None:
+                _format = _file.get("format")
+                format = None
+                if _format is not None:
+                    _json = _format.get("json")
+                    json = None
+                    if _json is not None:
+                        json = [
+                            KeyValue(key=item.get("key"), value=item.get("value"))
+                            for item in _json
+                        ]
+                    format = LoggingFormat(json=json, text=_format.get("text"))
+                file = AccessLogFile(format=format, path=_file.get("path"))
+            access_log = AccessLog(file=file)
+        logging = Logging(access_log=access_log)
+
+    return VirtualGatewaySpec(
+        backend_defaults=backend_defaults, listeners=listeners, logging=logging
+    )
+
+
+def _get_gateway_route_target(action: Any) -> GatewayRouteTarget:  # type: ignore[misc]
+    _target = action.get("target") or {}
+    _virtual_service: Any = _target.get("virtualService") or {}
+    return GatewayRouteTarget(
+        port=_target.get("port"),
+        virtual_service=GatewayRouteVirtualService(
+            virtual_service_name=_virtual_service.get("virtualServiceName")
+        ),
+    )
+
+
+def _get_hostname_rewrite(rewrite: Any) -> GatewayRouteHostnameRewrite | None:  # type: ignore[misc]
+    _hostname = rewrite.get("hostname")
+    if _hostname is None:
+        return None
+    return GatewayRouteHostnameRewrite(
+        default_target_hostname=_hostname.get("defaultTargetHostname")
+    )
+
+
+def _get_hostname_match(match: Any) -> GatewayRouteHostnameMatch | None:  # type: ignore[misc]
+    _hostname = match.get("hostname")
+    if _hostname is None:
+        return None
+    return GatewayRouteHostnameMatch(
+        exact=_hostname.get("exact"), suffix=_hostname.get("suffix")
+    )
+
+
+def build_gateway_route_spec(spec: dict[str, Any]) -> GatewayRouteSpec:  # type: ignore[misc]
+    _grpc_route = spec.get("grpcRoute")
+    _http_route = spec.get("httpRoute")
+    _http2_route = spec.get("http2Route")
+    grpc_route, http_route, http2_route = None, None, None
+
+    if _grpc_route is not None:
+        _action = _grpc_route.get("action") or {}
+        _rewrite = _action.get("rewrite")
+        rewrite = None
+        if _rewrite is not None:
+            rewrite = GrpcGatewayRouteRewrite(hostname=_get_hostname_rewrite(_rewrite))
+        _match = _grpc_route.get("match") or {}
+        grpc_route = GrpcGatewayRoute(
+            action=GrpcGatewayRouteAction(
+                rewrite=rewrite, target=_get_gateway_route_target(_action)
+            ),
+            match=GrpcGatewayRouteMatch(
+                hostname=_get_hostname_match(_match),
+                metadata=get_route_match_metadata(_match.get("metadata") or []),
+                port=_match.get("port"),
+                service_name=_match.get("serviceName"),
+            ),
+        )
+
+    if _http_route is not None:
+        http_route = _build_http_gateway_route(_http_route)
+    if _http2_route is not None:
+        http2_route = _build_http_gateway_route(_http2_route)
+
+    return GatewayRouteSpec(
+        grpc_route=grpc_route,
+        http_route=http_route,
+        http2_route=http2_route,
+        priority=spec.get("priority"),
+    )
+
+
+def _build_http_gateway_route(route: Any) -> HttpGatewayRoute:  # type: ignore[misc]
+    _action = route.get("action") or {}
+    _rewrite = _action.get("rewrite")
+    rewrite = None
+    if _rewrite is not None:
+        _path = _rewrite.get("path")
+        _prefix = _rewrite.get("prefix")
+        path = HttpGatewayRoutePathRewrite(exact=_path.get("exact")) if _path else None
+        prefix = (
+            HttpGatewayRoutePrefixRewrite(
+                default_prefix=_prefix.get("defaultPrefix"), value=_prefix.get("value")
+            )
+            if _prefix
+            else None
+        )
+        rewrite = HttpGatewayRouteRewrite(
+            hostname=_get_hostname_rewrite(_rewrite), path=path, prefix=prefix
+        )
+
+    _match = route.get("match") or {}
+    _path = _match.get("path")
+    path_match = (
+        RouteMatchPath(exact=_path.get("exact"), regex=_path.get("regex"))
+        if _path is not None
+        else None
+    )
+    query_parameters = None
+    _query_parameters = _match.get("queryParameters")
+    if _query_parameters is not None:
+        query_parameters = []
+        for _param in _query_parameters:
+            _qmatch = _param.get("match")
+            qmatch = (
+                QueryParameterMatch(exact=_qmatch.get("exact"))
+                if _qmatch is not None
+                else None
+            )
+            query_parameters.append(
+                RouteMatchQueryParameter(name=_param.get("name"), match=qmatch)
+            )
+
+    return HttpGatewayRoute(
+        action=HttpGatewayRouteAction(
+            rewrite=rewrite, target=_get_gateway_route_target(_action)
+        ),
+        match=HttpGatewayRouteMatch(
+            headers=get_route_match_metadata(_match.get("headers") or []),
+            hostname=_get_hostname_match(_match),
+            method=_match.get("method"),
+            path=path_match,
+            port=_match.get("port"),
+            prefix=_match.get("prefix"),
+            query_parameters=query_parameters,
+        ),
     )

--- a/tests/test_appmesh/data.py
+++ b/tests/test_appmesh/data.py
@@ -685,3 +685,120 @@ modified_http2_virtual_node_spec = {
         }
     },
 }
+
+virtual_gateway_spec = {
+    "backendDefaults": {
+        "clientPolicy": {
+            "tls": {
+                "certificate": {
+                    "file": {
+                        "certificateChain": "/path/to/cert_chain.pem",
+                        "privateKey": "/path/to/private_key.pem",
+                    }
+                },
+                "enforce": True,
+                "ports": [443],
+                "validation": {
+                    "subjectAlternativeNames": {
+                        "match": {"exact": ["gateway.example.com"]}
+                    },
+                    "trust": {"file": {"certificateChain": "/path/to/ca_bundle.pem"}},
+                },
+            }
+        }
+    },
+    "listeners": [
+        {
+            "connectionPool": {
+                "http": {"maxConnections": 100, "maxPendingRequests": 10}
+            },
+            "healthCheck": {
+                "healthyThreshold": 5,
+                "intervalMillis": 10000,
+                "path": "/ping",
+                "port": 8080,
+                "protocol": "http",
+                "timeoutMillis": 5000,
+                "unhealthyThreshold": 2,
+            },
+            "portMapping": {"port": 8080, "protocol": "http"},
+            "tls": {
+                "certificate": {
+                    "acm": {
+                        "certificateArn": "arn:aws:acm:us-east-1:123456789012:certificate/abc"
+                    }
+                },
+                "mode": "STRICT",
+            },
+        }
+    ],
+    "logging": {"accessLog": {"file": {"path": "/dev/stdout"}}},
+}
+
+modified_virtual_gateway_spec = {
+    "listeners": [
+        {
+            "connectionPool": {"grpc": {"maxRequests": 50}},
+            "portMapping": {"port": 9090, "protocol": "grpc"},
+        }
+    ],
+}
+
+http_gateway_route_spec = {
+    "priority": 1,
+    "httpRoute": {
+        "action": {
+            "rewrite": {
+                "hostname": {"defaultTargetHostname": "ENABLED"},
+                "prefix": {"defaultPrefix": "DISABLED"},
+            },
+            "target": {
+                "port": 8080,
+                "virtualService": {"virtualServiceName": "web.local"},
+            },
+        },
+        "match": {
+            "headers": [
+                {"invert": False, "match": {"exact": "v1"}, "name": "x-version"}
+            ],
+            "hostname": {"suffix": ".local"},
+            "method": "GET",
+            "port": 8080,
+            "prefix": "/",
+            "queryParameters": [{"match": {"exact": "example"}, "name": "q"}],
+        },
+    },
+}
+
+http2_gateway_route_spec = {
+    "priority": 2,
+    "http2Route": {
+        "action": {
+            "rewrite": {"path": {"exact": "/rewritten"}},
+            "target": {"virtualService": {"virtualServiceName": "h2.local"}},
+        },
+        "match": {
+            "hostname": {"exact": "h2.example.com"},
+            "path": {"exact": "/api"},
+        },
+    },
+}
+
+grpc_gateway_route_spec = {
+    "priority": 3,
+    "grpcRoute": {
+        "action": {
+            "rewrite": {"hostname": {"defaultTargetHostname": "ENABLED"}},
+            "target": {
+                "port": 9090,
+                "virtualService": {"virtualServiceName": "grpc.local"},
+            },
+        },
+        "match": {
+            "hostname": {"suffix": ".grpc.local"},
+            "metadata": [{"invert": True, "match": {"prefix": "m"}, "name": "x-meta"}],
+            "port": 9090,
+            "serviceName": "myService",
+        },
+    },
+}

--- a/tests/test_appmesh/test_appmesh.py
+++ b/tests/test_appmesh/test_appmesh.py
@@ -10,16 +10,21 @@ from botocore.exceptions import ClientError
 from moto import mock_aws
 
 from .data import (
+    grpc_gateway_route_spec,
     grpc_route_spec,
     grpc_virtual_node_spec,
+    http2_gateway_route_spec,
     http2_route_spec,
     http2_virtual_node_spec,
+    http_gateway_route_spec,
     http_route_spec,
     http_virtual_node_spec,
     modified_http2_virtual_node_spec,
     modified_http_route_spec,
+    modified_virtual_gateway_spec,
     tcp_route_spec,
     tcp_virtual_node_spec,
+    virtual_gateway_spec,
 )
 
 MESH_NAME = "mock_mesh"
@@ -1443,3 +1448,330 @@ def test_tag_and_list_tags_for_resource(client):
         resourceArn=virtual_node_arn, nextToken=page1["nextToken"]
     )
     assert page2["tags"] == [{"key": "k2", "value": "v2"}, {"key": "k3", "value": "v3"}]
+
+
+@mock_aws
+def test_create_describe_list_update_delete_virtual_gateway(client):
+    mesh = client.create_mesh(meshName=MESH_NAME)["mesh"]
+    mesh_owner = mesh["metadata"]["meshOwner"]
+
+    GATEWAY_1 = "gateway1"
+    GATEWAY_2 = "gateway2"
+
+    connection = client.create_virtual_gateway(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_1,
+        spec=virtual_gateway_spec,
+        tags=[{"key": "gateway_traffic", "value": "http"}],
+    )
+    gateway1 = connection["virtualGateway"]
+    assert gateway1["virtualGatewayName"] == GATEWAY_1
+    assert gateway1["meshName"] == MESH_NAME
+    assert gateway1["metadata"]["meshOwner"] == mesh_owner
+    assert gateway1["metadata"]["version"] == 1
+    assert gateway1["status"]["status"] == "ACTIVE"
+    spec = gateway1["spec"]
+    listener = spec["listeners"][0]
+    assert listener["portMapping"] == {"port": 8080, "protocol": "http"}
+    assert listener["healthCheck"]["path"] == "/ping"
+    assert listener["connectionPool"]["http"]["maxConnections"] == 100
+    assert listener["tls"]["mode"] == "STRICT"
+    assert (
+        listener["tls"]["certificate"]["acm"]["certificateArn"]
+        == "arn:aws:acm:us-east-1:123456789012:certificate/abc"
+    )
+    assert spec["logging"]["accessLog"]["file"]["path"] == "/dev/stdout"
+    assert spec["backendDefaults"]["clientPolicy"]["tls"]["enforce"] is True
+
+    client.create_virtual_gateway(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_2,
+        spec={"listeners": [{"portMapping": {"port": 443, "protocol": "http2"}}]},
+    )
+
+    connection = client.list_virtual_gateways(meshName=MESH_NAME, meshOwner=mesh_owner)
+    virtual_gateways = connection["virtualGateways"]
+    assert isinstance(virtual_gateways, list)
+    assert len(virtual_gateways) == 2
+    names_counted = defaultdict(int)
+    for virtual_gateway in virtual_gateways:
+        gateway_name = virtual_gateway.get("virtualGatewayName")
+        if gateway_name:
+            names_counted[gateway_name] += 1
+    assert names_counted[GATEWAY_1] == 1
+    assert names_counted[GATEWAY_2] == 1
+
+    connection = client.update_virtual_gateway(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_1,
+        spec=modified_virtual_gateway_spec,
+    )
+    updated_gateway1 = connection["virtualGateway"]
+    assert updated_gateway1["metadata"]["version"] == 2
+    listener = updated_gateway1["spec"]["listeners"][0]
+    assert listener["portMapping"] == {"port": 9090, "protocol": "grpc"}
+    assert listener["connectionPool"]["grpc"]["maxRequests"] == 50
+
+    connection = client.describe_virtual_gateway(
+        meshName=MESH_NAME, meshOwner=mesh_owner, virtualGatewayName=GATEWAY_1
+    )
+    described = connection["virtualGateway"]
+    assert described["virtualGatewayName"] == GATEWAY_1
+    assert described["metadata"]["version"] == 2
+
+    connection = client.delete_virtual_gateway(
+        meshName=MESH_NAME, meshOwner=mesh_owner, virtualGatewayName=GATEWAY_2
+    )
+    deleted = connection["virtualGateway"]
+    assert deleted["virtualGatewayName"] == GATEWAY_2
+    assert deleted["status"]["status"] == "DELETED"
+
+    with pytest.raises(ClientError) as e:
+        client.describe_virtual_gateway(
+            meshName=MESH_NAME, meshOwner=mesh_owner, virtualGatewayName=GATEWAY_2
+        )
+    err = e.value.response["Error"]
+    assert err["Code"] == "VirtualGatewayNotFound"
+    assert GATEWAY_2 in err["Message"]
+
+    with pytest.raises(ClientError) as e:
+        client.create_virtual_gateway(
+            meshName=MESH_NAME,
+            meshOwner=mesh_owner,
+            virtualGatewayName=GATEWAY_1,
+            spec={"listeners": [{"portMapping": {"port": 80, "protocol": "http"}}]},
+        )
+    err = e.value.response["Error"]
+    assert err["Code"] == "VirtualGatewayNameAlreadyTaken"
+
+
+@mock_aws
+def test_list_virtual_gateways_paginated(client):
+    mesh = client.create_mesh(meshName=MESH_NAME)["mesh"]
+    mesh_owner = mesh["metadata"]["meshOwner"]
+
+    for i in range(5):
+        client.create_virtual_gateway(
+            meshName=MESH_NAME,
+            meshOwner=mesh_owner,
+            virtualGatewayName=f"gateway{i}",
+            spec={"listeners": [{"portMapping": {"port": 80, "protocol": "http"}}]},
+        )
+
+    all_gateways = client.list_virtual_gateways(
+        meshName=MESH_NAME, meshOwner=mesh_owner
+    )["virtualGateways"]
+    assert len(all_gateways) == 5
+
+    page1 = client.list_virtual_gateways(
+        meshName=MESH_NAME, meshOwner=mesh_owner, limit=2
+    )
+    assert len(page1["virtualGateways"]) == 2
+
+    page2 = client.list_virtual_gateways(
+        meshName=MESH_NAME, meshOwner=mesh_owner, nextToken=page1["nextToken"]
+    )
+    assert len(page2["virtualGateways"]) == 3
+
+
+@mock_aws
+def test_create_describe_list_update_delete_gateway_route(client):
+    GATEWAY_NAME = "mock_virtual_gateway"
+    mesh = client.create_mesh(meshName=MESH_NAME)["mesh"]
+    mesh_owner = mesh["metadata"]["meshOwner"]
+    client.create_virtual_gateway(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        spec={"listeners": [{"portMapping": {"port": 8080, "protocol": "http"}}]},
+    )
+
+    connection = client.create_gateway_route(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        gatewayRouteName="http_route",
+        spec=http_gateway_route_spec,
+        tags=[{"key": "license", "value": "mit"}],
+    )
+    route = connection["gatewayRoute"]
+    assert route["gatewayRouteName"] == "http_route"
+    assert route["meshName"] == MESH_NAME
+    assert route["virtualGatewayName"] == GATEWAY_NAME
+    assert route["metadata"]["version"] == 1
+    assert route["status"]["status"] == "ACTIVE"
+    http = route["spec"]["httpRoute"]
+    assert route["spec"]["priority"] == 1
+    assert (
+        http["action"]["target"]["virtualService"]["virtualServiceName"] == "web.local"
+    )
+    assert http["action"]["target"]["port"] == 8080
+    assert http["action"]["rewrite"]["prefix"]["defaultPrefix"] == "DISABLED"
+    assert http["match"]["prefix"] == "/"
+    assert http["match"]["method"] == "GET"
+    assert http["match"]["hostname"]["suffix"] == ".local"
+    assert http["match"]["headers"][0]["name"] == "x-version"
+    assert http["match"]["queryParameters"][0]["name"] == "q"
+
+    client.create_gateway_route(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        gatewayRouteName="grpc_route",
+        spec=grpc_gateway_route_spec,
+    )
+    described = client.describe_gateway_route(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        gatewayRouteName="grpc_route",
+    )["gatewayRoute"]
+    grpc = described["spec"]["grpcRoute"]
+    assert grpc["match"]["serviceName"] == "myService"
+    assert grpc["match"]["metadata"][0]["invert"] is True
+    assert grpc["action"]["rewrite"]["hostname"]["defaultTargetHostname"] == "ENABLED"
+
+    connection = client.list_gateway_routes(
+        meshName=MESH_NAME, meshOwner=mesh_owner, virtualGatewayName=GATEWAY_NAME
+    )
+    routes = connection["gatewayRoutes"]
+    assert len(routes) == 2
+    names_counted = defaultdict(int)
+    for r in routes:
+        names_counted[r["gatewayRouteName"]] += 1
+    assert names_counted["http_route"] == 1
+    assert names_counted["grpc_route"] == 1
+
+    connection = client.update_gateway_route(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        gatewayRouteName="http_route",
+        spec=http2_gateway_route_spec,
+    )
+    updated = connection["gatewayRoute"]
+    assert updated["metadata"]["version"] == 2
+    assert updated["spec"]["priority"] == 2
+    h2 = updated["spec"]["http2Route"]
+    assert h2["action"]["rewrite"]["path"]["exact"] == "/rewritten"
+    assert h2["match"]["hostname"]["exact"] == "h2.example.com"
+    assert "httpRoute" not in updated["spec"]
+
+    connection = client.delete_gateway_route(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        gatewayRouteName="grpc_route",
+    )
+    deleted = connection["gatewayRoute"]
+    assert deleted["gatewayRouteName"] == "grpc_route"
+    assert deleted["status"]["status"] == "DELETED"
+
+    with pytest.raises(ClientError) as e:
+        client.describe_gateway_route(
+            meshName=MESH_NAME,
+            meshOwner=mesh_owner,
+            virtualGatewayName=GATEWAY_NAME,
+            gatewayRouteName="grpc_route",
+        )
+    assert e.value.response["Error"]["Code"] == "GatewayRouteNotFound"
+
+    with pytest.raises(ClientError) as e:
+        client.create_gateway_route(
+            meshName=MESH_NAME,
+            meshOwner=mesh_owner,
+            virtualGatewayName=GATEWAY_NAME,
+            gatewayRouteName="http_route",
+            spec=http_gateway_route_spec,
+        )
+    assert e.value.response["Error"]["Code"] == "GatewayRouteNameAlreadyTaken"
+
+
+@mock_aws
+def test_list_gateway_routes_paginated(client):
+    GATEWAY_NAME = "mock_virtual_gateway"
+    mesh = client.create_mesh(meshName=MESH_NAME)["mesh"]
+    mesh_owner = mesh["metadata"]["meshOwner"]
+    client.create_virtual_gateway(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        spec={"listeners": [{"portMapping": {"port": 8080, "protocol": "http"}}]},
+    )
+
+    for i in range(5):
+        client.create_gateway_route(
+            meshName=MESH_NAME,
+            meshOwner=mesh_owner,
+            virtualGatewayName=GATEWAY_NAME,
+            gatewayRouteName=f"route{i}",
+            spec=http_gateway_route_spec,
+        )
+
+    all_routes = client.list_gateway_routes(
+        meshName=MESH_NAME, meshOwner=mesh_owner, virtualGatewayName=GATEWAY_NAME
+    )["gatewayRoutes"]
+    assert len(all_routes) == 5
+
+    page1 = client.list_gateway_routes(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        limit=2,
+    )
+    assert len(page1["gatewayRoutes"]) == 2
+
+    page2 = client.list_gateway_routes(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        nextToken=page1["nextToken"],
+    )
+    assert len(page2["gatewayRoutes"]) == 3
+
+
+@mock_aws
+def test_tag_virtual_gateway_and_gateway_route(client):
+    GATEWAY_NAME = "mock_virtual_gateway"
+    mesh = client.create_mesh(meshName=MESH_NAME)["mesh"]
+    mesh_owner = mesh["metadata"]["meshOwner"]
+
+    gateway = client.create_virtual_gateway(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        spec={"listeners": [{"portMapping": {"port": 8080, "protocol": "http"}}]},
+        tags=[{"key": "type", "value": "gateway"}],
+    )["virtualGateway"]
+    gateway_arn = gateway["metadata"]["arn"]
+
+    route = client.create_gateway_route(
+        meshName=MESH_NAME,
+        meshOwner=mesh_owner,
+        virtualGatewayName=GATEWAY_NAME,
+        gatewayRouteName="http_route",
+        spec=http_gateway_route_spec,
+        tags=[{"key": "license", "value": "mit"}],
+    )["gatewayRoute"]
+    route_arn = route["metadata"]["arn"]
+
+    client.tag_resource(
+        resourceArn=gateway_arn, tags=[{"key": "organization", "value": "moto"}]
+    )
+    tags = client.list_tags_for_resource(resourceArn=gateway_arn)["tags"]
+    assert tags == [
+        {"key": "type", "value": "gateway"},
+        {"key": "organization", "value": "moto"},
+    ]
+
+    client.tag_resource(
+        resourceArn=route_arn, tags=[{"key": "organization", "value": "moto"}]
+    )
+    tags = client.list_tags_for_resource(resourceArn=route_arn)["tags"]
+    assert tags == [
+        {"key": "license", "value": "mit"},
+        {"key": "organization", "value": "moto"},
+    ]


### PR DESCRIPTION
Implements the AppMesh **VirtualGateway** and **GatewayRoute** API surface, which was previously unimplemented (resolves #8002). Mirrors the existing virtual-router / route structure already in the module and reuses the virtual-node dataclasses (TLS, connection pool, health check, logging) so the response shapes match botocore exactly.

New actions (10):
- VirtualGateway: `CreateVirtualGateway`, `DescribeVirtualGateway`, `ListVirtualGateways`, `UpdateVirtualGateway`, `DeleteVirtualGateway`
- GatewayRoute: `CreateGatewayRoute`, `DescribeGatewayRoute`, `ListGatewayRoutes`, `UpdateGatewayRoute`, `DeleteGatewayRoute`

Includes `NotFound` / `NameAlreadyTaken` errors, pagination for both `List*` actions, tag support (ARN resolution extended), and the `IMPLEMENTATION_COVERAGE.md` / docs coverage flips for the 10 new actions.

Validation (local):
- `pytest tests/test_appmesh/` — 14 passed (9 existing + 5 new: VirtualGateway CRUD, GatewayRoute CRUD, both paginated, error cases, tagging)
- `ruff check` + `ruff format --check` — clean
- `mypy moto/appmesh/` — Success, no issues found

related: #7363 (the wider S3 EventBridge tracker is unrelated; this PR targets #8002 only)