### PR TITLE
Glue: default Hive-required table fields on get_table

### DIFF
--- a/moto/glue/models.py
+++ b/moto/glue/models.py
@@ -1753,7 +1753,7 @@ class FakeTable(BaseModel):
             "DatabaseName": self.database_name,
             "Name": self.name,
             "CreateTime": self.created_time,
-            **self.get_version(str(version)),
+            **self._with_defaults(self.get_version(str(version))),
             # Add VersionId after we get the version-details, just to make sure that it's a valid version (int)
             "VersionId": str(version),
             "CatalogId": self.catalog_id,
@@ -1761,6 +1761,22 @@ class FakeTable(BaseModel):
         if self.updated_time is not None:
             obj["UpdateTime"] = self.updated_time
         return obj
+
+    @staticmethod
+    def _with_defaults(table_input: dict[str, Any]) -> dict[str, Any]:
+        # Real AWS Glue populates these fields with defaults when omitted from
+        # the TableInput; clients that unbox them (e.g. the Hive metastore Glue
+        # client) NPE when they are absent. Mirror that behaviour here.
+        table = {"Retention": 0, **table_input}
+        storage_descriptor = table.get("StorageDescriptor")
+        if storage_descriptor is not None:
+            table["StorageDescriptor"] = {
+                "Compressed": False,
+                "NumberOfBuckets": 0,
+                "StoredAsSubDirectories": False,
+                **storage_descriptor,
+            }
+        return table
 
     def create_partition(self, partiton_input: dict[str, Any]) -> None:
         partition = FakePartition(self.database_name, self.name, partiton_input)

--- a/tests/test_glue/test_datacatalog.py
+++ b/tests/test_glue/test_datacatalog.py
@@ -198,6 +198,33 @@ def test_create_table():
 
 
 @mock_aws
+def test_get_table_populates_hive_defaults_when_omitted():
+    # Real AWS Glue defaults these fields when they are omitted from the
+    # TableInput. Clients that unbox them (e.g. the Hive metastore Glue client)
+    # NPE when they are absent, so moto must mirror the defaulting behaviour.
+    client = boto3.client("glue", region_name="us-east-1")
+    database_name = "myspecialdatabase"
+    helpers.create_database(client, database_name)
+
+    table_name = "tablewithsparseinput"
+    table_input = {
+        "Name": table_name,
+        "StorageDescriptor": {
+            "Location": "s3://my-bucket/tablewithsparseinput/",
+            "Columns": [{"Name": "col1", "Type": "string"}],
+        },
+    }
+    client.create_table(DatabaseName=database_name, TableInput=table_input)
+
+    table = client.get_table(DatabaseName=database_name, Name=table_name)["Table"]
+
+    assert table["Retention"] == 0
+    assert table["StorageDescriptor"]["Compressed"] is False
+    assert table["StorageDescriptor"]["NumberOfBuckets"] == 0
+    assert table["StorageDescriptor"]["StoredAsSubDirectories"] is False
+
+
+@mock_aws
 def test_create_table_already_exists():
     client = boto3.client("glue", region_name="us-east-1")
     database_name = "myspecialdatabase"


### PR DESCRIPTION
Real AWS Glue populates `Retention` and the StorageDescriptor's `Compressed`,
`NumberOfBuckets` and `StoredAsSubDirectories` fields with defaults when they are
omitted from the `TableInput`. Clients that unbox those fields (e.g. the Hive
metastore Glue client used by Spark) throw a `NullPointerException` when they are
absent from `GetTable`.

This defaults them the same way real Glue does, so such clients work against moto.

Test added in `tests/test_glue/test_datacatalog.py`.
