### PR TITLE
EC2: Fix describe_instances availability-zone filter returning no results

### DIFF
--- a/moto/ec2/utils.py
+++ b/moto/ec2/utils.py
@@ -423,7 +423,7 @@ filter_dict_attribute_mapping = {
     "instance-type": "instance_type",
     "private-ip-address": "private_ip",
     "ip-address": "public_ip",
-    "availability-zone": "placement",
+    "availability-zone": "placement.zone",
     "architecture": "architecture",
     "image-id": "image_id",
     "network-interface.private-dns-name": "private_dns_name",

--- a/tests/test_ec2/test_instances.py
+++ b/tests/test_ec2/test_instances.py
@@ -518,6 +518,51 @@ def test_get_instances_filtering_by_instance_type():
 
 
 @mock_aws
+def test_get_instances_filtering_by_availability_zone():
+    client = boto3.client("ec2", "us-west-1")
+    ec2 = boto3.resource("ec2", "us-west-1")
+    instance1 = ec2.create_instances(
+        ImageId=EXAMPLE_AMI_ID,
+        MinCount=1,
+        MaxCount=1,
+        Placement={"AvailabilityZone": "us-west-1a"},
+    )[0]
+    instance2 = ec2.create_instances(
+        ImageId=EXAMPLE_AMI_ID,
+        MinCount=1,
+        MaxCount=1,
+        Placement={"AvailabilityZone": "us-west-1b"},
+    )[0]
+
+    instances = retrieve_all_instances(
+        client, [{"Name": "availability-zone", "Values": ["us-west-1a"]}]
+    )
+    instance_ids = [i["InstanceId"] for i in instances]
+    assert instance1.id in instance_ids
+    assert instance2.id not in instance_ids
+
+    instances = retrieve_all_instances(
+        client, [{"Name": "availability-zone", "Values": ["us-west-1b"]}]
+    )
+    instance_ids = [i["InstanceId"] for i in instances]
+    assert instance2.id in instance_ids
+    assert instance1.id not in instance_ids
+
+    instances = retrieve_all_instances(
+        client,
+        [{"Name": "availability-zone", "Values": ["us-west-1a", "us-west-1b"]}],
+    )
+    instance_ids = [i["InstanceId"] for i in instances]
+    assert instance1.id in instance_ids
+    assert instance2.id in instance_ids
+
+    res = client.describe_instances(
+        Filters=[{"Name": "availability-zone", "Values": ["us-west-2a"]}]
+    )
+    assert len(res["Reservations"]) == 0
+
+
+@mock_aws
 def test_get_instances_filtering_by_reason_code():
     ec2 = boto3.resource("ec2", "us-west-1")
     client = boto3.client("ec2", "us-west-1")


### PR DESCRIPTION
## Summary

`describe_instances` with an `availability-zone` filter always returns an empty result set, even when matching instances exist in that AZ.

```python
client.describe_instances(
    Filters=[{"Name": "availability-zone", "Values": ["us-east-1a"]}]
)
# -> {"Reservations": []}  even though an instance is running in us-east-1a
```

## Root cause

In `moto/ec2/utils.py`, the generic instance filter resolves a filter name to an attribute via `get_object_value`:

```python
filter_dict_attribute_mapping = {
    ...
    "availability-zone": "placement",
    ...
}
```

`instance.placement` is an `InstancePlacement` object, not a string. `passes_filter_dict` then compares that object against the filter's string values (e.g. `["us-east-1a"]`), which never matches, so every instance is filtered out.

The correctly-filtering resources resolve this to a string — e.g. EBS volumes return `self.zone.name` from their `get_filter_value`. The mapping also already uses dotted paths for nested attributes (`"state-reason-code": "state_reason.code"`), so `availability-zone` was the inconsistent outlier.

## Fix

Map `availability-zone` to `placement.zone` (the AZ string).

## Test

Instance filtering by `availability-zone` was previously untested — which is why the regression went unnoticed. Added `test_get_instances_filtering_by_availability_zone` covering single-AZ matches, multi-AZ values, exclusion, and a no-match case. It fails on `master` and passes with the fix; all existing `test_instances.py` tests still pass.
