### PR TITLE
Fix StepFunctions parser: startExecution parameter/response casing (Pascal to boto)

### DIFF
--- a/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sfn.py
+++ b/moto/stepfunctions/parser/asl/component/state/exec/state_task/service/state_task_service_sfn.py
@@ -2,7 +2,9 @@ import json
 from collections.abc import Callable
 from typing import Any, Final
 
+import botocore.session
 from botocore.exceptions import ClientError
+from botocore.model import OperationModel
 
 from moto.stepfunctions.parser.api import (
     DescribeExecutionOutput,
@@ -47,6 +49,19 @@ _SUPPORTED_INTEGRATION_PATTERNS: Final[set[ResourceCondition]] = {
 _SUPPORTED_API_PARAM_BINDINGS: Final[dict[str, set[str]]] = {
     "startexecution": {"Input", "Name", "StateMachineArn"}
 }
+# Unlike most other service integrations (e.g. SNS, SQS, DynamoDB) whose boto3 API
+# members are already Pascal-cased and therefore pass through the ASL Parameters
+# unchanged, the Step Functions API itself uses lowerCamel member names
+# (stateMachineArn, name, input, traceHeader). The ASL Parameters/Task output are
+# always Pascal-cased, so the request/response of the boto3 `stepfunctions` calls
+# made on behalf of this service integration need to be normalised explicitly.
+_STEPFUNCTIONS_SERVICE_MODEL: Final = botocore.session.get_session().get_service_model(
+    "stepfunctions"
+)
+_BOTO_OPERATION_NAMES: Final[dict[str, str]] = {
+    "start_execution": "StartExecution",
+    "describe_execution": "DescribeExecution",
+}
 
 
 class StateTaskServiceSfn(StateTaskServiceCallback):
@@ -89,25 +104,53 @@ class StateTaskServiceSfn(StateTaskServiceCallback):
             )
         return super()._from_error(env=env, ex=ex)
 
+    @staticmethod
+    def _get_operation_model(action_name: str) -> OperationModel | None:
+        operation_name = _BOTO_OPERATION_NAMES.get(action_name)
+        if operation_name is None:
+            return None
+        return _STEPFUNCTIONS_SERVICE_MODEL.operation_model(operation_name)
+
     def _normalise_parameters(
         self,
         parameters: dict,
         boto_service_name: str | None = None,
         service_action_name: str | None = None,
     ) -> None:
-        if service_action_name is None:
-            if self._get_boto_service_action() == "start_execution":
-                optional_input = parameters.get("Input")
-                if not isinstance(optional_input, str):
-                    # AWS Sfn's documentation states:
-                    # If you don't include any JSON input data, you still must include the two braces.
-                    if optional_input is None:
-                        optional_input = {}
-                    parameters["Input"] = to_json_str(
-                        optional_input, separators=(",", ":")
-                    )
+        resolved_action_name = service_action_name or self._get_boto_service_action()
+        if resolved_action_name == "start_execution":
+            optional_input = parameters.get("Input")
+            if not isinstance(optional_input, str):
+                # AWS Sfn's documentation states:
+                # If you don't include any JSON input data, you still must include the two braces.
+                if optional_input is None:
+                    optional_input = {}
+                parameters["Input"] = to_json_str(optional_input, separators=(",", ":"))
+        # Convert the ASL (Pascal-cased) parameter keys to the boto3 `stepfunctions`
+        # client's own (lowerCamel) member names, e.g. StateMachineArn -> stateMachineArn.
+        operation_model = self._get_operation_model(resolved_action_name)
+        if operation_model is not None:
+            self._to_boto_request(parameters, operation_model.input_shape)
         super()._normalise_parameters(
             parameters=parameters,
+            boto_service_name=boto_service_name,
+            service_action_name=service_action_name,
+        )
+
+    def _normalise_response(
+        self,
+        response: Any,
+        boto_service_name: str | None = None,
+        service_action_name: str | None = None,
+    ) -> None:
+        resolved_action_name = service_action_name or self._get_boto_service_action()
+        # Convert the boto3 `stepfunctions` client's (lowerCamel) response member
+        # names back to the ASL (Pascal-cased) names, e.g. executionArn -> ExecutionArn.
+        operation_model = self._get_operation_model(resolved_action_name)
+        if operation_model is not None:
+            self._from_boto_response(response, operation_model.output_shape)
+        super()._normalise_response(
+            response=response,
             boto_service_name=boto_service_name,
             service_action_name=service_action_name,
         )

--- a/tests/test_stepfunctions/parser/test_stepfunctions_sfn_integration.py
+++ b/tests/test_stepfunctions/parser/test_stepfunctions_sfn_integration.py
@@ -1,0 +1,107 @@
+from datetime import datetime, timezone
+
+from moto.stepfunctions.parser.asl.component.state.exec.state_task.service.resource import (
+    ResourceARN,
+    ServiceResource,
+)
+from moto.stepfunctions.parser.asl.component.state.exec.state_task.service.state_task_service_sfn import (
+    StateTaskServiceSfn,
+)
+
+CHILD_ARN = "arn:aws:states:us-east-1:123456789012:stateMachine:child"
+EXECUTION_ARN = "arn:aws:states:us-east-1:123456789012:execution:child:run1"
+
+
+def _sfn_service(resource_arn: str) -> StateTaskServiceSfn:
+    service = StateTaskServiceSfn()
+    service.resource = ServiceResource(ResourceARN.from_arn(resource_arn))
+    return service
+
+
+def test_normalise_parameters_converts_pascal_case_to_boto_casing():
+    # Regression test for https://github.com/getmoto/moto/issues/10076
+    #
+    # The `arn:aws:states:::states:startExecution(.sync|.sync:2)` service
+    # integration's ASL Parameters use the (Pascal-cased) Step Functions API
+    # member names (StateMachineArn, Input, Name, TraceHeader), but boto3's
+    # `start_execution` expects its own (lowerCamel) member names
+    # (stateMachineArn, input, name, traceHeader). Without normalisation,
+    # botocore's serializer raises `KeyError: 'Input'`.
+    service = _sfn_service("arn:aws:states:::states:startExecution.sync:2")
+    parameters = {
+        "StateMachineArn": CHILD_ARN,
+        "Input": {"foo": "bar"},
+        "Name": "child-exec",
+        "TraceHeader": "trace-1",
+    }
+
+    service._normalise_parameters(parameters)
+
+    assert parameters == {
+        "stateMachineArn": CHILD_ARN,
+        "input": '{"foo":"bar"}',
+        "name": "child-exec",
+        "traceHeader": "trace-1",
+    }
+
+
+def test_normalise_parameters_plain_start_execution():
+    # The plain (non-.sync) `states:startExecution` integration goes through
+    # the same normalisation.
+    service = _sfn_service("arn:aws:states:::states:startExecution")
+    parameters = {"StateMachineArn": CHILD_ARN, "Name": "child-exec"}
+
+    service._normalise_parameters(parameters)
+
+    assert parameters == {
+        "stateMachineArn": CHILD_ARN,
+        "name": "child-exec",
+        # "Input" defaults to "{}" even when not supplied.
+        "input": "{}",
+    }
+
+
+def test_normalise_response_converts_boto_casing_for_start_execution_output():
+    # The immediate (non-.sync) task output of `states:startExecution` is the
+    # boto3 StartExecution response, whose (lowerCamel) member names must be
+    # converted back to the ASL/SFN (Pascal-cased) names.
+    service = _sfn_service("arn:aws:states:::states:startExecution")
+    response = {
+        "executionArn": EXECUTION_ARN,
+        "startDate": datetime(2024, 1, 1, tzinfo=timezone.utc),
+    }
+
+    service._normalise_response(response)
+
+    assert set(response.keys()) == {"ExecutionArn", "StartDate"}
+    assert response["ExecutionArn"] == EXECUTION_ARN
+
+
+def test_normalise_response_converts_boto_casing_for_describe_execution_output():
+    # The `.sync`/`.sync:2` task output is built from a DescribeExecution
+    # response, whose (lowerCamel) member names must likewise be converted
+    # back to the ASL/SFN (Pascal-cased) names (this is the "response" half
+    # of the same regression: `submission_output["ExecutionArn"]` and the
+    # `.sync:2` resolvers only work if this normalisation has run).
+    service = _sfn_service("arn:aws:states:::states:startExecution.sync:2")
+    response = {
+        "executionArn": EXECUTION_ARN,
+        "stateMachineArn": CHILD_ARN,
+        "name": "run1",
+        "status": "SUCCEEDED",
+        "startDate": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "stopDate": datetime(2024, 1, 1, tzinfo=timezone.utc),
+        "input": {"foo": "bar"},
+        "output": {"child": "done"},
+    }
+
+    service._normalise_response(response, service_action_name="describe_execution")
+
+    assert response["ExecutionArn"] == EXECUTION_ARN
+    assert response["StateMachineArn"] == CHILD_ARN
+    assert response["Name"] == "run1"
+    assert response["Status"] == "SUCCEEDED"
+    assert response["Input"] == {"foo": "bar"}
+    assert response["Output"] == {"child": "done"}
+    assert "executionArn" not in response
+    assert "stateMachineArn" not in response


### PR DESCRIPTION
Fixes #10076

The `arn:aws:states:::states:startExecution(.sync|.sync:2)` service integration (a state machine starting another state machine) failed under the parser backend with `States.Runtime` / `KeyError: 'Input'`.

Root cause: the ASL Parameters use the Pascal-cased Step Functions API member names (`StateMachineArn`, `Input`, `Name`, `TraceHeader`), but these were passed straight to boto3's `start_execution`, whose members are lowerCamel (`stateMachineArn`, `input`, `name`, `traceHeader`). Unlike sibling service integrations (SNS, SQS, DynamoDB) whose boto3 members are already Pascal-cased and pass through the ASL Parameters unchanged, Step Functions' own API uses lowerCamel, so this integration needs explicit normalisation — the generic `_to_boto_request`/`_from_boto_response` helpers on the base `StateTaskService` existed but were never invoked for this path.

This PR wires up those existing helpers in `StateTaskServiceSfn`, looking up the real botocore service model shapes for `StartExecution`/`DescribeExecution`, to convert:
- request parameters: ASL PascalCase -> boto3 lowerCamel, before the call
- response: boto3 lowerCamel -> ASL PascalCase, for both the immediate `start_execution` output and the `.sync`/`.sync:2` `describe_execution` output used by the sync resolvers

This mirrors the sibling service-integration casing pattern (e.g. SQS's `_normalise_response` already renames `Md5OfMessageBody` -> `MD5OfMessageBody`), extended here to cover the full request/response shape since Step Functions' own casing differs across every member, not just one.

Test plan:
- Added `tests/test_stepfunctions/parser/test_stepfunctions_sfn_integration.py`: regression tests on `_normalise_parameters`/`_normalise_response` (request casing for `.sync:2` and plain `startExecution`, response casing for `start_execution` and `describe_execution` outputs), verified failing on main and passing with this change.
- Ran `tests/test_stepfunctions/parser` (excluding docker-requiring tests): no new failures introduced.
- A full end-to-end parent->child `.sync:2` test currently cannot reach SUCCEEDED regardless of this fix because of the separate deepcopy/RLock bug tracked in #10077 (with this fix, the failure changes from `KeyError: 'Input'` to that unrelated pickle error), so the committed regression tests target the normalisation layer directly.
