### PR TITLE
Complete the sfn versioning API

### DIFF
--- a/moto/stepfunctions/exceptions.py
+++ b/moto/stepfunctions/exceptions.py
@@ -31,6 +31,11 @@ class StateMachineDoesNotExist(AWSError):
     STATUS = 400
 
 
+class ConflictException(AWSError):
+    TYPE = "ConflictException"
+    STATUS = 400
+
+
 class InvalidToken(AWSError):
     TYPE = "InvalidToken"
     STATUS = 400

--- a/moto/stepfunctions/models.py
+++ b/moto/stepfunctions/models.py
@@ -20,6 +20,7 @@ from moto.utilities.utils import ARN_PARTITION_REGEX, get_partition
 from .exceptions import (
     ActivityAlreadyExists,
     ActivityDoesNotExist,
+    ConflictException,
     ExecutionAlreadyExists,
     ExecutionDoesNotExist,
     InvalidArn,
@@ -127,11 +128,20 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
             loggingConfiguration=loggingConfiguration,
             tracingConfiguration=tracingConfiguration,
         )
-        self.latest_version_number = 0
         self.versions: dict[int, StateMachineVersion] = {}
         self.aliases: dict[str, StateMachineAlias] = {}
-        self.latest_version: StateMachineVersion | None = None
         self.backend = backend
+
+    @property
+    def latest_version(self) -> StateMachineVersion | None:
+        if not self.versions:
+            return None
+        return max(self.versions.values(), key=lambda item: item.version)
+
+    @property
+    def latest_version_number(self) -> int:
+        latest_version = self.latest_version
+        return latest_version.version if latest_version else 0
 
     def publish(self, description: str | None) -> None:
         new_version_number = self.latest_version_number + 1
@@ -139,8 +149,6 @@ class StateMachine(StateMachineInstance, CloudFormationModel):
             source=self, version=new_version_number, description=description
         )
         self.versions[new_version_number] = new_version
