### PR TITLE
Lambda: fix test parameter input

### DIFF
--- a/tests/test_awslambda/test_lambda_eventsourcemapping.py
+++ b/tests/test_awslambda/test_lambda_eventsourcemapping.py
@@ -522,7 +522,7 @@ def test_get_event_source_mapping():
     assert mapping["FunctionArn"] == func["FunctionArn"]
 
     with pytest.raises(ClientError) as exc:
-        conn.get_event_source_mapping(UUID="1")
+        conn.get_event_source_mapping(UUID=str(uuid.uuid4()))
     err = exc.value.response["Error"]
     assert err["Code"] == "ResourceNotFoundException"
     assert err["Message"] == "The resource you requested does not exist."


### PR DESCRIPTION
Latest version of Botocore added min/max constraints for UUIDString:

```json
"UUIDString":{
      "type":"string",
      "max":36,
      "min":36
    }
```