### PR TITLE
RDS: fix test using invalid RoleArn length

### DIFF
--- a/tests/test_rds/test_rds_clusters.py
+++ b/tests/test_rds/test_rds_clusters.py
@@ -2143,7 +2143,7 @@ def test_add_role_to_db_cluster_adding_feature_a_second_time_throws_DBClusterRol
     with pytest.raises(ClientError) as ex:
         client.add_role_to_db_cluster(
             DBClusterIdentifier=db_cluster_identifier,
-            RoleArn="a-different-role",
+            RoleArn="arn:aws:iam::123456789012:role/a-different-role",
             FeatureName="S3_INTERGRATION",
         )
 


### PR DESCRIPTION
Botocore 1.43.51 tightened RoleArn validation on AddRoleToDBCluster to require a minimum length of 20 characters, so the test's placeholder value "a-different-role" (16 characters) now fails client-side before it can exercise the intended DBClusterRoleAlreadyExists error.

- Changelog: https://github.com/boto/botocore/blob/1.43.51/CHANGELOG.rst
- Release diff: https://github.com/boto/botocore/compare/1.43.50...1.43.51 

Failure example in build:
<img width="781" height="515" alt="image" src="https://github.com/user-attachments/assets/12c72cdb-232e-45b9-a1a3-a837e240114c" />