-        self.latest_version = new_version
-        self.latest_version_number = new_version_number
 
     def start_execution(
         self,
@@ -687,20 +695,30 @@ class StepFunctionBackend(BaseBackend, TaggableResourcesMixin):
         sm.aliases[name] = alias
         return alias
 
+    def _get_state_machine(self, arn: str) -> StateMachine | None:
+        return next((x for x in self.state_machines if x.arn == arn), None)
+
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_state_machines(self) -> list[StateMachine]:
         return sorted(self.state_machines, key=lambda x: x.creation_date)
 
     @paginate(pagination_model=PAGINATION_MODEL)
     def list_state_machine_aliases(self, arn: str) -> list[StateMachineAlias]:
-        sm = next((x for x in self.state_machines if x.arn == arn), None)
+        sm = self._get_state_machine(arn)
         if not sm:
             raise StateMachineDoesNotExist(f"State Machine Does Not Exist: '{arn}'")
         return sorted(sm.aliases.values(), key=lambda x: x.creation_date)
 
+    @paginate(pagination_model=PAGINATION_MODEL)
+    def list_state_machine_versions(self, arn: str) -> list[StateMachineVersion]:
+        sm = self._get_state_machine(arn)
+        if not sm:
+            raise StateMachineDoesNotExist(f"State Machine Does Not Exist: '{arn}'")
+        return sorted(sm.versions.values(), key=lambda x: x.creation_date, reverse=True)
+
     def describe_state_machine(self, arn: str) -> StateMachine:
         self._validate_machine_arn(arn)
-        sm = next((x for x in self.state_machines if x.arn == arn), None)
+        sm = self._get_state_machine(arn)
         if not sm:
             if (
                 (arn_parts := arn.split(":"))
@@ -709,9 +727,7 @@ class StepFunctionBackend(BaseBackend, TaggableResourcesMixin):
             ):
                 # we might have a versioned arn, ending in :stateMachine:name:version_nr
                 source_arn = ":".join(arn_parts[:-1])
-                source_sm = next(
-                    (x for x in self.state_machines if x.arn == source_arn), None
-                )
+                source_sm = self._get_state_machine(source_arn)
                 if source_sm:
                     sm = source_sm.versions.get(int(arn_parts[-1]))  # type: ignore[assignment]
         if not sm:
@@ -726,7 +742,7 @@ class StepFunctionBackend(BaseBackend, TaggableResourcesMixin):
 
         self._validate_machine_arn(state_machine_arn)
 
-        sm = next((x for x in self.state_machines if x.arn == state_machine_arn), None)
+        sm = self._get_state_machine(state_machine_arn)
         if not sm:
             raise StateMachineDoesNotExist(
                 f"State Machine Does Not Exist: '{state_machine_arn}'"
@@ -740,7 +756,7 @@ class StepFunctionBackend(BaseBackend, TaggableResourcesMixin):
 
     def delete_state_machine(self, arn: str) -> None:
         self._validate_machine_arn(arn)
-        sm = next((x for x in self.state_machines if x.arn == arn), None)
+        sm = self._get_state_machine(arn)
         if sm:
             self.state_machines.remove(sm)
 
@@ -751,7 +767,7 @@ class StepFunctionBackend(BaseBackend, TaggableResourcesMixin):
 
         self._validate_machine_arn(state_machine_arn)
 
-        sm = next((x for x in self.state_machines if x.arn == state_machine_arn), None)
+        sm = self._get_state_machine(state_machine_arn)
         if not sm:
             raise StateMachineDoesNotExist(
                 f"State Machine Does Not Exist: '{state_machine_arn}'"
@@ -761,6 +777,56 @@ class StepFunctionBackend(BaseBackend, TaggableResourcesMixin):
             raise ResourceNotFound(f"State Machine Alias Does Not Exist: '{arn}'")
 
         del sm.aliases[alias_name]
+
+    def delete_state_machine_version(self, arn: str) -> None:
+        version = None
+        state_machine = None
+        version_number = None
+
+        for sm in self.state_machines:
+            for current_version_number, current_version in sm.versions.items():
+                if current_version.arn == arn:
+                    state_machine = sm
+                    version = current_version
+                    version_number = current_version_number
+                    break
+            if version is not None:
+                break
+
+        if version is None or state_machine is None or version_number is None:
+            return
+
+        referencing_aliases = [
+            alias.name
+            for alias in state_machine.aliases.values()
+            if any(
+                routing["stateMachineVersionArn"] == arn
+                for routing in alias.routing_configuration
+            )
+        ]
+        if referencing_aliases:
+            alias_names = ", ".join(referencing_aliases)
+            raise ConflictException(
+                "Version to be deleted must not be referenced by an alias. "
+                f"Current list of aliases referencing this version: [{alias_names}]"
+            )
+
+        del state_machine.versions[version_number]
+
+    def publish_state_machine_version(
+        self,
+        arn: str,
+        description: str | None = None,
+    ) -> StateMachineVersion:
+        state_machine = self.describe_state_machine(arn)
+        if not isinstance(state_machine, StateMachine):
+            raise StateMachineDoesNotExist(f"State Machine Does Not Exist: '{arn}'")
+
+        state_machine.publish(description=description)
+        latest_version = state_machine.latest_version
+        if latest_version is None:
+            raise StateMachineDoesNotExist(f"State Machine Does Not Exist: '{arn}'")
+        return latest_version
 
     def update_state_machine(
         self,

--- a/moto/stepfunctions/responses.py
+++ b/moto/stepfunctions/responses.py
@@ -117,6 +117,27 @@ class StepFunctionResponse(BaseResponse):
         }
         return ActionResult(response)
 
+    def list_state_machine_versions(self) -> ActionResult:
+        state_machine_arn = self._get_param("stateMachineArn")
+        max_results = self._get_int_param("maxResults")
+        next_token = self._get_param("nextToken")
+        results, next_token = self.stepfunction_backend.list_state_machine_versions(
+            arn=state_machine_arn, max_results=max_results, next_token=next_token
+        )
+        state_machine_versions = [
+            {
+                "creationDate": state_machine_version.creation_date,
+                "stateMachineVersionArn": state_machine_version.arn,
+            }
+            for state_machine_version in results
+        ]
+
+        response = {
+            "stateMachineVersions": state_machine_versions,
+            "nextToken": next_token,
+        }
+        return ActionResult(response)
+
     def describe_state_machine(self) -> ActionResult:
         arn = self._get_param("stateMachineArn")
         return self._describe_state_machine(arn)
@@ -164,6 +185,24 @@ class StepFunctionResponse(BaseResponse):
         arn = self._get_param("stateMachineAliasArn")
         self.stepfunction_backend.delete_state_machine_alias(arn)
         return EmptyResult()
+
+    def delete_state_machine_version(self) -> ActionResult:
+        arn = self._get_param("stateMachineVersionArn")
+        self.stepfunction_backend.delete_state_machine_version(arn)
+        return EmptyResult()
+
+    def publish_state_machine_version(self) -> ActionResult:
+        arn = self._get_param("stateMachineArn")
+        description = self._get_param("description")
+        state_machine_version = self.stepfunction_backend.publish_state_machine_version(
+            arn=arn,
+            description=description,
+        )
+        response = {
+            "creationDate": state_machine_version.creation_date,
+            "stateMachineVersionArn": state_machine_version.arn,
+        }
+        return ActionResult(response)
 
     def update_state_machine(self) -> ActionResult:
         arn = self._get_param("stateMachineArn")

--- a/moto/stepfunctions/utils.py
+++ b/moto/stepfunctions/utils.py
@@ -17,6 +17,12 @@ PAGINATION_MODEL = {
         "limit_default": 100,
         "unique_attribute": ["creation_date", "arn"],
     },
+    "list_state_machine_versions": {
+        "input_token": "next_token",
+        "limit_key": "max_results",
+        "limit_default": 100,
+        "unique_attribute": ["creation_date", "arn"],
+    },
     "list_activities": {
         "input_token": "next_token",
         "limit_key": "max_results",

--- a/tests/test_stepfunctions/test_stepfunctions_versions.py
+++ b/tests/test_stepfunctions/test_stepfunctions_versions.py
@@ -1,4 +1,4 @@
-import json
+from datetime import datetime
 from uuid import uuid4
 
 import boto3
@@ -6,27 +6,25 @@ import pytest
 from botocore.exceptions import ClientError
 
 from moto import mock_aws
+from moto.core import DEFAULT_ACCOUNT_ID as ACCOUNT_ID
 from tests import aws_verified
-from tests.test_stepfunctions.parser import sfn_role_policy
-from tests.test_stepfunctions.test_stepfunctions import simple_definition
+from tests.test_stepfunctions.test_stepfunctions import (
+    _get_default_role,
+    simple_definition,
+)
 
 
 @pytest.mark.parametrize("use_parser", [True, False], ids=["use_parser", "use_mock"])
 def test_describe_state_machine_using_version_arn(use_parser):
     with mock_aws(config={"stepfunctions": {"execute_state_machine": use_parser}}):
-        iam = boto3.client("iam", region_name="us-east-1")
-        role_name = f"sfn_role_{str(uuid4())[0:6]}"
-        sfn_role = iam.create_role(
-            RoleName=role_name,
-            AssumeRolePolicyDocument=json.dumps(sfn_role_policy),
-            Path="/",
-        )["Role"]["Arn"]
-
         client = boto3.client("stepfunctions", region_name="us-east-1")
 
         name = f"sfn_name_{str(uuid4())[0:6]}"
         response = client.create_state_machine(
-            name=name, definition=simple_definition, roleArn=sfn_role, publish=True
+            name=name,
+            definition=simple_definition,
+            roleArn=_get_default_role(),
+            publish=True,
         )
         arn = response["stateMachineArn"]
         version_arn1 = response["stateMachineVersionArn"]
@@ -58,14 +56,6 @@ def test_describe_state_machine_using_version_arn(use_parser):
 @aws_verified
 @pytest.mark.aws_verified
 def test_create_state_machine_with_version_description():
-    iam = boto3.client("iam", region_name="us-east-1")
-    role_name = f"sfn_role_{str(uuid4())[0:6]}"
-    sfn_role = iam.create_role(
-        RoleName=role_name,
-        AssumeRolePolicyDocument=json.dumps(sfn_role_policy),
-        Path="/",
-    )["Role"]["Arn"]
-
     client = boto3.client("stepfunctions", region_name="us-east-1")
 
     try:
@@ -74,7 +64,7 @@ def test_create_state_machine_with_version_description():
         response = client.create_state_machine(
             name=name,
             definition=simple_definition,
-            roleArn=sfn_role,
+            roleArn=_get_default_role(),
             versionDescription="first version",
             publish=True,
         )
@@ -100,37 +90,197 @@ def test_create_state_machine_with_version_description():
         assert version["description"] == "second version"
     finally:
         client.delete_state_machine(stateMachineArn=arn)
-        iam.delete_role(RoleName=role_name)
 
 
 @aws_verified
 @pytest.mark.aws_verified
 def test_create_unpublished_state_machine_with_version_description():
-    iam = boto3.client("iam", region_name="us-east-1")
-    role_name = f"sfn_role_{str(uuid4())[0:6]}"
-    sfn_role = iam.create_role(
-        RoleName=role_name,
-        AssumeRolePolicyDocument=json.dumps(sfn_role_policy),
-        Path="/",
-    )["Role"]["Arn"]
-
     client = boto3.client("stepfunctions", region_name="us-east-1")
 
-    try:
-        name = f"sfn_name_{str(uuid4())[0:6]}"
+    name = f"sfn_name_{str(uuid4())[0:6]}"
 
-        with pytest.raises(ClientError) as exc:
-            client.create_state_machine(
-                name=name,
-                definition=simple_definition,
-                roleArn=sfn_role,
-                versionDescription="first version of statemachine",
-            )
-        err = exc.value.response["Error"]
-        assert err["Code"] == "ValidationException"
-        assert (
-            err["Message"] == "Version description can only be set when publish is true"
+    with pytest.raises(ClientError) as exc:
+        client.create_state_machine(
+            name=name,
+            definition=simple_definition,
+            roleArn=_get_default_role(),
+            versionDescription="first version of statemachine",
+        )
+    err = exc.value.response["Error"]
+    assert err["Code"] == "ValidationException"
+    assert err["Message"] == "Version description can only be set when publish is true"
+
+
+@mock_aws
+def test_list_state_machine_versions_includes_published_versions_only():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    name = "versioned_step_function"
+    response_create = client.create_state_machine(
+        name=name,
+        definition=simple_definition,
+        roleArn=_get_default_role(),
+        publish=True,
+    )
+    arn = response_create["stateMachineArn"]
+    version_arn1 = response_create["stateMachineVersionArn"]
+
+    updated_definition = simple_definition.replace("DefaultState", "DefaultStateV2")
+    response_update = client.update_state_machine(
+        stateMachineArn=arn,
+        definition=updated_definition,
+        publish=True,
+    )
+    version_arn2 = response_update["stateMachineVersionArn"]
+
+    response = client.list_state_machine_versions(stateMachineArn=arn)
+
+    assert [
+        item["stateMachineVersionArn"] for item in response["stateMachineVersions"]
+    ] == [version_arn2, version_arn1]
+
+
+@mock_aws
+def test_delete_state_machine_version_removes_version():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    name = "versioned_step_function"
+    response_create = client.create_state_machine(
+        name=name,
+        definition=simple_definition,
+        roleArn=_get_default_role(),
+        publish=True,
+    )
+    arn = response_create["stateMachineArn"]
+    version_arn1 = response_create["stateMachineVersionArn"]
+
+    updated_definition = simple_definition.replace("DefaultState", "DefaultStateV2")
+    response_update = client.update_state_machine(
+        stateMachineArn=arn,
+        definition=updated_definition,
+        publish=True,
+    )
+    version_arn2 = response_update["stateMachineVersionArn"]
+
+    client.delete_state_machine_version(stateMachineVersionArn=version_arn1)
+
+    response = client.list_state_machine_versions(stateMachineArn=arn)
+    assert [
+        item["stateMachineVersionArn"] for item in response["stateMachineVersions"]
+    ] == [version_arn2]
+
+
+@mock_aws
+def test_delete_state_machine_version_fails_if_alias_references_it():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    name = "versioned_step_function"
+    response_create = client.create_state_machine(
+        name=name,
+        definition=simple_definition,
+        roleArn=_get_default_role(),
+        publish=True,
+    )
+
+    client.create_state_machine_alias(
+        name="stable",
+        routingConfiguration=[
+            {
+                "stateMachineVersionArn": response_create["stateMachineVersionArn"],
+                "weight": 100,
+            }
+        ],
+    )
+
+    with pytest.raises(ClientError) as exc:
+        client.delete_state_machine_version(
+            stateMachineVersionArn=response_create["stateMachineVersionArn"]
         )
 
-    finally:
-        iam.delete_role(RoleName=role_name)
+    assert exc.value.response["Error"]["Code"] == "ConflictException"
+
+
+@mock_aws
+def test_publish_state_machine_version_creates_new_version():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    response_create = client.create_state_machine(
+        name="versioned_step_function",
+        definition=simple_definition,
+        roleArn=_get_default_role(),
+    )
+    arn = response_create["stateMachineArn"]
+
+    response = client.publish_state_machine_version(
+        stateMachineArn=arn,
+        description="first published version",
+    )
+
+    assert response["stateMachineVersionArn"] == f"{arn}:1"
+
+    version = client.describe_state_machine(
+        stateMachineArn=response["stateMachineVersionArn"]
+    )
+    assert version["description"] == "first published version"
+
+
+@mock_aws
+def test_list_state_machine_versions_fails_for_unknown_state_machine():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    nonexistent_arn = f"arn:aws:states:us-east-1:{ACCOUNT_ID}:stateMachine:nonexistent"
+
+    with pytest.raises(ClientError) as exc:
+        client.list_state_machine_versions(stateMachineArn=nonexistent_arn)
+
+    assert exc.value.response["Error"]["Code"] == "StateMachineDoesNotExist"
+
+
+@mock_aws
+def test_publish_state_machine_version_returns_creation_date():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    response_create = client.create_state_machine(
+        name="versioned_step_function",
+        definition=simple_definition,
+        roleArn=_get_default_role(),
+    )
+    arn = response_create["stateMachineArn"]
+
+    response = client.publish_state_machine_version(stateMachineArn=arn)
+
+    assert isinstance(response["creationDate"], datetime)
+
+
+@mock_aws
+def test_delete_state_machine_version_is_noop_when_version_missing():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    response_create = client.create_state_machine(
+        name="versioned_step_function",
+        definition=simple_definition,
+        roleArn=_get_default_role(),
+        publish=True,
+    )
+    arn = response_create["stateMachineArn"]
+    version_arn1 = response_create["stateMachineVersionArn"]
+
+    missing_version_arn = f"{arn}:99"
+    client.delete_state_machine_version(stateMachineVersionArn=missing_version_arn)
+
+    response = client.list_state_machine_versions(stateMachineArn=arn)
+    assert [
+        item["stateMachineVersionArn"] for item in response["stateMachineVersions"]
+    ] == [version_arn1]
+
+
+@mock_aws
+def test_publish_state_machine_version_fails_for_unknown_state_machine():
+    client = boto3.client("stepfunctions", region_name="us-east-1")
+
+    nonexistent_arn = f"arn:aws:states:us-east-1:{ACCOUNT_ID}:stateMachine:nonexistent"
+
+    with pytest.raises(ClientError) as exc:
+        client.publish_state_machine_version(stateMachineArn=nonexistent_arn)
+
+    assert exc.value.response["Error"]["Code"] == "StateMachineDoesNotExist"


### PR DESCRIPTION
Hey there: Added these methods to stepfunctions

- `list_state_machine_versions` returns only published versions, ordered newest-first.
- `delete_state_machine_version` is idempotent when the version does not exist, but raises `ConflictException` if any alias references the version.
- `publish_state_machine_version` returns `stateMachineVersionArn` and `creationDate`.
- `list_state_machine_versions` and `publish_state_machine_version` raise `StateMachineDoesNotExist` for unknown state machine ARNs.
- `create_state_machine` rejects `versionDescription` unless `publish=True`, raising `ValidationException`.

Also simplifies a little bit the code creating a helper method `_get_state_machine(self, arn: str) -> StateMachine` which was repeated a lot across the file.

Simplfies the tests using  `_get_default_role `and `simple_definition`
