### PR TITLE
Transfer: Omit unset optional fields from describe responses

### DIFF
--- a/moto/transfer/types.py
+++ b/moto/transfer/types.py
@@ -6,6 +6,25 @@ from moto.core.common_models import BaseModel
 from moto.moto_api._internal import mock_random
 
 
+def prune_unset(value: Any) -> Any:
+    """Recursively drop unset fields (None / empty dict / empty list).
+
+    AWS Transfer omits optional fields that were never set from its Describe*
+    responses rather than returning them as null, so the serialized model must
+    do the same.
+    """
+    if isinstance(value, dict):
+        pruned = {}
+        for key, val in value.items():
+            cleaned = prune_unset(val)
+            if cleaned is not None and cleaned != {} and cleaned != []:
+                pruned[key] = cleaned
+        return pruned
+    if isinstance(value, list):
+        return [prune_unset(item) for item in value]
+    return value
+
+
 class UserHomeDirectoryType(str, Enum):
     PATH = "PATH"
     LOGICAL = "LOGICAL"
@@ -228,7 +247,7 @@ class Server(BaseModel):
                 "OnPartialUpload": on_partial_upload,
             },
         }
-        return server
+        return prune_unset(server)
 
     def to_short_dict(self) -> dict[str, Any]:
         return {
@@ -307,7 +326,7 @@ class Connector(BaseModel):  # type: ignore[misc]
                     "max_concurrent_connections"
                 ),
             }
-        return connector
+        return prune_unset(connector)
 
     def to_short_dict(self) -> dict[str, str]:
         return {

--- a/tests/test_transfer/test_transfer.py
+++ b/tests/test_transfer/test_transfer.py
@@ -454,3 +454,48 @@ def test_update_connector_not_found(client):
             Url="sftp://example.com",
         )
     assert exc.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+def test_describe_server_omits_unset_optional_fields(client):
+    server_id = client.create_server()["ServerId"]
+
+    described_server = client.describe_server(ServerId=server_id)["Server"]
+
+    # Optional fields that were never set must be omitted, not returned as null.
+    for omitted in [
+        "Certificate",
+        "LoggingRole",
+        "SecurityPolicyName",
+        "HostKeyFingerprint",
+        "PreAuthenticationLoginBanner",
+        "PostAuthenticationLoginBanner",
+        "EndpointDetails",
+        "IdentityProviderDetails",
+        "ProtocolDetails",
+        "S3StorageOptions",
+        "WorkflowDetails",
+    ]:
+        assert omitted not in described_server
+
+    # Fields that are always populated remain present.
+    assert described_server["ServerId"] == server_id
+    assert "Arn" in described_server
+    assert "State" in described_server
+
+
+def test_describe_connector_omits_unset_optional_fields(client):
+    connector_id = client.create_connector(
+        Url="sftp://example.com",
+        AccessRole="arn:aws:iam::123456789012:role/TransferAccessRole",
+    )["ConnectorId"]
+
+    connector = client.describe_connector(ConnectorId=connector_id)["Connector"]
+
+    for omitted in ["LoggingRole", "SecurityPolicyName", "As2Config", "SftpConfig"]:
+        assert omitted not in connector
+
+    assert connector["ConnectorId"] == connector_id
+    assert connector["Url"] == "sftp://example.com"
+    assert (
+        connector["AccessRole"] == "arn:aws:iam::123456789012:role/TransferAccessRole"
+    )


### PR DESCRIPTION
AWS Transfer omits optional fields that were never set from `DescribeServer` / `DescribeConnector` responses, but moto was returning them as `null` (the model `to_dict()` output is serialized verbatim). This adds a small recursive `prune_unset` helper applied in `Server.to_dict()` and `Connector.to_dict()` so unset scalars (e.g. `LoggingRole`, `Certificate`, `SecurityPolicyName`) and empty nested blocks (`EndpointDetails`, `IdentityProviderDetails`, `As2Config`, ...) are dropped, matching the real API.

Validation:
- `pytest tests/test_transfer/` — 18 passed (2 new tests asserting describe_server / describe_connector omit unset optional fields; all 16 existing tests pass unchanged)
- `ruff check` / `ruff format --check` — clean
- `mypy moto/transfer/` — no issues found

Resolves #9901
