### PR TITLE
Logs: Update InvalidParam error message to bring back parity with AWS

### DIFF
--- a/moto/logs/models.py
+++ b/moto/logs/models.py
@@ -1577,7 +1577,7 @@ class LogsBackend(BaseBackend, TaggableResourcesMixin):
         elif log_group_id:
             if not re.fullmatch(r"[\w#+=/:,.@-]*", log_group_id):
                 raise InvalidParameterException(
-                    msg=f"1 validation error detected: Value '{log_group_id}' at 'logGroupIdentifier' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w#+=/:,.@-]*"
+                    msg="1 validation error detected: Value at 'logGroupIdentifier' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w#+=/:,.@-]*"
                 )
             for log_group in self.groups.values():
                 if log_group.arn == log_group_id:

--- a/tests/test_logs/test_logs.py
+++ b/tests/test_logs/test_logs.py
@@ -661,7 +661,7 @@ def test_arn_formats_log_group_and_stream(account_id, log_group_name):
     assert err["Code"] == "InvalidParameterException"
     assert (
         err["Message"]
-        == f"1 validation error detected: Value '{group['arn']}' at 'logGroupIdentifier' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w#+=/:,.@-]*"
+        == "1 validation error detected: Value at 'logGroupIdentifier' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w#+=/:,.@-]*"
     )
 
 
@@ -691,7 +691,7 @@ def test_get_log_events_using_arn(account_id, log_group_name):
     assert err["Code"] == "InvalidParameterException"
     assert (
         err["Message"]
-        == f"1 validation error detected: Value '{group['arn']}' at 'logGroupIdentifier' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w#+=/:,.@-]*"
+        == "1 validation error detected: Value at 'logGroupIdentifier' failed to satisfy constraint: Member must satisfy regular expression pattern: [\\w#+=/:,.@-]*"
     )
 
 


### PR DESCRIPTION
Looks like AWS changed the actual error message when providing an invalid `logGroupIdentifier`, so our AWS-validated tests started failing. With this change, the tests should pass again (verified locally)