### PR TITLE
Fix SES verify_email_identity and verify_email_address to be idempotent

### DIFF
--- a/moto/ses/models.py
+++ b/moto/ses/models.py
@@ -132,11 +132,13 @@ class SESBackend(BaseBackend):
 
     def verify_email_identity(self, address):
         _, address = parseaddr(address)
-        self.addresses.append(address)
+        if address not in self.addresses:
+            self.addresses.append(address)
 
     def verify_email_address(self, address):
         _, address = parseaddr(address)
-        self.email_addresses.append(address)
+        if address not in self.email_addresses:
+            self.email_addresses.append(address)
 
     def verify_domain(self, domain):
         if domain.lower() not in self.domains:


### PR DESCRIPTION
## Issue
Using `verify_email_identity` on an existing identity with boto3 allows to re-send the verification email, without creating a duplicate identity. However, in moto it duplicates the identity.

## Example
```python
import boto3
from moto import mock_ses

@mock_ses
def verify():
    region = "us-east-2"
    client = boto3.client("ses", region_name=region)
    addr = "test@example.com"
    _ = client.verify_email_identity(EmailAddress=addr)
    _ = client.verify_email_identity(EmailAddress=addr)

    identities = client.list_identities()
    return identities["Identities"]

print(verify())
# Before fix: ["test@example.com", "test@example.com"]
# After fix: ["test@example.com"]
```

## Root Cause
There was no check before adding the address to the identities in `verify_email_identity` and `verify_email_address` methods.

## Fix
Added idempotency checks to both `verify_email_identity` and `verify_email_address` methods to prevent duplicate entries, making them consistent with `verify_domain` behavior.