### PR TITLE
MQ: Add empty describe_shared_resources() for TF compatibility

### DIFF
--- a/moto/mq/responses.py
+++ b/moto/mq/responses.py
@@ -210,3 +210,6 @@ class MQResponse(BaseResponse):
         broker_id = self.path.split("/")[-2]
         self.mq_backend.reboot_broker(broker_id=broker_id)
         return EmptyResult()
+
+    def describe_shared_resources(self) -> ActionResult:
+        return ActionResult(result={"SharedResources": []})

--- a/moto/mq/urls.py
+++ b/moto/mq/urls.py
@@ -9,6 +9,7 @@ url_bases = [
 
 url_paths = {
     "{0}/v1/brokers/(?P<broker_id>[^/]+)$": MQResponse.dispatch,
+    "{0}/v1/brokers/(?P<broker_id>[^/]+)/shared-resources$": MQResponse.dispatch,
     "{0}/v1/brokers/(?P<broker_id>[^/]+)/reboot$": MQResponse.dispatch,
     "{0}/v1/brokers/(?P<broker_id>[^/]+)/users$": MQResponse.dispatch,
     "{0}/v1/brokers/(?P<broker_id>[^/]+)/users/(?P<user_name>[^/]+)$": MQResponse.dispatch,

--- a/tests/test_mq/test_mq.py
+++ b/tests/test_mq/test_mq.py
@@ -426,5 +426,11 @@ def test_reboot_broker():
     )["BrokerId"]
     client.reboot_broker(BrokerId=broker_id)
 
-    # Noop - nothing to assert or verify
-    pass
+
+@mock_aws
+def test_describe_shared_resources():
+    client = boto3.client("mq", region_name="ap-southeast-1")
+
+    # No-OP at the moment - no validation, always returns an empty list
+    resp = client.describe_shared_resources(BrokerId="sth")
+    assert resp["SharedResources"] == []


### PR DESCRIPTION
A recent TF upgrade started making requests to `describe_shared_resources`, causing the pipeline to fail because this method wasn't implemented.

This PR introduces a no-op version of this method - it only returns an empty list for now, just to get the TF tests to pass.