### PR TITLE
Add support for 'key' and 'value' filters in autoscaling describe_tags

### DIFF
--- a/moto/autoscaling/models.py
+++ b/moto/autoscaling/models.py
@@ -1558,7 +1558,6 @@ class AutoScalingBackend(BaseBackend):
     def describe_tags(self, filters: List[Dict[str, str]]) -> List[Dict[str, str]]:
         """
         Pagination is not yet implemented.
-        Only the `auto-scaling-group` and `propagate-at-launch` filters are implemented.
         """
         resources = self.autoscaling_groups.values()
         tags = list(itertools.chain(*[r.tags for r in resources]))
@@ -1572,6 +1571,10 @@ class AutoScalingBackend(BaseBackend):
                     for t in tags
                     if t.get("propagate_at_launch", "").lower() in values
                 ]
+            if f["Name"] == "key":
+                tags = [t for t in tags if t["key"] in f["Values"]]
+            if f["Name"] == "value":
+                tags = [t for t in tags if t["value"] in f["Values"]]
         return tags
 
     def enable_metrics_collection(self, group_name: str, metrics: List[str]) -> None:

--- a/tests/test_autoscaling/test_autoscaling_tags.py
+++ b/tests/test_autoscaling/test_autoscaling_tags.py
@@ -234,6 +234,79 @@ def test_describe_tags_filter_by_propgateatlaunch():
 
 
 @mock_autoscaling
+def test_describe_tags_filter_by_key():
+    subnet = setup_networking()["subnet1"]
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    create_asgs(client, subnet)
+
+    # Filter by a single key
+    response = client.describe_tags(
+        Filters=[{"Name": "key", "Values": ["test_key"]}]
+    )
+    assert len(response["Tags"]) == 1
+    assert response["Tags"][0]["Key"] == "test_key"
+
+    # Filter by multiple keys
+    response = client.describe_tags(
+        Filters=[{"Name": "key", "Values": ["test_key", "asg2tag1"]}]
+    )
+    assert len(response["Tags"]) == 2
+    keys = [tag["Key"] for tag in response["Tags"]]
+    assert "test_key" in keys
+    assert "asg2tag1" in keys
+
+
+@mock_autoscaling
+def test_describe_tags_filter_by_value():
+    subnet = setup_networking()["subnet1"]
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    create_asgs(client, subnet)
+
+    # Filter by a single value
+    response = client.describe_tags(
+        Filters=[{"Name": "value", "Values": ["updated_test_value"]}]
+    )
+    assert len(response["Tags"]) == 1
+    assert response["Tags"][0]["Value"] == "updated_test_value"
+
+    # Filter by multiple values
+    response = client.describe_tags(
+        Filters=[{"Name": "value", "Values": ["val", "diff"]}]
+    )
+    assert len(response["Tags"]) == 2
+    values = [tag["Value"] for tag in response["Tags"]]
+    assert "val" in values
+    assert "diff" in values
+
+
+@mock_autoscaling
+def test_describe_tags_filter_by_key_and_value():
+    subnet = setup_networking()["subnet1"]
+    client = boto3.client("autoscaling", region_name="us-east-1")
+    create_asgs(client, subnet)
+
+    # Filter by both key and value
+    response = client.describe_tags(
+        Filters=[
+            {"Name": "key", "Values": ["test_key"]},
+            {"Name": "value", "Values": ["updated_test_value"]},
+        ]
+    )
+    assert len(response["Tags"]) == 1
+    assert response["Tags"][0]["Key"] == "test_key"
+    assert response["Tags"][0]["Value"] == "updated_test_value"
+
+    # Filter by key and non-matching value should return empty
+    response = client.describe_tags(
+        Filters=[
+            {"Name": "key", "Values": ["test_key"]},
+            {"Name": "value", "Values": ["nonexistent"]},
+        ]
+    )
+    assert len(response["Tags"]) == 0
+
+
+@mock_autoscaling
 def test_create_20_tags_auto_scaling_group():
     """test to verify that the tag-members are sorted correctly, and there is no regression for
     https://github.com/getmoto/moto/issues/6033


### PR DESCRIPTION
## Summary
This PR adds support for 'key' and 'value' filters in the autoscaling `describe_tags` API call.

## Changes
- Implemented 'key' filter to filter tags by their key
- Implemented 'value' filter to filter tags by their value
- Both filters support multiple values (OR logic within filter, AND across filters)
- Updated documentation comment in the describe_tags method

## Testing
Added comprehensive tests:
- test_describe_tags_filter_by_key: Tests filtering by single and multiple keys
- test_describe_tags_filter_by_value: Tests filtering by single and multiple values
- test_describe_tags_filter_by_key_and_value: Tests filtering by both key and value together
