### PR TITLE
SSM: resolve full parameter ARNs in get_parameters (#9396)

### DIFF
--- a/moto/ssm/models.py
+++ b/moto/ssm/models.py
@@ -1871,6 +1871,15 @@ class SimpleSystemManagerBackend(BaseBackend, TaggableResourcesMixin):
                 f"{count} validation error{plural} detected: {errors}"
             )
 
+    def _strip_parameter_arn(self, name: str) -> str:
+        """Reduce a full parameter ARN to the bare parameter name.
+
+        Names that are not ARNs are returned unchanged.
+        """
+        if name.startswith(self.ssm_prefix):
+            return name.replace(self.ssm_prefix, "")
+        return name
+
     def get_parameters(self, names: list[str]) -> dict[str, Parameter]:
         result = {}
 
@@ -1882,7 +1891,11 @@ class SimpleSystemManagerBackend(BaseBackend, TaggableResourcesMixin):
             )
 
         for name in set(names):
-            if name.split(":")[0] in self._parameters:
+            # Names may be full ARNs, as when reading a parameter shared from
+            # another account. Strip the prefix for the lookup, but keep the
+            # caller's original string as the key, so that the response layer
+            # reports InvalidParameters using what was actually requested.
+            if self._strip_parameter_arn(name).split(":")[0] in self._parameters:
                 try:
                     param = self.get_parameter(name)
 
@@ -2050,8 +2063,7 @@ class SimpleSystemManagerBackend(BaseBackend, TaggableResourcesMixin):
         return True
 
     def get_parameter(self, name: str) -> Parameter | None:
-        if name.startswith(self.ssm_prefix):
-            name = name.replace(self.ssm_prefix, "")
+        name = self._strip_parameter_arn(name)
 
         name_parts = name.split(":")
         name_prefix = name_parts[0]

--- a/tests/test_ssm/test_ssm.py
+++ b/tests/test_ssm/test_ssm.py
@@ -2334,6 +2334,49 @@ def test_get_parameters_should_only_return_unique_requests():
     assert len(response["Parameters"]) == 1
 
 
+@pytest.mark.parametrize(
+    "as_arn",
+    [False, True],
+    ids=["by-name", "by-arn"],
+)
+@mock_aws
+def test_get_parameters_by_arn(as_arn):
+    # A parameter shared from another account is read by its full ARN.
+    # get_parameter already supported this; get_parameters did not.
+    client = boto3.client("ssm", region_name=SSM_REGION)
+    client.put_parameter(Name="/Parameter1", Value="Value1", Type="String")
+    client.put_parameter(Name="/Parameter2", Value="Value2", Type="String")
+
+    def ref(name: str) -> str:
+        if as_arn:
+            return f"arn:aws:ssm:{SSM_REGION}:{ACCOUNT_ID}:parameter{name}"
+        return name
+
+    response = client.get_parameters(Names=[ref("/Parameter1"), ref("/Parameter2")])
+
+    assert response["InvalidParameters"] == []
+    assert {p["Name"]: p["Value"] for p in response["Parameters"]} == {
+        "/Parameter1": "Value1",
+        "/Parameter2": "Value2",
+    }
+
+
+@mock_aws
+def test_get_parameters_by_arn_reports_unknown_arn_as_invalid():
+    # An ARN that resolves to nothing must come back in InvalidParameters
+    # verbatim -- as requested -- not as the stripped name.
+    client = boto3.client("ssm", region_name=SSM_REGION)
+    client.put_parameter(Name="/Parameter1", Value="Value1", Type="String")
+
+    known = f"arn:aws:ssm:{SSM_REGION}:{ACCOUNT_ID}:parameter/Parameter1"
+    unknown = f"arn:aws:ssm:{SSM_REGION}:{ACCOUNT_ID}:parameter/DoesNotExist"
+
+    response = client.get_parameters(Names=[known, unknown])
+
+    assert [p["Name"] for p in response["Parameters"]] == ["/Parameter1"]
+    assert response["InvalidParameters"] == [unknown]
+
+
 @mock_aws
 def test_get_parameter_history_should_throw_exception_when_MaxResults_is_too_large():
     client = boto3.client("ssm", region_name=SSM_REGION)


### PR DESCRIPTION
Partially addresses #9396.

### Problem

`get_parameter` accepts a full parameter ARN — that was fixed in #7748. `get_parameters` was not updated to match, so reading parameters by ARN (as you do for a parameter shared from another account via RAM) silently returns nothing:

```python
arn = f"arn:aws:ssm:{region}:{account}:parameter/Parameter1"
client.get_parameter(Name=arn)      # works
client.get_parameters(Names=[arn])  # {} + the ARN listed in InvalidParameters
```

The cause is the guard in `get_parameters`:

```python
if name.split(":")[0] in self._parameters:
```

For an ARN, `name.split(":")[0]` is `"arn"`, which is never a stored parameter name, so the entry is skipped before `get_parameter` (which would have handled the ARN) is ever called.

### Change

Extract the prefix-stripping already present in `get_parameter` into `_strip_parameter_arn`, and use it in the `get_parameters` guard as well.

The caller's original string stays the dict key, so the response layer still reports `InvalidParameters` using exactly what was requested rather than a stripped name — there's a test for that. `Name` in the returned parameter is the bare name, matching the existing `get_parameter`-by-ARN behaviour.

### Tests

- `test_get_parameters_by_arn`, parametrized `by-name` / `by-arn`, mirroring the existing parametrized `test_get_parameter` from #7748.
- `test_get_parameters_by_arn_reports_unknown_arn_as_invalid` — an unresolvable ARN comes back in `InvalidParameters` verbatim.

Against unpatched master these give 2 failed / 1 passed; the `by-name` case passes either way. Full `tests/test_ssm/` suite: 181 passed. `mypy` and `ruff check` clean.

### Not covered by this PR

Two other things reported in #9396:

- `create_resource_share` still rejects SSM parameters — `SHAREABLE_RESOURCES` in `moto/ram/models.py` has no `"parameter"` entry. Adding the string is trivial, but AWS only permits sharing Advanced-tier parameters, and RAM has no visibility into SSM state to enforce that. Happy to do it if you have a preference on how strict it should be.
- The reported missing `Tier` on `put_parameter` appears to be a non-issue — `Tier` is stored and returned in `response_object` on current master.
