### PR TITLE
ECS: support capacityProviderStrategy in RunTask

### DIFF
--- a/moto/ecs/models.py
+++ b/moto/ecs/models.py
@@ -314,6 +314,7 @@ class Task(ManagedState, BaseModel):
         tags: list[dict[str, str]] | None = None,
         networking_configuration: dict[str, Any] | None = None,
         platform_version: str | None = None,
+        capacity_provider_name: str | None = None,
     ):
         # Configure ManagedState
         # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html
@@ -344,6 +345,7 @@ class Task(ManagedState, BaseModel):
         self.started_by = started_by
         self.tags = tags or []
         self.launch_type = launch_type
+        self.capacity_provider_name = capacity_provider_name
         self.platform_version = platform_version
         self.stopped_reason = ""
         self.resource_requirements = resource_requirements
@@ -1247,13 +1249,34 @@ class EC2ContainerServiceBackend(BaseBackend, TaggableResourcesMixin):
         networking_configuration: dict[str, Any] | None = None,
         group: str | None = None,
         platform_version: str | None = None,
+        capacity_provider_strategy: list[dict[str, Any]] | None = None,
     ) -> list[Task]:
         if launch_type and launch_type not in ["EC2", "FARGATE", "EXTERNAL"]:
             raise InvalidParameterException(
                 "launch type should be one of [EC2,FARGATE,EXTERNAL]"
             )
+        if launch_type and capacity_provider_strategy:
+            raise InvalidParameterException(
+                "Specify either Launch Type or Capacity Provider Strategy, but not both."
+            )
 
         cluster = self._get_cluster(cluster_str)
+
+        # When neither a launch type nor an explicit strategy is given, fall back
+        # to the cluster's default capacity provider strategy (matches AWS).
+        if not launch_type and not capacity_provider_strategy:
+            capacity_provider_strategy = cluster.default_capacity_provider_strategy
+
+        capacity_provider_name = None
+        if capacity_provider_strategy:
+            capacity_provider_name = capacity_provider_strategy[0]["capacityProvider"]
+
+        # FARGATE/FARGATE_SPOT are managed providers that need no container instance;
+        # any user-defined capacity provider is backed by an EC2 Auto Scaling group.
+        fargate_capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+        use_fargate = launch_type == "FARGATE" or (
+            capacity_provider_name in fargate_capacity_providers
+        )
 
         task_definition = self.describe_task_definition(task_definition_str)
         # The "group" associated with this task is either the one passed explicitly or derived from "family" of the task definition
@@ -1266,7 +1289,7 @@ class EC2ContainerServiceBackend(BaseBackend, TaggableResourcesMixin):
         if cluster.name not in self.tasks:
             self.tasks[cluster.name] = {}
         tasks = []
-        if launch_type == "FARGATE":
+        if use_fargate:
             for _ in range(count):
                 task = Task(
                     cluster=cluster,
@@ -1281,6 +1304,7 @@ class EC2ContainerServiceBackend(BaseBackend, TaggableResourcesMixin):
                     launch_type=launch_type or "",
                     networking_configuration=networking_configuration,
                     platform_version=platform_version,
+                    capacity_provider_name=capacity_provider_name,
                 )
                 tasks.append(task)
                 self.tasks[cluster.name][task.task_arn] = task
@@ -1319,6 +1343,7 @@ class EC2ContainerServiceBackend(BaseBackend, TaggableResourcesMixin):
                         tags=tags or [],
                         launch_type=launch_type or "",
                         networking_configuration=networking_configuration,
