### PR TITLE
Firehose: Add Iceberg destination support

### DIFF
--- a/moto/firehose/models.py
+++ b/moto/firehose/models.py
@@ -49,6 +49,7 @@ DESTINATION_TYPES_TO_NAMES = {
     "elasticsearch": "Elasticsearch",
     "redshift": "Redshift",
     "snowflake": "Snowflake",
+    "iceberg": "Iceberg",
     "splunk": "Splunk",  # Unimplemented
 }
 
@@ -205,6 +206,7 @@ class FirehoseBackend(BaseBackend, TaggableResourcesMixin):
         splunk_destination_configuration: dict[str, Any],
         http_endpoint_destination_configuration: dict[str, Any],
         snowflake_destination_configuration: dict[str, Any],
+        iceberg_destination_configuration: dict[str, Any],
         tags: list[dict[str, str]],
     ) -> str:
         """Create a Kinesis Data Firehose delivery stream."""
@@ -612,6 +614,7 @@ class FirehoseBackend(BaseBackend, TaggableResourcesMixin):
         splunk_destination_update: dict[str, Any],
         http_endpoint_destination_update: dict[str, Any],
         snowflake_destination_configuration: dict[str, Any],
+        iceberg_destination_update: dict[str, Any],
     ) -> None:
         (dest_name, dest_config) = find_destination_config_in_args(locals())
 

--- a/moto/firehose/responses.py
+++ b/moto/firehose/responses.py
@@ -32,6 +32,7 @@ class FirehoseResponse(BaseResponse):
             self._get_param("SplunkDestinationConfiguration"),
             self._get_param("HttpEndpointDestinationConfiguration"),
             self._get_param("SnowflakeDestinationConfiguration"),
+            self._get_param("IcebergDestinationConfiguration"),
             self._get_param("Tags"),
         )
         return ActionResult({"DeliveryStreamARN": delivery_stream_arn})
@@ -110,6 +111,7 @@ class FirehoseResponse(BaseResponse):
             self._get_param("SplunkDestinationUpdate"),
             self._get_param("HttpEndpointDestinationUpdate"),
             self._get_param("SnowflakeDestinationConfiguration"),
+            self._get_param("IcebergDestinationUpdate"),
         )
         return EmptyResult()
 

--- a/tests/test_firehose/test_firehose_destination_types.py
+++ b/tests/test_firehose/test_firehose_destination_types.py
@@ -122,6 +122,25 @@ def create_snowflake_delivery_stream(client, stream_name):
     )
 
 
+def create_iceberg_delivery_stream(client, stream_name):
+    """Return delivery stream ARN of an Iceberg destination."""
+    return client.create_delivery_stream(
+        DeliveryStreamName=stream_name,
+        DeliveryStreamType="DirectPut",
+        IcebergDestinationConfiguration={
+            "RoleARN": f"arn:aws:iam::{ACCOUNT_ID}:role/firehose_delivery_role",
+            "CatalogConfiguration": {
+                "CatalogARN": f"arn:aws:glue:{TEST_REGION}:{ACCOUNT_ID}:catalog"
+            },
+            "S3BackupMode": "FailedDataOnly",
+            "S3Configuration": {
+                "RoleARN": f"arn:aws:iam::{ACCOUNT_ID}:role/firehose_delivery_role",
+                "BucketARN": "arn:aws:s3:::firehose-test",
+            },
+        },
+    )
+
+
 @mock_aws
 def test_create_snowflake_delivery_stream():
     """Verify fields of a Snowflake delivery stream."""
@@ -163,6 +182,71 @@ def test_create_snowflake_delivery_stream():
         "HasMoreDestinations": False,
         "VersionId": "1",
     }
+
+
+@mock_aws
+def test_create_iceberg_delivery_stream():
+    """Verify fields of an Iceberg delivery stream."""
+    client = boto3.client("firehose", region_name=TEST_REGION)
+
+    stream_name = f"stream_{mock_random.get_random_hex(6)}"
+    response = create_iceberg_delivery_stream(client, stream_name)
+    stream_arn = response["DeliveryStreamARN"]
+
+    response = client.describe_delivery_stream(DeliveryStreamName=stream_name)
+    stream_description = response["DeliveryStreamDescription"]
+
+    # Sure and Freezegun don't play nicely together
+    stream_description.pop("CreateTimestamp")
+    stream_description.pop("LastUpdateTimestamp")
+
+    assert stream_description == {
+        "DeliveryStreamName": stream_name,
+        "DeliveryStreamARN": stream_arn,
+        "DeliveryStreamStatus": "ACTIVE",
+        "DeliveryStreamType": "DirectPut",
+        "Destinations": [
+            {
+                "DestinationId": "destinationId-000000000001",
+                "IcebergDestinationDescription": {
+                    "RoleARN": f"arn:aws:iam::{ACCOUNT_ID}:role/firehose_delivery_role",
+                    "CatalogConfiguration": {
+                        "CatalogARN": f"arn:aws:glue:{TEST_REGION}:{ACCOUNT_ID}:catalog"
+                    },
+                    "S3BackupMode": "FailedDataOnly",
+                    "S3DestinationDescription": {
+                        "RoleARN": f"arn:aws:iam::{ACCOUNT_ID}:role/firehose_delivery_role",
+                        "BucketARN": "arn:aws:s3:::firehose-test",
+                    },
+                },
+            },
+        ],
+        "HasMoreDestinations": False,
+        "VersionId": "1",
+    }
+
+
+@mock_aws
+def test_update_iceberg_delivery_stream():
+    """Verify an Iceberg destination can be updated via UpdateDestination."""
+    client = boto3.client("firehose", region_name=TEST_REGION)
+
+    stream_name = f"stream_{mock_random.get_random_hex(6)}"
+    create_iceberg_delivery_stream(client, stream_name)
+
+    client.update_destination(
+        DeliveryStreamName=stream_name,
+        CurrentDeliveryStreamVersionId="1",
+        DestinationId="destinationId-000000000001",
+        IcebergDestinationUpdate={"S3BackupMode": "AllData"},
+    )
+
+    response = client.describe_delivery_stream(DeliveryStreamName=stream_name)
+    stream_description = response["DeliveryStreamDescription"]
+
+    assert stream_description["VersionId"] == "2"
+    destination = stream_description["Destinations"][0]
+    assert destination["IcebergDestinationDescription"]["S3BackupMode"] == "AllData"
 
 
 @mock_aws


### PR DESCRIPTION
Add support for the Iceberg destination type to Kinesis Data Firehose. `CreateDeliveryStream` now accepts `IcebergDestinationConfiguration` and `UpdateDestination` accepts `IcebergDestinationUpdate`; the config is stored and echoed back by `DescribeDeliveryStream` as `IcebergDestinationDescription` (with the nested `S3Configuration` mapped to `S3DestinationDescription`, matching the AWS API output shape). This reuses the existing generic destination handling already used by the other destination types, so no special-casing was needed.

Validation:
- `pytest tests/test_firehose/` — 31 passed (2 new tests: create+describe of an Iceberg stream, and an UpdateDestination round-trip)
- `ruff check` / `ruff format --check` — clean

Resolves #9546
