### PR TITLE
Fix core decorator typing for mypy 2.3.0 (isclass now narrows to type[object])

### DIFF
--- a/moto/core/models.py
+++ b/moto/core/models.py
@@ -12,6 +12,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     TypeVar,
+    cast,
 )
 from unittest.mock import patch
 
@@ -65,7 +66,7 @@ class MockAWS(AbstractContextManager["MockAWS"]):
         self, func: "Callable[P, T]", reset: bool = True, remove_data: bool = True
     ) -> "Callable[P, T]":
         if inspect.isclass(func):
-            return self._decorate_class(func)
+            return cast("Callable[P, T]", self._decorate_class(func))
         return self._decorate_callable(func, reset, remove_data)
 
     def __enter__(self) -> "MockAWS":
@@ -125,8 +126,7 @@ class MockAWS(AbstractContextManager["MockAWS"]):
         wrapper.__wrapped__ = func  # type: ignore[attr-defined]
         return wrapper
 
-    def _decorate_class(self, klass: "Callable[P, T]") -> "Callable[P, T]":
-        assert inspect.isclass(klass)  # Keep mypy happy
+    def _decorate_class(self, klass: type[T]) -> type[T]:
         direct_methods = get_direct_methods_of(klass)
         defined_classes = {x for x, y in klass.__dict__.items() if inspect.isclass(y)}
 


### PR DESCRIPTION
mypy's latest release changed isclass annotation from `TypeIs[type[Any]]` to `TypeIs[type[object]]`

_decorate_class now has an accurate signature: it takes a class and returns a class (type[T] -> type[T]), where previously both were typed as Callable.
Removed the assert inspect.isclass(klass)  # Keep mypy happy line. It was originally added as a workaround for older mypy, and under mypy 2.3.0 it actively re-triggers the problem by re-narrowing the type.
Added a single cast() where __call__ returns the decorated class, telling mypy what's true at runtime but inexpressible in its type system: a class is also a callable that produces its instances.

Suggested change would fix #10109