+                        capacity_provider_name=capacity_provider_name,
                     )
                     self.update_container_instance_resources(
                         container_instance, resource_requirements

--- a/moto/ecs/responses.py
+++ b/moto/ecs/responses.py
@@ -211,6 +211,7 @@ class EC2ContainerServiceResponse(BaseResponse):
         network_configuration = self._get_param("networkConfiguration")
         group = self._get_param("group")
         platform_version = self._get_param("platformVersion")
+        capacity_provider_strategy = self._get_param("capacityProviderStrategy")
         tasks = self.ecs_backend.run_task(
             cluster_str,
             task_definition_str,
@@ -222,6 +223,7 @@ class EC2ContainerServiceResponse(BaseResponse):
             network_configuration,
             group,
             platform_version,
+            capacity_provider_strategy,
         )
         return ActionResult({"tasks": tasks, "failures": []})
 

--- a/tests/test_ecs/test_ecs.py
+++ b/tests/test_ecs/test_ecs.py
@@ -2107,6 +2107,143 @@ def test_run_task():
 
 
 @mock_aws
+def test_run_task_with_capacity_provider_strategy_fargate():
+    client = boto3.client("ecs", region_name=ECS_REGION)
+    client.create_cluster(clusterName="test_ecs_cluster")
+    client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+            }
+        ],
+    )
+
+    response = client.run_task(
+        cluster="test_ecs_cluster",
+        taskDefinition="test_ecs_task",
+        count=2,
+        capacityProviderStrategy=[{"capacityProvider": "FARGATE", "weight": 1}],
+    )
+
+    assert len(response["tasks"]) == 2
+    task = response["tasks"][0]
+    # FARGATE-backed capacity providers need no container instance
+    assert task.get("containerInstanceArn") is None
+    assert task["capacityProviderName"] == "FARGATE"
+    # When a capacity provider strategy is used, launchType is not set
+    assert task.get("launchType", "") == ""
+
+
+@mock_aws
+def test_run_task_with_capacity_provider_strategy_ec2():
+    client = boto3.client("ecs", region_name=ECS_REGION)
+    ec2 = boto3.resource("ec2", region_name=ECS_REGION)
+    client.create_cluster(clusterName="test_ecs_cluster")
+    client.create_capacity_provider(
+        name="my_provider",
+        autoScalingGroupProvider={"autoScalingGroupArn": "asg:arn"},
+    )
+
+    test_instance = ec2.create_instances(
+        ImageId=EXAMPLE_AMI_ID, MinCount=1, MaxCount=1
+    )[0]
+    instance_id_document = json.dumps(
+        ec2_utils.generate_instance_identity_document(test_instance)
+    )
+    client.register_container_instance(
+        cluster="test_ecs_cluster", instanceIdentityDocument=instance_id_document
+    )
+    client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+            }
+        ],
+    )
+
+    response = client.run_task(
+        cluster="test_ecs_cluster",
+        taskDefinition="test_ecs_task",
+        count=1,
+        capacityProviderStrategy=[{"capacityProvider": "my_provider", "weight": 1}],
+    )
+
+    assert len(response["tasks"]) == 1
+    task = response["tasks"][0]
+    # User-defined capacity providers are EC2-backed and placed on a container instance
+    assert (
+        f"arn:aws:ecs:us-east-1:{ACCOUNT_ID}:container-instance/"
+        in task["containerInstanceArn"]
+    )
+    assert task["capacityProviderName"] == "my_provider"
+
+
+@mock_aws
+def test_run_task_with_launch_type_and_capacity_provider_strategy_fails():
+    client = boto3.client("ecs", region_name=ECS_REGION)
+    client.create_cluster(clusterName="test_ecs_cluster")
+    client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+            }
+        ],
+    )
+
+    with pytest.raises(ClientError) as exc:
+        client.run_task(
+            cluster="test_ecs_cluster",
+            taskDefinition="test_ecs_task",
+            launchType="FARGATE",
+            capacityProviderStrategy=[{"capacityProvider": "FARGATE", "weight": 1}],
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "InvalidParameterException"
+
+
+@mock_aws
+def test_run_task_uses_cluster_default_capacity_provider_strategy():
+    client = boto3.client("ecs", region_name=ECS_REGION)
+    client.create_cluster(
+        clusterName="test_ecs_cluster",
+        capacityProviders=["FARGATE"],
+        defaultCapacityProviderStrategy=[{"capacityProvider": "FARGATE", "weight": 1}],
+    )
+    client.register_task_definition(
+        family="test_ecs_task",
+        containerDefinitions=[
+            {
+                "name": "hello_world",
+                "image": "docker/hello-world:latest",
+                "cpu": 1024,
+                "memory": 400,
+            }
+        ],
+    )
+
+    # No launchType and no container instances: without the default strategy this
+    # would raise "No instances found"; instead it should place on FARGATE.
+    response = client.run_task(
+        cluster="test_ecs_cluster", taskDefinition="test_ecs_task", count=1
+    )
+
+    assert len(response["tasks"]) == 1
+    assert response["tasks"][0]["capacityProviderName"] == "FARGATE"
+
+
+@mock_aws
 def test_wait_tasks_stopped():
     if settings.TEST_SERVER_MODE:
         raise SkipTest("Can't set transition directly in ServerMode")


### PR DESCRIPTION
## Summary

`ECS.RunTask` did not accept `capacityProviderStrategy`. The parameter was silently dropped, and because no `launchType` was supplied the backend fell through to EC2 placement and raised `No instances found in cluster ...`. Fixes #8722.

## Changes

- `responses.py`: parse `capacityProviderStrategy` and pass it to the backend.
- `models.py`:
  - Accept `capacity_provider_strategy` in `run_task`.
  - Raise `InvalidParameterException` when both `launchType` and `capacityProviderStrategy` are given (matches AWS).
  - Fall back to the cluster's `defaultCapacityProviderStrategy` when neither is supplied.
  - Route `FARGATE`/`FARGATE_SPOT` providers to Fargate placement and user-defined (ASG-backed) providers to EC2 container instances.
  - Record `capacityProviderName` on the task so it is returned in the response.

## Tests

Added to `tests/test_ecs/test_ecs.py`:
- `test_run_task_with_capacity_provider_strategy_fargate`
- `test_run_task_with_capacity_provider_strategy_ec2`
- `test_run_task_with_launch_type_and_capacity_provider_strategy_fails`
- `test_run_task_uses_cluster_default_capacity_provider_strategy`

All ECS tests pass locally (the only failures are pre-existing CloudFormation tests that require the optional `openapi_spec_validator` dependency). `ruff check` is clean.