### PR TITLE
Transfer: give create_user keys a real ssh public key id

### DIFF
--- a/moto/transfer/models.py
+++ b/moto/transfer/models.py
@@ -184,7 +184,7 @@ class TransferBackend(BaseBackend):
                 {
                     "date_imported": str(now),
                     "ssh_public_key_body": ssh_public_key_body,
-                    "ssh_public_key_id": "mock_ssh_public_key_id_{ssh_public_key_body}_{now}",
+                    "ssh_public_key_id": f"{server_id}:{user_name}:public_key:{now}",
                 }
             ]
             user.ssh_public_keys = ssh_public_keys

--- a/tests/test_transfer/test_transfer.py
+++ b/tests/test_transfer/test_transfer.py
@@ -197,6 +197,9 @@ def test_create_describe_and_delete_user(client, server):
     assert user["PosixProfile"]["Gid"] == 1
     assert user["Role"] == "TransferFamilyAdministrator"
     assert user["SshPublicKeys"][0]["SshPublicKeyBody"] == "ED25519"
+    assert user["SshPublicKeys"][0]["SshPublicKeyId"].startswith(
+        f"{server_id}:{user_name}:public_key:"
+    )
     assert user["Tags"][0]["Key"] == "Owner"
     assert user["Tags"][0]["Value"] == "MotoUser1337"
     assert user["UserName"] == "test_user"


### PR DESCRIPTION
`create_user` stores the ssh public key id as a plain string with a missing `f` prefix, so every user gets the same literal placeholder text as their key id:

```pycon
>>> client.create_user(ServerId=server_id, UserName="alice", Role=..., SshPublicKeyBody=key)
>>> client.describe_user(ServerId=server_id, UserName="alice")["User"]["SshPublicKeys"][0]["SshPublicKeyId"]
'mock_ssh_public_key_id_{ssh_public_key_body}_{now}'
```

`import_ssh_public_key` in the same file fills the same field properly:

```pycon
>>> client.import_ssh_public_key(ServerId=server_id, SshPublicKeyBody=key, UserName="bob")["SshPublicKeyId"]
's-567f9d96944a50eca:bob:public_key:1785415192.219024'
```

So the two ways of attaching a key to a user produce different shapes for the same field, and one of them is not an identifier at all.

I matched `import_ssh_public_key` rather than just adding the missing `f`, for two reasons: it keeps a single format for the field that `delete_ssh_public_key` and `describe_user` both work with, and interpolating the original string would embed the entire public key body, spaces and all, into the id. If you would rather keep the literal wording and just add the `f`, say so and I will switch it.

One thing worth stating because it changes what this fixes: `delete_ssh_public_key` still worked before this change, since it compared the stored literal against the same literal returned by `describe_user`. The defect is the value itself being unusable and identical for every user, not a broken lookup.

Added an assertion to `test_create_describe_and_delete_user`, which fails without the change at `tests/test_transfer/test_transfer.py:200`. `tests/test_transfer` passes (18), `ruff format` is clean and mypy reports nothing.
